### PR TITLE
Add nut-09: Mint information

### DIFF
--- a/09.md
+++ b/09.md
@@ -27,7 +27,7 @@ With the data being of the form `GetInfoResponse`:
   "contact": [
     ["email", "contact@me.com"],
     ["twitter", "@me"],
-    ["Nostr" ,"npub..."]
+    ["nostr" ,"npub..."]
   ],
   "nuts": [
     "NUT-07",

--- a/09.md
+++ b/09.md
@@ -55,8 +55,6 @@ curl -X GET https://mint.host:3338/info
 
 ## Deriving `pubkey`
 
-the private key `supersecretprivatekey` returns the hex public key `0283bf290884eed3a7ca2663fc0260de2e2064d6b355ea13f98dec004b7a7ead99`
-
 Python example:
 ```python
 from secp256k1 import PrivateKey
@@ -69,6 +67,8 @@ def derive_pubkey(private_key: str):
         raw=True,
     ).pubkey.serialize.hex()
 ```
+
+As an example, the private key `supersecretprivatekey` returns the hex public key `0283bf290884eed3a7ca2663fc0260de2e2064d6b355ea13f98dec004b7a7ead99`.
 
 [00]: 00.md
 [01]: 01.md

--- a/09.md
+++ b/09.md
@@ -1,0 +1,92 @@
+NUT-09: Mint information
+==========================
+
+`optional` `author: calle`
+
+---
+
+This endpoint returns information of the mint that a wallet can show to the user and can make decisions on how to interact with the mint.
+
+## Example
+
+**Request** of `Alice`:
+
+```http
+GET https://mint.host:3338/info
+```
+
+With the data being of the form `GetInfoResponse`:
+
+```json
+{
+  "name": "Bob's Cashu mint",
+  "pubkey": "0283bf290884eed3a7ca2663fc0260de2e2064d6b355ea13f98dec004b7a7ead99",
+  "version": "Nutshell/0.11.0",
+  "description": "The short mint description",
+  "description_long": "A description that can be a long piece of text.",
+  "contact": [
+    "Email: contact@me.com",
+    "Twitter: @me",
+    "Nostr: npub..."
+  ],
+  "nuts": [
+    "NUT-07",
+    "NUT-08"
+  ],
+  "motd": "Message to display to users."
+}
+```
+
+- `name` is the name of the mint and should be recognizable. 
+- `pubkey` is the hex pubkey of the mint derived from its private key. 
+- `version` is the implementation name and the version running on this mint separated with a slash "/", 
+- `description` is a short description of the mint that can be shown in the wallet next to the mint's name. 
+- `description_long` is a long description that can be shown in an additional field. 
+- `contact` is an array of contact methods to reach the mint operator. 
+- `nuts` is an array that shows which NUTs the mint supports. 
+- `modt` is the message of the day that the wallet must display to the user. It should only be used to display important announcements to users, such as scheduled maintenances. 
+
+With curl:
+
+```bash
+curl -X GET https://mint.host:3338/info
+```
+
+## Deriving `pubkey`
+
+the private key `supersecretprivatekey` returns the hex public key `0283bf290884eed3a7ca2663fc0260de2e2064d6b355ea13f98dec004b7a7ead99`
+
+Python example:
+```python
+from cashu.core.secp import PrivateKey
+
+def derive_pubkey(private_key: str):
+    return PrivateKey(
+        hashlib.sha256(private_key.encode("utf-8"))
+        .hexdigest()
+        .encode("utf-8")[:32],
+        raw=True,
+    ).pubkey.serialize.hex()
+```
+
+[00]: 00.md
+[01]: 01.md
+[02]: 02.md
+[03]: 03.md
+[04]: 04.md
+[05]: 05.md
+[06]: 06.md
+[07]: 07.md
+[08]: 08.md
+[09]: 09.md
+[10]: 10.md
+[11]: 11.md
+[12]: 12.md
+[13]: 13.md
+[14]: 14.md
+[15]: 15.md
+[16]: 16.md
+[17]: 17.md
+[18]: 18.md
+[19]: 19.md
+[20]: 20.md

--- a/09.md
+++ b/09.md
@@ -25,13 +25,14 @@ With the data being of the form `GetInfoResponse`:
   "description": "The short mint description",
   "description_long": "A description that can be a long piece of text.",
   "contact": [
-    "Email: contact@me.com",
-    "Twitter: @me",
-    "Nostr: npub..."
+    ["email", "contact@me.com"],
+    ["twitter", "@me"],
+    ["Nostr" ,"npub..."]
   ],
   "nuts": [
     "NUT-07",
-    "NUT-08"
+    "NUT-08",
+    "NUT-09"
   ],
   "motd": "Message to display to users."
 }
@@ -42,7 +43,7 @@ With the data being of the form `GetInfoResponse`:
 - `version` is the implementation name and the version running on this mint separated with a slash "/", 
 - `description` is a short description of the mint that can be shown in the wallet next to the mint's name. 
 - `description_long` is a long description that can be shown in an additional field. 
