### PR TITLE
Add clarification around public key format mints should use

### DIFF
--- a/02.md
+++ b/02.md
@@ -5,7 +5,7 @@ NUT-02: Keysets and keyset ID
 
 ---
 
-A keyset is a set of public keys that the mint `Bob` generates and shares with its users. It refers to the set of public keys that each correspond to the amount values that the mint supports (e.g. 1, 2, 4, 8, ...) respectively.
+A keyset is a set of public keys that the mint `Bob` generates and shares with its users. The mint **MUST** use the [compressed public key format](https://learnmeabitcoin.com/technical/public-key#public-key-format) used in bitcoin when defining public keys in the keyset. The keyset refers to the set of public keys that each correspond to the amount values that the mint supports (e.g. 1, 2, 4, 8, ...) respectively.
 
 ## Requesting mint keyset IDs
 

--- a/02.md
+++ b/02.md
@@ -5,7 +5,7 @@ NUT-02: Keysets and keyset ID
 
 ---
 
-A keyset is a set of public keys that the mint `Bob` generates and shares with its users. The mint **MUST** use the [compressed public key format](https://learnmeabitcoin.com/technical/public-key#public-key-format) used in bitcoin when defining public keys in the keyset. The keyset refers to the set of public keys that each correspond to the amount values that the mint supports (e.g. 1, 2, 4, 8, ...) respectively.
+A keyset is a set of public keys that the mint `Bob` generates and shares with its users. The mint **MUST** use the [compressed public key format](https://learnmeabitcoin.com/technical/public-key#public-key-format). The keyset refers to the set of public keys that each correspond to the amount values that the mint supports (e.g. 1, 2, 4, 8, ...) respectively.
 
 ## Requesting mint keyset IDs
 


### PR DESCRIPTION
This PR is a small addition to the definition of the keyset type, stating that the public keys must be serialized using the compressed public key format used everywhere in bitcoin when building keysets.

This is not unique to bitcoin so I couldn't find a BIP to link to for further information on the format, but information about it is basically found everywhere, including many questions and answers on Stack Overflow and a section of Mastering Bitcoin by Antonopoulos. I chose an article from learnmeabitcoin.com for the link. 

Note that this is also the approach used in one of the [BIPs defining SegWit](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#restrictions-on-public-key-type), where only compressed keys are accepted, standardizing the length required to share them as well as making them shorter in general.