### PR TITLE
NUT-07: add new field `pending`

### DIFF
--- a/07.md
+++ b/07.md
@@ -1,7 +1,7 @@
 NUT-07: Token state check
 ==========================
 
-`optional` `author: calle`
+`optional` `author: calle` `author: tb`
 
 ---
 

--- a/07.md
+++ b/07.md
@@ -21,9 +21,11 @@ A wallet can internally represent the combination of these booleans the proof's 
 
 ## Use cases
 
-**Example 1:** When `Alice` prepares a token to be sent to `Carol`, she can mark these tokens in her database as *db:pending*. She can then, periodically or upon user input, check with the mint if the proof is still spendable (mint returns `True` for `spendable`) or if it has been redeemed by `Carol` already (mint retrns `False` for `spendable`). If the proof is not spendable anymore (and, thus, has been redeemed by `Carol`), she can safely delete the proof from her database.
+#### Example 1: Ecash transaction 
+When `Alice` prepares a token to be sent to `Carol`, she can mark these tokens in her database as *db:pending*. She can then, periodically or upon user input, check with the mint if the proof is still spendable (mint returns `True` for `spendable`) or if it has been redeemed by `Carol` already (mint retrns `False` for `spendable`). If the proof is not spendable anymore (and, thus, has been redeemed by `Carol`), she can safely delete the proof from her database.
 
-**Example 2:** If Alice pays a very slow Lightning invoice (for example a HODL invoice) and closes her wallet in the meantime, the next time she comes online, she can check all proof marked as *db:pending* in her database to determine, whether the payment is still in flight (mint returns `True` for `pending` and `spendable`), it has succeeded (mint returns `False` for `pending` and `spendable`), or it has failed (mint returns `False` for `pending` and `True` for `spendable`).
+#### Example 2: Lightning payments 
+If `Alice` pays a very slow Lightning invoice (for example a HODL invoice) and closes her wallet in the meantime, the next time she comes online, she can check all proof marked as *db:pending* in her database to determine, whether the payment is still in flight (mint returns `True` for `pending` and `spendable`), it has succeeded (mint returns `False` for `pending` and `spendable`), or it has failed (mint returns `False` for `pending` and `True` for `spendable`).
 
 ## Example
 

--- a/07.md
+++ b/07.md
@@ -1,11 +1,22 @@
-NUT-07: Spendable check
+NUT-07: Token state check
 ==========================
 
 `optional` `author: calle`
 
 ---
 
-With the spendable check, wallets can ask the mint whether a specific token is already spent. This can be useful for different reasons. For example, when `Alice` prepares a token to be sent to `Carol`, she can mark these tokens in her database as *pending*. She can then, periodically or upon user input, check with the mint, if the token is still spendable or if it has been redeemed by `Carol` already (thus not spendable anymore). Another use case is for wallets that want to delete spent proofs from their database. Before deleting a proof, a wallet can check if the token is still spendable to be sure that they don't delete an unspent token by accident.
+With the spendable check, wallets can ask the mint whether a specific token is already spent (`spendable`) or pending in a transaction (`pending`). 
+
+- A token is `not spendable` if it has been redeemed and its secret is in the list of spent secrets of the mint.
+- A token is `pending` if it is being processed in a transaction (either being redeemed for another token or associated with an ongoing payment). A `pending` token cannot be used in another transaction until it is `not pending`.
+
+**Important:** Before deleting spent tokens from their database, wallets MUST check if the token is still `spendable` to make sure that they don't delete an unspent token by accident.
+
+## Use cases
+
+**Example 1:** When `Alice` prepares a token to be sent to `Carol`, she can mark these tokens in her database as *db:pending*. She can then, periodically or upon user input, check with the mint, if the token is still spendable (mint returns `True` for `spendable`) or if it has been redeemed by `Carol` already (mint retrns `False` for `spendable`). If the token is not spendable anymore (and, thus, has been redeemed by `Carol`), she can safely delete the token from her database.
+
+**Example 2:** If Alice pays a very slow Lightning invoice (for example a HODL invoice) and closes her wallet in the mean time, the next time she comes online, she can check all tokens marked as *db:pending* in her database to determine, whether the payment is still in flight (mint returns `True` for `pending` and `spendable`), it has succeeded (mint returns `False` for `pending` and `spendable`), or it has failed (mint returns `False` for `pending` and `True` for `spendable`).
 
 ## Example
 
