### PR TITLE
Tokenv3 with URI prefix and version flag

### DIFF
--- a/00.md
+++ b/00.md
@@ -124,7 +124,7 @@ W3siaWQiOiAiRFNBbDludnZ5ZnZhIiwgImFtb3VudCI6IDgsICJzZWNyZXQiOiAiRGJSS0l5YTBldGR3
 
 **Note:** This token format is deprecated. Do not implement it. All its benefits are preserved in V3 tokens. 
 
-This token format includes information about the mint as well. The field `proofs` is like a V0 token. Additionally, the field `mints` can include an array (list) of multiple mints from which the `proofs` are from. The `url` field is the URL of the mint. `ids` is a list of the keyset IDs belonging to this mint. It is important that all keyset IDs of the `proofs` must be present here to allow a wallet to map each proof to a mint.
+This token format includes information about the mint as well. The field `proofs` is like a V1 token. Additionally, the field `mints` can include an array (list) of multiple mints from which the `proofs` are from. The `url` field is the URL of the mint. `ids` is a list of the keyset IDs belonging to this mint. It is important that all keyset IDs of the `proofs` must be present here to allow a wallet to map each proof to a mint.
 
 ##### Example JSON:
 
@@ -165,7 +165,7 @@ eyJwcm9vZnMiOlt7ImlkIjoiRFNBbDludnZ5ZnZhIiwiYW1vdW50IjoyLCJzZWNyZXQiOiJFaHBlbm5D
 
 This new token format is easier to implement for wallet developers. It also introuces a new URI prefix and a token versioning flag.
 
-**Note:** This format deprecates the V1 token since it achieves the same thing as a V2 token but requires more complexity when implementing it.
+**Note:** This format deprecates the V2 token since it achieves the same thing as a V2 token but requires more complexity when implementing it.
 
 ##### Serialization and version flag
 We use the following format for token serialization:
@@ -181,7 +181,7 @@ To make Cashu tokens clickable on the web, we use the URI tag `cashu:` or `cashu
 
 ##### Token format
 
-This token format has the `[version]` value `2`. Here, `List[Proof]` is identical to a V0 token.
+This token format has the `[version]` value `A`. Here, `List[Proof]` is identical to a V2 token.
 
 Note: undecided whether to use the first or the second one
 

--- a/00.md
+++ b/00.md
@@ -87,9 +87,9 @@ An array (list) of `Proof`'s. In general, this will be used for most operations 
 
 Wallets serialize tokens in a `base64_urlsafe` format (base64 encoding with `/` replaced by `_` and `+` by `-`). There are multiple token formats. Wallets are expected to support those that aren't market as deprecated.
 
-#### 0.2.1 - V0 tokens
+#### 0.2.1 - V1 tokens
 
-`optional`
+`deprecated`
 
 This token format is a list of `Proof`s. Each `Proof` contains the keyset id in the field `id` that can be used by a wallet to identify the mint of this token. A wallet that encounters an unknown `id`, it can ask the user to enter the mint url of the yet unknown mint. The wallet should explicity ask the user whether they trust the mint.
 
@@ -118,11 +118,11 @@ When serialized, this becomes:
 W3siaWQiOiAiRFNBbDludnZ5ZnZhIiwgImFtb3VudCI6IDgsICJzZWNyZXQiOiAiRGJSS0l5YTBldGR3STVzRkFOMEFYUSIsICJDIjogIjAyZGY3ZjJmYzI5NjMxYjcxYTFkYjExYzE2M2IwYjFjYjQwNDQ0YWEyYjNkMjUzZDQzYjY4ZDc3YTcyZWQyZDYyNSJ9LCB7ImlkIjogIkRTQWw5bnZ2eWZ2YSIsICJhbW91bnQiOiAxNiwgInNlY3JldCI6ICJkX1BQYzVLcHVBQjJNNjBXWUFXNS1RIiwgIkMiOiAiMDI3MGUwYTM3ZjdhMGIyMWVhYjQzYWY3NTFkZDNjMDNmNjFmMDRjNjI2YzA0NDhmNjAzZjFkMWY1YWU1YTdkN2U2In1d
 ```
 
-#### 0.2.2 - V1 tokens
+#### 0.2.2 - V2 tokens
 
 `deprecated`
 
-**Note:** This token format is deprecated. Do not implement it. All its benefits are preserved in V2 tokens. 
+**Note:** This token format is deprecated. Do not implement it. All its benefits are preserved in V3 tokens. 
 
 This token format includes information about the mint as well. The field `proofs` is like a V0 token. Additionally, the field `mints` can include an array (list) of multiple mints from which the `proofs` are from. The `url` field is the URL of the mint. `ids` is a list of the keyset IDs belonging to this mint. It is important that all keyset IDs of the `proofs` must be present here to allow a wallet to map each proof to a mint.
 
