### PR TITLE
NUT-08: handle log(0) and log(1) possibilities

### DIFF
--- a/08.md
+++ b/08.md
@@ -11,7 +11,17 @@ The problem is also described in [this gist](https://gist.github.com/callebtc/a6
 
 ## Description
 
-Before requesting a Lightning payment as described in [NUT-05][05], `Alice` produces a number of `BlindedMessage` which are similar to ordinary blinded messages but their value is yet to be determined by the mint `Bob` and are thus called *blank outputs*. The number of necessary blank outputs is `ceil(log2(fee_reserve))` which ensures that any overpaid fees can be represented and be returned by the mint to the wallet.
+Before requesting a Lightning payment as described in [NUT-05][05], `Alice` produces a number of `BlindedMessage` which are similar to ordinary blinded messages but their value is yet to be determined by the mint `Bob` and are thus called *blank outputs*. The number of necessary blank outputs is `max(ceil(log2(fee_reserve)), 1)` which ensures that there is at least one output if there is any fee. If the `fee_reserve` is `0`, then the number of blank outputs is `0` as well. The blank outputs will contain the overpaid fees that will be returned by the mint to the wallet. 
+
+This code calculates the number of necessary blank outputs in Python:
+
+```python
+def calculate_number_of_blank_outputs(fee_reserve_sat: int):
+    assert fee_reserve_sat >= 0, "Fee reserve can't be negative."
+    if fee_reserve_sat == 0:
+        return 0
+    return max(math.ceil(math.log2(fee_reserve_sat)), 1)
+```
 
 ## Example
 


### PR DESCRIPTION
For `fee_reserve == 0` (if the payment is internal for example), and for `fee_reserve == 1` the calculation breaks.