### PR TITLE
Clarify how clients should order lists of outputs to preserve privacy

### DIFF
--- a/04.md
+++ b/04.md
@@ -7,7 +7,7 @@ NUT-04: Mint tokens
 
 After requesting a mint (see [NUT-03][03]) and paying the invoice that was returned by the mint, a wallet proceeds with requesting tokens from the mint in return for paying the invoice. 
 
-For that, a wallet sends a `POST /mint?hash=<hash>` request with a JSON body to the mint. The body **MUST** include `BlindedMessages` (see [NUT-00][00]) that are worth a maximum of `<amount_sat>`. If successful (i.e. the invoice has been previously paid and the `BlindedMessages` are valid), the mint responds with `Promises` (see [NUT-00][00]).
+For that, a wallet sends a `POST /mint?hash=<hash>` request with a JSON body to the mint. The body **MUST** include `BlindedMessages` (see [NUT-00][00]) that are worth a maximum of `<amount_sat>`. If successful (i.e. the invoice has been previously paid and the `BlindedMessages` are valid), the mint responds with `Promises` (see [NUT-00][00]). Note that in order to preserve privacy around the exact amount a client might be trying to build a token for, the client **SHOULD** ensure that the list of `BlindedMessage`s is always ordered by amount in ascending order. For example, a request for tokens expressed like so: `[16, 8, 2, 64, 8]` might imply the client is building a payment for 26 sat; the client should instead order the list like so: `[2, 8, 8, 16, 64]` to reduce extra information given to the mint.
 
 ## Example
 

--- a/04.md
+++ b/04.md
@@ -7,7 +7,9 @@ NUT-04: Mint tokens
 
 After requesting a mint (see [NUT-03][03]) and paying the invoice that was returned by the mint, a wallet proceeds with requesting tokens from the mint in return for paying the invoice. 
 
-For that, a wallet sends a `POST /mint?hash=<hash>` request with a JSON body to the mint. The body **MUST** include `BlindedMessages` (see [NUT-00][00]) that are worth a maximum of `<amount_sat>`. If successful (i.e. the invoice has been previously paid and the `BlindedMessages` are valid), the mint responds with `Promises` (see [NUT-00][00]). Note that in order to preserve privacy around the exact amount a client might be trying to build a token for, the client **SHOULD** ensure that the list of `BlindedMessage`s is always ordered by amount in ascending order. For example, a request for tokens expressed like so: `[16, 8, 2, 64, 8]` might imply the client is building a payment for 26 sat; the client should instead order the list like so: `[2, 8, 8, 16, 64]` to reduce extra information given to the mint.
+For that, a wallet sends a `POST /mint?hash=<hash>` request with a JSON body to the mint. The body **MUST** include `BlindedMessages` (see [NUT-00][00]) that are worth a maximum of `<amount_sat>`. If successful (i.e. the invoice has been previously paid and the `BlindedMessages` are valid), the mint responds with `Promises` (see [NUT-00][00]). 
+
+Note: In order to preserve privacy around the amount that a client might want to send to another user and keep the rest as change, the client **SHOULD** ensure that the list of `BlindedMessage`s is ordered by amount in ascending order. As an example of what to avoid, a request for tokens expressed like so: `[16, 8, 2, 64, 8]` might imply the client is building a payment for 26 sat; the client should instead order the list like so: `[2, 8, 8, 16, 64]` to mitigate this privacy leak to the mint.
 
 ## Example
 

--- a/06.md
+++ b/06.md
@@ -15,7 +15,7 @@ To make this more clear, we make an example of a typical case of sending tokens 
 
 `Alice` has 64 satoshis in her wallet, composed of two tokens, one worth 32 sats and another two worth 16 sats. She wants to send `Carol` 40 sats but does not have the necessary tokens to combine them to reach the exact target amount of 40 sats. `Alice` requests a split from the mint. For that, she sends the mint `Bob` her tokens (`Proofs`) worth `[16, 16, 32]` and asks for a split at amount 40. The mint will then return her new tokens with the amounts `[8, 8, 16, 32]`. Notice that the first two tokens can now be combined to 40 sats. The original tokens that `Alice` sent to `Bob` are now invalidated.
 