@@ -159,8 +159,7 @@ When serialized, this becomes:
 eyJwcm9vZnMiOlt7ImlkIjoiRFNBbDludnZ5ZnZhIiwiYW1vdW50IjoyLCJzZWNyZXQiOiJFaHBlbm5DOXFCM2lGbFc4RlpfcFp3IiwiQyI6IjAyYzAyMDA2N2RiNzI3ZDU4NmJjMzE4M2FlY2Y5N2ZjYjgwMGMzZjRjYzQ3NTlmNjljNjI2YzlkYjVkOGY1YjVkNCJ9LHsiaWQiOiJEU0FsOW52dnlmdmEiLCJhbW91bnQiOjgsInNlY3JldCI6IlRtUzZDdjBZVDVQVV81QVRWS251a3ciLCJDIjoiMDJhYzkxMGJlZjI4Y2JlNWQ3MzI1NDE1ZDVjMjYzMDI2ZjE1ZjliOTY3YTA3OWNhOTc3OWFiNmU1YzJkYjEzM2E3In1dLCJtaW50cyI6W3sidXJsIjoiaHR0cHM6Ly84MzMzLnNwYWNlOjMzMzgiLCJpZHMiOlsiRFNBbDludnZ5ZnZhIl19XX0=
 ```
 
-
-#### 0.2.3 - V2 tokens
+#### 0.2.3 - V3 tokens
 
 `mandatory`
 
@@ -171,8 +170,14 @@ This new token format is easier to implement for wallet developers. It also intr
 ##### Serialization and version flag
 We use the following format for token serialization:
 ```sh
-cashu:[version]:[base64_urlsafe]
+cashu[version][base64_urlsafe]
 ```
+
+`cashu` is the prefix. `[version]` is a base64 character (starting with `A` to denote the token format version). `[base64_urlsafe]` is the token JSON serialized in base64_urlsafe.
+
+##### URI tag
+
+To make Cashu tokens clickable on the web, we use the URI tag `cashu:` or `cashu://` or `web+cashu://` (for PWAs).
 
 ##### Token format
 
@@ -189,18 +194,8 @@ Note: undecided whether to use the first or the second one
     },
     ...
   ],
-  "memo": str
+  "memo": str <optional>
 }
-```
-
-```json
-[
-  {
-    "mint": str,
-    "proofs": List[Proof]
-  },
-  ...
-]
 ```
 
 
@@ -231,31 +226,9 @@ Note: undecided whether to use the first or the second one
 }
 ```
 
-```json
-[
-  {
-    "mint": "https://8333.space:3338",
-    "proofs": [
-      {
-        "id": "DSAl9nvvyfva",
-        "amount": 2,
-        "secret": "EhpennC9qB3iFlW8FZ_pZw",
-        "C": "02c020067db727d586bc3183aecf97fcb800c3f4cc4759f69c626c9db5d8f5b5d4"
-      },
-      {
-        "id": "DSAl9nvvyfva",
-        "amount": 8,
-        "secret": "TmS6Cv0YT5PU_5ATVKnukw",
-        "C": "02ac910bef28cbe5d7325415d5c263026f15f9b967a079ca9779ab6e5c2db133a7"
-      }
-    ]
-  }
-]
-```
-
 When serialized, this becomes:
 ```
-cashu:2:eyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vODMzMy5zcGFjZTozMzM4IiwicHJvb2ZzIjpbeyJpZCI6IkRTQWw5bnZ2eWZ2YSIsImFtb3VudCI6Miwic2VjcmV0IjoiRWhwZW5uQzlxQjNpRmxXOEZaX3BadyIsIkMiOiIwMmMwMjAwNjdkYjcyN2Q1ODZiYzMxODNhZWNmOTdmY2I4MDBjM2Y0Y2M0NzU5ZjY5YzYyNmM5ZGI1ZDhmNWI1ZDQifSx7ImlkIjoiRFNBbDludnZ5ZnZhIiwiYW1vdW50Ijo4LCJzZWNyZXQiOiJUbVM2Q3YwWVQ1UFVfNUFUVktudWt3IiwiQyI6IjAyYWM5MTBiZWYyOGNiZTVkNzMyNTQxNWQ1YzI2MzAyNmYxNWY5Yjk2N2EwNzljYTk3NzlhYjZlNWMyZGIxMzNhNyJ9XX1dLCJtZW1vIjoiVGhhbmt5b3UuIn0=
+cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vODMzMy5zcGFjZTozMzM4IiwicHJvb2ZzIjpbeyJpZCI6IkRTQWw5bnZ2eWZ2YSIsImFtb3VudCI6Miwic2VjcmV0IjoiRWhwZW5uQzlxQjNpRmxXOEZaX3BadyIsIkMiOiIwMmMwMjAwNjdkYjcyN2Q1ODZiYzMxODNhZWNmOTdmY2I4MDBjM2Y0Y2M0NzU5ZjY5YzYyNmM5ZGI1ZDhmNWI1ZDQifSx7ImlkIjoiRFNBbDludnZ5ZnZhIiwiYW1vdW50Ijo4LCJzZWNyZXQiOiJUbVM2Q3YwWVQ1UFVfNUFUVktudWt3IiwiQyI6IjAyYWM5MTBiZWYyOGNiZTVkNzMyNTQxNWQ1YzI2MzAyNmYxNWY5Yjk2N2EwNzljYTk3NzlhYjZlNWMyZGIxMzNhNyJ9XX1dLCJtZW1vIjoiVGhhbmt5b3UuIn0=
 ```
 
 [00]: 00.md

