### PR TITLE
Nut 08/overpaid fees

### DIFF
--- a/05.md
+++ b/05.md
@@ -5,11 +5,48 @@ NUT-05: Melting tokens
 
 ---
 
-Melting tokens is the opposite of minting them (see #4): the wallet `Alice` sends `Proofs` to the mint `Bob` together with a bolt11 Lightning invoice that `Alice` wants to be paid. To melt tokens, `Alice` sends a `POST /melt` request with a JSON body to the mint. The `Proofs` included in the request will be burned by the mint and the mint will pay the invoice in exchange.
+Melting tokens is the opposite of minting tokens (see [NUT-04][04]). The wallet of `Alice` sends `Proofs` to the mint `Bob` together with a bolt11 Lightning invoice that `Alice` wants to be paid. To melt tokens, `Alice` sends a `POST /melt` request with a JSON body to the mint. The `Proofs` included in the request will be burned by the mint and the mint will pay the invoice in exchange. 
 
-`Alice`'s request **MUST** include a `PostMeltRequest` ([TODO: Link PostMeltRequest]) JSON body with `Proofs` that have at least the amount of the invoice to be paid.
+`Alice` needs to send two requests to `Bob` to make a Lightning payment: one request for checking the expected maximum fees, and one for making the actual payment. In the first request, `Alice` must check the expected maximum fee reserve with the mint by including a `CheckFeesRequest` JSON body with her request. In the second request, `Alice` must include a `PostMeltRequest` JSON body with `Proofs` that have *at least* the amount of the invoice to be paid.
 
-## Example
+## Checking Lightning fees
+
+The mint expects `Alice` to include `Proofs` of *at least* `total_amount = amount + fee_reserve` where `amount` is the amount to be paid with the Lightning invoice and `fee_reserve` is the maximum potential Lightning network fees for the payment. A wallet should first call the `/checkfees` endpoint to ask the mint what the expected maximum fee is by making a `CheckFeesRequest` post request to the following endpoint:
+
+```http
+POST https://mint.host:3338/checkfees
+```
+With the data being of the form `CheckFeesRequest`:
+
+```json
+{
+  "pr": str
+}
+```
+
+Here, `pr` is the bolt11 Lightning invoice to be paid.
+
+With curl:
+
+```bash
+curl -X POST https://mint.host:3338/checkfees -d \
+{
+"pr": "lnbc100n1p3kdrv5sp5lpdxzghe5j67q..."
+}
+```
+
+**Response** `CheckFeesResponse` from `Bob`:
+
+```json
+{
+"fee": int
+}
+```
+Here, `fee` is the expected maximum fees in satoshis.
+
+## Paying the invoice
+
+Now that `Alice` knows what the `total_amount` has to be, she can ask `Bob` to make a Lightning payment for her.
 
 **Request** of `Alice`:
 
@@ -26,10 +63,11 @@ With the data being of the form `PostMeltRequest`:
       Proof,
       ...
     ],
-  "invoice": str
+  "pr": str
 }
 ```
 
+Here, `pr` is the bolt11 invoice to be paid with an amount `amount` and `proofs` are the proofs with a total value of at least `total_amount := amount + fee_reserve` (see above).
 
 With curl:
 
@@ -48,7 +86,7 @@ curl -X POST https://mint.host:3338/mint&payment_hash=67d1d9ea6ada225c115418671b
     ...
     }
   ],
-"invoice": "lnbc100n1p3kdrv5sp5lpdxzghe5j67q..."
+"pr": "lnbc100n1p3kdrv5sp5lpdxzghe5j67q..."
 }
 ```
 