-- `contact` is an array of contact methods to reach the mint operator. 
+- `contact` is an array of contact methods to reach the mint operator. A contact method consists of two fields. The first denotes the method (like "email"), the second the identifier (like "contact@me.com").
 - `nuts` is an array that shows which NUTs the mint supports. 
 - `modt` is the message of the day that the wallet must display to the user. It should only be used to display important announcements to users, such as scheduled maintenances. 
 
@@ -58,7 +59,7 @@ the private key `supersecretprivatekey` returns the hex public key `0283bf290884
 
 Python example:
 ```python
-from cashu.core.secp import PrivateKey
+from secp256k1 import PrivateKey
 
 def derive_pubkey(private_key: str):
     return PrivateKey(

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 |--- | --- | --- | --- |
 | [07][07] | Token spendable check | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns] | [Nutshell][py], [Feni][feni], [LNbits]
 | [08][08] | Overpaid Lightning fees | [Nutshell][py], [Cashu.Me][cashume], [Nutstash][ns] | [Nutshell][py], [LNbits]
+| [09][09] | Mint info | - | [Nutshell][py]
 | TBD | Multimint support | [Nutshell][py], [Cashu.Me][cashume], [Nutstash][ns] | N/A
 | TBD | DLEQ proofs | - | -
 | TBD | Bitcoin script | [Nutshell][py] | [Nutshell][py]
 | TBD | Token version prefixes | - | N/A
 | TBD | Cashu URI | - | N/A
 | TBD | Mint LN swap | [Cashu.Me][cashume], [Nutstash][ns] | N/A
-| TBD | Mint info | - | -
 | TBD | Token comment | - | N/A
 | TBD | Token sender information | - | N/A
 

--- a/README.md
+++ b/README.md
@@ -12,24 +12,25 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 ### Mandatory
 | # | Description | Wallets | Mints |
 |--- | --- | --- | --- |
-| [00][00] | Cryptography and Models | [Nutshell][py], [Feni][feni], [LNbits][lnbits], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
-| [01][01] | Mint public keys | [Nutshell][py], [Feni][feni], [LNbits][lnbits], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
-| [02][02] | Keysets and keyset IDs | [Nutshell][py], [Feni][feni], [LNbits][lnbits], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
-| [03][03] | Request minting | [Nutshell][py], [Feni][feni], [LNbits][lnbits], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
-| [04][04] | Minting tokens | [Nutshell][py], [Feni][feni], [LNbits][lnbits], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
-| [05][05] | Melting tokens | [Nutshell][py], [Feni][feni], [LNbits][lnbits], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
-| [06][06] | Splitting tokens | [Nutshell][py], [Feni][feni], [LNbits][lnbits], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
+| [00][00] | Cryptography and Models | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
+| [01][01] | Mint public keys | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
+| [02][02] | Keysets and keyset IDs | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
+| [03][03] | Request minting | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
+| [04][04] | Minting tokens | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
+| [05][05] | Melting tokens | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
+| [06][06] | Splitting tokens | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns], [JS][js] | [Nutshell][py], [Feni][feni], [LNbits]
 
 ### Optional
 | # | Description | Wallets | Mints
 |--- | --- | --- | --- |
-| [07][07] | Token spendable check | [Nutshell][py], [Feni][feni], [LNbits][lnbits], [Nutstash][ns] | [Nutshell][py], [Feni][feni], [LNbits]
-| [08][08] | Overpaid Lightning fees | [Nutshell][py]| [Nutshell][py]
-| TBD | Multimint | [Nutshell][py], [LNbits][lnbits], [Nutstash][ns] | -
-| TBD | P2SH spending conditions | - | -
+| [07][07] | Token spendable check | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns] | [Nutshell][py], [Feni][feni], [LNbits]
+| [08][08] | Overpaid Lightning fees | [Nutshell][py], [Cashu.Me][cashume], [Nutstash][ns] | [Nutshell][py], [LNbits]
+| TBD | Multimint support | [Nutshell][py], [Cashu.Me][cashume], [Nutstash][ns] | N/A
+| TBD | DLEQ proofs | - | -
+| TBD | Bitcoin script | [Nutshell][py] | [Nutshell][py]
 | TBD | Token version prefixes | - | N/A
 | TBD | Cashu URI | - | N/A
-| TBD | Mint LN swap | - | N/A
+| TBD | Mint LN swap | [Cashu.Me][cashume], [Nutstash][ns] | N/A
 | TBD | Mint info | - | -
 | TBD | Token comment | - | N/A
 | TBD | Token sender information | - | N/A
@@ -38,6 +39,7 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 [py]: https://github.com/cashubtc/cashu
 [feni]: https://github.com/cashubtc/cashu-feni
 [lnbits]: https://github.com/lnbits/lnbits/tree/main/lnbits/extensions/cashu
+[cashume]: https://cashu.me
 [ns]: https://nutstash.app/
 [js]: https://github.com/cashubtc/cashu-js
 


### PR DESCRIPTION
Adds NUT-09 that describes how a wallet can retrieve information about the mint using the endpoint `GET /info`.