--- a/00.md
+++ b/00.md
@@ -83,15 +83,15 @@ An array (list) of `Proof`'s. In general, this will be used for most operations 
 
 ## 0.2 - Methods
 
-### Serialization of `Proofs`
+### Serialization of tokens
 
-To send and receive `Proofs`, wallets serialize them in a `base64_urlsafe` format (base64 encoding with `/` replaced by `_` and `+` by `-`). 
+Wallets serialize tokens in a `base64_urlsafe` format (base64 encoding with `/` replaced by `_` and `+` by `-`). There are multiple token formats. Wallets are expected to support those that aren't market as deprecated.
 
-There are two versions of the serialization format. Clients should support both and are encouraged to only use the `V2` format but for some applications the simpler `V1` format may be preferrable.
+#### 0.2.1 - V0 tokens
 
-#### 0.2.1 - V1 tokens
+`optional`
 
-This token format is a list of `Proof`s. Each `Proof` contains the keyset id in the field `id` that can be used by a wallet to identify the mint of this token. A wallet that encounters an unknown `id`, it CAN ask the user to enter the mint url of this yet unknown mint. The wallet SHOULD explicity ask the user whether they trust the mint.
+This token format is a list of `Proof`s. Each `Proof` contains the keyset id in the field `id` that can be used by a wallet to identify the mint of this token. A wallet that encounters an unknown `id`, it can ask the user to enter the mint url of the yet unknown mint. The wallet should explicity ask the user whether they trust the mint.
 
 ##### Example JSON:
 
@@ -118,9 +118,13 @@ When serialized, this becomes:
 W3siaWQiOiAiRFNBbDludnZ5ZnZhIiwgImFtb3VudCI6IDgsICJzZWNyZXQiOiAiRGJSS0l5YTBldGR3STVzRkFOMEFYUSIsICJDIjogIjAyZGY3ZjJmYzI5NjMxYjcxYTFkYjExYzE2M2IwYjFjYjQwNDQ0YWEyYjNkMjUzZDQzYjY4ZDc3YTcyZWQyZDYyNSJ9LCB7ImlkIjogIkRTQWw5bnZ2eWZ2YSIsICJhbW91bnQiOiAxNiwgInNlY3JldCI6ICJkX1BQYzVLcHVBQjJNNjBXWUFXNS1RIiwgIkMiOiAiMDI3MGUwYTM3ZjdhMGIyMWVhYjQzYWY3NTFkZDNjMDNmNjFmMDRjNjI2YzA0NDhmNjAzZjFkMWY1YWU1YTdkN2U2In1d
 ```
 
-#### 0.2.2 - V2 tokens
+#### 0.2.2 - V1 tokens
 
-This token format includes information about the mint as well. The field `proofs` is like a V1 token. Additionally, the field `mints` can include an array (list) of multiple mints from which the `proofs` are from. The `url` field is the URL of the mint. `ids` is a list of the keyset IDs belonging to this mint. It is important that all keyset IDs of the `proofs` must be present here to allow a wallet to map each proof to a mint.
+`deprecated`
+
+**Note:** This token format is deprecated. Do not implement it. All its benefits are preserved in V2 tokens. 
+
+This token format includes information about the mint as well. The field `proofs` is like a V0 token. Additionally, the field `mints` can include an array (list) of multiple mints from which the `proofs` are from. The `url` field is the URL of the mint. `ids` is a list of the keyset IDs belonging to this mint. It is important that all keyset IDs of the `proofs` must be present here to allow a wallet to map each proof to a mint.
 
 ##### Example JSON:
 
@@ -153,6 +157,105 @@ When serialized, this becomes:
 
 ```
 eyJwcm9vZnMiOlt7ImlkIjoiRFNBbDludnZ5ZnZhIiwiYW1vdW50IjoyLCJzZWNyZXQiOiJFaHBlbm5DOXFCM2lGbFc4RlpfcFp3IiwiQyI6IjAyYzAyMDA2N2RiNzI3ZDU4NmJjMzE4M2FlY2Y5N2ZjYjgwMGMzZjRjYzQ3NTlmNjljNjI2YzlkYjVkOGY1YjVkNCJ9LHsiaWQiOiJEU0FsOW52dnlmdmEiLCJhbW91bnQiOjgsInNlY3JldCI6IlRtUzZDdjBZVDVQVV81QVRWS251a3ciLCJDIjoiMDJhYzkxMGJlZjI4Y2JlNWQ3MzI1NDE1ZDVjMjYzMDI2ZjE1ZjliOTY3YTA3OWNhOTc3OWFiNmU1YzJkYjEzM2E3In1dLCJtaW50cyI6W3sidXJsIjoiaHR0cHM6Ly84MzMzLnNwYWNlOjMzMzgiLCJpZHMiOlsiRFNBbDludnZ5ZnZhIl19XX0=