@@ -61,7 +99,7 @@ curl -X POST https://mint.host:3338/mint&payment_hash=67d1d9ea6ada225c115418671b
 }
 ```
 
-Only if the `paid==true`, the wallet `Alice` **MUST** delete the `Proofs` from her database (or move them to a history). If `paid==false`, `Alice` **CAN** repeat the same multiple times until the payment is successful.
+Only if the `paid==true`, the wallet `Alice` must delete the `Proofs` from her database (or move them to a history). If `paid==false`, `Alice` can repeat the same request again until the payment is successful.
 
 [00]: 00.md
 [01]: 01.md

--- a/08.md
+++ b/08.md
@@ -5,7 +5,9 @@ NUT-08: Lightning fee return
 
 ---
 
-This document describes how the overpaid Lightning fees are handled and extendes [NUT-05][05] which describes melting tokens (i.e. paying a Lightning invoice). In short, a wallet includes *blank outputs* when paying a Lightning invoice which can be assigned a value by the mint if the user has overpaid Lightning fees. This can be the case due to the unpredictability of Lightning network fees. To solve this issue, we introduce so-called *blank outputs* which are blinded messages with an undetermined value.
+This document describes how the overpaid Lightning fees are handled and extendes [NUT-05][05] which describes melting tokens (i.e. paying a Lightning invoice). In short, a wallet includes *blank outputs* when paying a Lightning invoice which can be assigned a value by the mint if the user has overpaid Lightning fees. This can be the case due to the unpredictability of Lightning network fees. To solve this issue, we introduce so-called *blank outputs* which are blinded messages with an undetermined value. 
+
+The problem is also described in [this gist](https://gist.github.com/callebtc/a6cc0bd2b6f70e081e478147c40fc578).
 
 ## Description
 

--- a/08.md
+++ b/08.md
@@ -1,0 +1,92 @@
+NUT-08: Lightning fee return
+==========================
+
+`optional` `author: calle`
+
+---
+
+This document describes how the overpaid Lightning fees are handled and extendes [NUT-05][05] which describes melting tokens (i.e. paying a Lightning invoice). In short, a wallet includes *blank outputs* when paying a Lightning invoice which can be assigned a value by the mint if the user has overpaid Lightning fees. This can be the case due to the unpredictability of Lightning network fees. To solve this issue, we introduce so-called *blank outputs* which are blinded messages with an undetermined value.
+
+## Description
+
+Before requesting a Lightning payment as described in [NUT-05][05], `Alice` produces a predefined number of `BlindedMessage` which are similar to ordinary blinded messages but their value is yet to be determined by the mint `Bob` and are thus called *blank outputs*. The predefined number is chosen to be `n_blank_outputs := 4` by convention which means that we can return at minimum 93.75% (but up to 100%) of the overpaid fees back to the user (because each blank output can account for at least 50% of the remaining overpaid fees).
+
+## Example
+
+The wallet wants to pay an invoice with `amount := 100 000 sats` and determines by asking the mint that `fee_reseve` is `1000 sats`. The wallet then provides `101 000 sats` worth of proofs and 4 blank `outputs` to make the payment. The mint pays the invoice and determines that the actual fee was `100 sat`, i.e, the overpaid fee to return is `fee_return = 900 sats`. The mint splits the amount `900` into summands of `2^n` which is `4, 128, 256, 512`. The mint inserts these amounts into the blank `outputs` it received form the wallet and generates 4 new promises. The mint then returns these `BlindedSignature`'s to the wallet together with the successful payment status.
+
+## Wallet flow
+The wallet asks the mint for the `fee_reserve` for paying a specific bolt11 invoice of value `amount` by calling `/checkfees` as described in [NUT-05][05]. The wallet then provides a MeltRequest to `/melt` that has 1. proofs of the value `amount+fee_reserve`, 2. the bolt11 invoice to be paid, and finally, as a new new entry, 3. a field `outputs` that has `n_blank_outputs` blinded messages that are generated before the payment attempt to receive potenaitl overpaid fees back to her.
+
+## Mint flow
+
+Here we describe how the mint generates `BlindedSignature`'s for the overpaid fees. The mint `Bob` returns in `PostMeltResponse` the field `change` **ONLY IF** `Alice` has previously provided `outputs` for the change **AND** if the Lightning `actual_fees` were smaller than the `fee_reserve`.
+
+If the `overpaid_fees = fee_reserve - actual_fees` is positive, `Bob` decomposes it to values of `2^n` (as in [NUT-00][00]). `Bob` then takes at most `n_blank_outputs` **largest** of these amounts and imprints them into the `ouptputs` provided by `Alice`. 
+
+`Bob` then signs these blank outputs (now with the imprinted amounts) and thus generates `BlindedSignature`'s. `Bob` then returns a payment status to the wallet, and, in addition, the up to `n_blank_outputs` blinded signatures it generated for the overpaid fees.
+
+## Example
+
+**Request** of `Alice`:
+
+```http
+POST https://mint.host:3338/melt
+```
+
+With the data being of the form `PostMeltRequest`:
+
+```json
+{
+  "proofs": 
+    [
+      Proof,
+      ...
+    ],
+  "invoice": str,
+  "outputs": [
+      BlindedMessage,
+      ...
+    ]
+}
+```
+
+Everything here is the same as in [NUT-05][05] except for `outputs`. The `amount` field in the `BlindedMessage`'s here are ignored by `Bob` so they can be set to any arbitrary value by `Alice` (they should be set to a value, like `1` so potential JSON validations do not error).
+
+If the mint has made a successful payment, it will respond the following.
+
+**Response** `PostMeltResponse` from `Bob`:
+
+```json
+{
+"paid": true,
+"preimage": "da225c115418671b64a67d1d9ea6a...",
+"change": [
+    BlindedSignature,
+    ...
+  ]
+}
+```
+The field `change` has a list (array) of `BlindedSignature`'s (or promises) that account for the overpaid fees. `Alice` must take these and generate `Proof`'s from them (unblinding), as described in [NUT-00][00] and as she does in [NUT-04][04] when minting new tokens with the important difference being that the `amount` of each `BlindedSignature` is determined by the mint `Bob` and not in advance by `Alice`. After generating the `Proof`'s, `Alice` stores them in her database.
+
+[00]: 00.md
+[01]: 01.md
+[02]: 02.md
+[03]: 03.md
+[04]: 04.md
+[05]: 05.md
+[06]: 06.md
+[07]: 07.md
+[08]: 08.md
+[09]: 09.md
+[10]: 10.md
+[11]: 11.md
+[12]: 12.md
+[13]: 13.md
+[14]: 14.md
+[15]: 15.md
+[16]: 16.md
+[17]: 17.md
+[18]: 18.md
+[19]: 19.md
+[20]: 20.md


### PR DESCRIPTION
This document describes how the overpaid Lightning fees are handled and extendes [NUT-05][05] which describes melting tokens (i.e. paying a Lightning invoice). In short, a wallet includes *blank outputs* when paying a Lightning invoice which can be assigned a value by the mint if the user has overpaid Lightning fees. This can be the case due to the unpredictability of Lightning network fees. To solve this issue, we introduce so-called *blank outputs* which are blinded messages with an undetermined value. 

The problem is also described in [this gist](https://gist.github.com/callebtc/a6cc0bd2b6f70e081e478147c40fc578).