-Note that in order to preserve privacy around the exact amount a client might be trying to build a token for, the client **SHOULD** ensure that the list of `Proof`s and `BlindedMessage`s are always ordered by amount in ascending order. For example, a request for tokens expressed like so: `[16, 8, 2, 64, 8]` might imply the client is building a payment for 26 sat; the client should instead order the list like so: `[2, 8, 8, 16, 64]` to reduce extra information given to the mint.
+Note: In order to preserve privacy around the amount that a client might want to send to another user and keep the rest as change, the client **SHOULD** ensure that the list of `BlindedMessage`s is ordered by amount in ascending order. As an example of what to avoid, a request for tokens expressed like so: `[16, 8, 2, 64, 8]` might imply the client is building a payment for 26 sat; the client should instead order the list like so: `[2, 8, 8, 16, 64]` to mitigate this privacy leak to the mint.
 
 ## 6.2 - Split to receive
 

--- a/06.md
+++ b/06.md
@@ -13,7 +13,9 @@ The basic idea is that `Alice` sends `Bob` a set of  `Proof`'s and a set of `Bli
 
 To make this more clear, we make an example of a typical case of sending tokens from `Alice` to `Carol`:
 
-`Alice` has 64 satoshis in her wallet, composed of two tokens, one worth 32 sats and another two worth 16 sats. She wants to send `Carol` 40 sats but does not have the necessary tokens to combine them to reach the exact target amount of 40 sats. `Alice` requests a split from the mint. For that, she sends the mint `Bob` her tokens (`Proofs`) worth `[32, 16, 16]` and asks for a split at amount 40. The mint will then return her new tokens with the amounts `[32, 8, 16, 8]`. Notice that the first two tokens can now be combined to 40 sats. The original tokens that `Alice` sent to `Bob` are now invalidated.
+`Alice` has 64 satoshis in her wallet, composed of two tokens, one worth 32 sats and another two worth 16 sats. She wants to send `Carol` 40 sats but does not have the necessary tokens to combine them to reach the exact target amount of 40 sats. `Alice` requests a split from the mint. For that, she sends the mint `Bob` her tokens (`Proofs`) worth `[16, 16, 32]` and asks for a split at amount 40. The mint will then return her new tokens with the amounts `[8, 8, 16, 32]`. Notice that the first two tokens can now be combined to 40 sats. The original tokens that `Alice` sent to `Bob` are now invalidated.
+
+Note that in order to preserve privacy around the exact amount a client might be trying to build a token for, the client **SHOULD** ensure that the list of `Proof`s and `BlindedMessage`s are always ordered by amount in ascending order. For example, a request for tokens expressed like so: `[16, 8, 2, 64, 8]` might imply the client is building a payment for 26 sat; the client should instead order the list like so: `[2, 8, 8, 16, 64]` to reduce extra information given to the mint.
 
 ## 6.2 - Split to receive
 


### PR DESCRIPTION
The NUTs do not currently offer insights/recommendations on how to order the list of `BlindedMessage`s that the client builds when it requests minting and splitting tokens. Because ordering those in specific ways is potentially a privacy leak to the mint, advising clients to sort this list of outputs before sending them over is helpful.

The paragraph added to NUT-04 and NUT-06 is the following:
> Note that in order to preserve privacy around the exact amount a client might be trying to build a token for, the client **SHOULD** ensure that the list of `BlindedMessage`s is always ordered by amount in ascending order. For example, a request for tokens expressed like so: `[16, 8, 2, 64, 8]` might imply the client is building a payment for 26 sat; the client should instead order the list like so: `[2, 8, 8, 16, 64]` to reduce extra information given to the mint.

A few questions for reviewers of this PR:
1. Are there any advantages to the ordering being ascending, descending, or random? I couldn't think of any so I just picked one (ascending), but let me know if you can see any reason to maybe pick a different one and I'll adjust the wording (my only thought was around the "random" sorting effectively adding a reliance on access to proper randomness; if it's not needed, better keep it out?).
2. I currently have this sorting as a **SHOULD** statement, but of course it could actually be a **MUST** as well, and the protocol could simply parse those requests as invalid if the outputs are not sorted the way they should be. It's a stricter approach. Not sure if it's better to be stricter or looser with these things.