+```
+
+
+#### 0.2.3 - V2 tokens
+
+`mandatory`
+
+This new token format is easier to implement for wallet developers. It also introuces a new URI prefix and a token versioning flag.
+
+**Note:** This format deprecates the V1 token since it achieves the same thing as a V2 token but requires more complexity when implementing it.
+
+##### Serialization and version flag
+We use the following format for token serialization:
+```sh
+cashu:[version]:[base64_urlsafe]
+```
+
+##### Token format
+
+This token format has the `[version]` value `2`. Here, `List[Proof]` is identical to a V0 token.
+
+Note: undecided whether to use the first or the second one
+
+```json
+{
+  "token": [
+    {
+      "mint": str,
+      "proofs": List[Proof]
+    },
+    ...
+  ],
+  "memo": str
+}
+```
+
+```json
+[
+  {
+    "mint": str,
+    "proofs": List[Proof]
+  },
+  ...
+]
+```
+
+
+##### Example JSON:
+
+```json
+{
+  "token": [
+    {
+      "mint": "https://8333.space:3338",
+      "proofs": [
+        {
+          "id": "DSAl9nvvyfva",
+          "amount": 2,
+          "secret": "EhpennC9qB3iFlW8FZ_pZw",
+          "C": "02c020067db727d586bc3183aecf97fcb800c3f4cc4759f69c626c9db5d8f5b5d4"
+        },
+        {
+          "id": "DSAl9nvvyfva",
+          "amount": 8,
+          "secret": "TmS6Cv0YT5PU_5ATVKnukw",
+          "C": "02ac910bef28cbe5d7325415d5c263026f15f9b967a079ca9779ab6e5c2db133a7"
+        }
+      ]
+    }
+  ],
+  "memo": "Thank you."
+}
+```
+
+```json
+[
+  {
+    "mint": "https://8333.space:3338",
+    "proofs": [
+      {
+        "id": "DSAl9nvvyfva",
+        "amount": 2,
+        "secret": "EhpennC9qB3iFlW8FZ_pZw",
+        "C": "02c020067db727d586bc3183aecf97fcb800c3f4cc4759f69c626c9db5d8f5b5d4"
+      },
+      {
+        "id": "DSAl9nvvyfva",
+        "amount": 8,
+        "secret": "TmS6Cv0YT5PU_5ATVKnukw",
+        "C": "02ac910bef28cbe5d7325415d5c263026f15f9b967a079ca9779ab6e5c2db133a7"
+      }
+    ]
+  }
+]
+```
+
+When serialized, this becomes:
+```
+cashu:2:eyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vODMzMy5zcGFjZTozMzM4IiwicHJvb2ZzIjpbeyJpZCI6IkRTQWw5bnZ2eWZ2YSIsImFtb3VudCI6Miwic2VjcmV0IjoiRWhwZW5uQzlxQjNpRmxXOEZaX3BadyIsIkMiOiIwMmMwMjAwNjdkYjcyN2Q1ODZiYzMxODNhZWNmOTdmY2I4MDBjM2Y0Y2M0NzU5ZjY5YzYyNmM5ZGI1ZDhmNWI1ZDQifSx7ImlkIjoiRFNBbDludnZ5ZnZhIiwiYW1vdW50Ijo4LCJzZWNyZXQiOiJUbVM2Q3YwWVQ1UFVfNUFUVktudWt3IiwiQyI6IjAyYWM5MTBiZWYyOGNiZTVkNzMyNTQxNWQ1YzI2MzAyNmYxNWY5Yjk2N2EwNzljYTk3NzlhYjZlNWMyZGIxMzNhNyJ9XX1dLCJtZW1vIjoiVGhhbmt5b3UuIn0=
 ```
 
 [00]: 00.md


### PR DESCRIPTION
New token format with URI prefix and version flag that is easier to implement.

Note: this is unfinished, it has to be decided whether we want to use a token JSON that is a dictionary (extendible) or a list (smaller). 