@@ -15,7 +26,7 @@ With the spendable check, wallets can ask the mint whether a specific token is a
 POST https://mint.host:3338/check
 ```
 
-With the data being of the form `CheckSpendableRequest`:
+With the data being of the form `CheckStateRequest`:
 
 ```json
 {
@@ -43,11 +54,12 @@ curl -X POST https://mint.host:3338/check -d \
 ```
 **Response** of `Bob`:
 
-`Bob` will respond with a `CheckSpendableResponse` 
+`Bob` will respond with a `CheckStateResponse` 
 
 ```json
 {
-  "spendable": Array[bool]
+  "spendable": Array[bool],
+  "pending": Array[bool]
 }
 ```
 

--- a/07.md
+++ b/07.md
@@ -5,18 +5,25 @@ NUT-07: Token state check
 
 ---
 
-With the spendable check, wallets can ask the mint whether a specific token is already spent (`spendable`) or pending in a transaction (`pending`). 
+With the token state check, wallets can ask the mint whether a specific proof is already spent (`spendable`) and whether it is in-flight in a transaction (`pending`). Both of these attributes are returned as sepearte booleans.
 
-- A token is `not spendable` if it has been redeemed and its secret is in the list of spent secrets of the mint.
-- A token is `pending` if it is being processed in a transaction (either being redeemed for another token or associated with an ongoing payment). A `pending` token cannot be used in another transaction until it is `not pending`.
+### Token states 
 
-**Important:** Before deleting spent tokens from their database, wallets MUST check if the token is still `spendable` to make sure that they don't delete an unspent token by accident.
+A wallet can internally represent the combination of these booleans the proof's `state`. A proof can either be `live` (`spendable == true && pending == false`), `burned` (`spendable == false && pending == (true || false)`), or `in-flight` (`spendable == true && pending == true`).
+
+- A proof is `live` if it has been minted but not spent yet.
+- A proof is `burned` if it has been redeemed and its secret is in the list of spent secrets of the mint.
+- A proof is `in-flight` if it is being processed in a transaction (in an ongoing payment). An `in-flight` proof cannot be used in another transaction until it is `live` again.
+
+**Important:** Before deleting spent proofs from their database, wallets **MUST** check if the proof is still `spendable` to make sure that they don't delete an unspent proof by accident.
+
+**Note:** Mints **MUST** remember which proofs are currently `pending` to avoid reuse of the same token in multiple concurrent transactions. This can be achieved with a mutex whose key is the proof's `secret`.
 
 ## Use cases
 
-**Example 1:** When `Alice` prepares a token to be sent to `Carol`, she can mark these tokens in her database as *db:pending*. She can then, periodically or upon user input, check with the mint, if the token is still spendable (mint returns `True` for `spendable`) or if it has been redeemed by `Carol` already (mint retrns `False` for `spendable`). If the token is not spendable anymore (and, thus, has been redeemed by `Carol`), she can safely delete the token from her database.
+**Example 1:** When `Alice` prepares a token to be sent to `Carol`, she can mark these tokens in her database as *db:pending*. She can then, periodically or upon user input, check with the mint if the proof is still spendable (mint returns `True` for `spendable`) or if it has been redeemed by `Carol` already (mint retrns `False` for `spendable`). If the proof is not spendable anymore (and, thus, has been redeemed by `Carol`), she can safely delete the proof from her database.
 
-**Example 2:** If Alice pays a very slow Lightning invoice (for example a HODL invoice) and closes her wallet in the mean time, the next time she comes online, she can check all tokens marked as *db:pending* in her database to determine, whether the payment is still in flight (mint returns `True` for `pending` and `spendable`), it has succeeded (mint returns `False` for `pending` and `spendable`), or it has failed (mint returns `False` for `pending` and `True` for `spendable`).
+**Example 2:** If Alice pays a very slow Lightning invoice (for example a HODL invoice) and closes her wallet in the meantime, the next time she comes online, she can check all proof marked as *db:pending* in her database to determine, whether the payment is still in flight (mint returns `True` for `pending` and `spendable`), it has succeeded (mint returns `False` for `pending` and `spendable`), or it has failed (mint returns `False` for `pending` and `True` for `spendable`).
 
 ## Example
 
@@ -34,7 +41,7 @@ With the data being of the form `CheckStateRequest`:
 }
 ```
 
-`Proofs` is a list (array) of `Proof`s (see [NUT-0][00]). `Alice` CAN provide a full `Proof` but MUST provide at least the `secret` (which is the only thing that `Bob` needs to check whether the token has been spent).
+`Proofs` is a list (array) of `Proof`s (see [NUT-0][00]). `Alice` CAN provide a full `Proof` but MUST provide at least the `secret` (which is the only thing that `Bob` needs to check whether the proof has been spent).
 
 With curl:
 
@@ -63,7 +70,9 @@ curl -X POST https://mint.host:3338/check -d \
 }
 ```
 
-Where `[bool]` is an array of booleans indicating whether the provided `Proof` is still spendable. **Important:** The list of booleans MUST be in the same order as the proofs provided by `Alice` in the request.
+Where `Array[bool]` is an array of booleans indicating whether the provided `Proof` is still spendable or pending. 
+
+**Important:** The list of booleans **MUST** be in the same order as the proofs provided by `Alice` in the request.
 
 [00]: 00.md
 [01]: 01.md

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 ### Optional
 | # | Description | Wallets | Mints
 |--- | --- | --- | --- |
-| [07][07] | Token spendable check | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns] | [Nutshell][py], [Feni][feni], [LNbits]
+| [07][07] | Token state check | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns] | [Nutshell][py], [Feni][feni], [LNbits]
 | [08][08] | Overpaid Lightning fees | [Nutshell][py], [Feni][feni], [Cashu.Me][cashume], [Nutstash][ns] | [Nutshell][py], [LNbits]
 | [09][09] | Mint info | - | [Nutshell][py]
 | TBD | Multimint support | [Nutshell][py], [Cashu.Me][cashume], [Nutstash][ns] | N/A

--- a/wallet/cashu_wallet_spec.md
+++ b/wallet/cashu_wallet_spec.md
@@ -99,9 +99,9 @@ Note that the following steps can also be performed by `Alice` herself if she wa
 ## 5 - Burn sent tokens
 Here we describe how `Alice` checks with the mint whether the tokens she sent `Carol` have been redeemed so she can safely delete them from her database. This step is optional but highly recommended so `Alice` can properly account for the tokens and adjust her balance accordingly.
 - `Alice` loads all `<send_proofs>` with `pending=True` from her database and might group them by the `send_id`.
-- `Alice` constructs a JSON of the form `{"proofs" : [{"amount" : <amount>, "secret" : s, "C" : Z}, ...]}` from these (grouped) tokens. [*TODO: this object is called CheckSpendableRequest*]
+- `Alice` constructs a JSON of the form `{"proofs" : [{"amount" : <amount>, "secret" : s, "C" : Z}, ...]}` from these (grouped) tokens (`CheckStateRequest`).
 - `Alice` sends them to the mint `Bob` via the endpoint `POST /check` with the JSON as the body of the request.
-- `Alice` receives a JSON of the form `{"spendable" : [true, false, ...]}` where each boolean value corresponds to the proof she sent to the mint before in the same order. The value is `True` if the token has not been claimed yet and `False` if it has already been claimed.
+- `Alice` receives a JSON of the form `{"spendable" : [true, false, ...], "pending": [false, false, ....]}` where each boolean value corresponds to the proof she sent to the mint before in the same order. The value is `True` if the token has not been claimed yet and `False` if it has already been claimed.
 - If `<spendable>` is `False`, `Alice` removes the proof from her list of spendable proofs.
 
 ## 6 - Pay a Lightning invoice


### PR DESCRIPTION
This is necessary in order for a wallet to determine whether a token it used for making a Lightning payment is still in-flight or not.

In short, LN payments can have 3 states but our tokens only 2 (because there's only `spendable` or not). We need another boolean state (`pending`).

Using this, wallets can determine the state of an outgoing Lightning payment as follows:

- if a token is `not spendable` and `not pending`, the payment succeeded
- if a token is `spendable` and `pending`, the payment is in-flight
- if a token is `spendable` and `not pending`, the payment failed