### PR TITLE
NUT-00: Remove `p2pksig` reference

### DIFF
--- a/00.md
+++ b/00.md
@@ -59,7 +59,7 @@ A signature on the `BlindedMessage` is sent from `Bob` to `Alice` after [minting
 }
 ```
 
-`amount` is the value of the blinded token, `C_` is the blinded signature on the secret message `B_` sent in the previous step. `id` is the [keyset id][02] of the mint public keys that signed the token.
+`amount` is the value of the blinded token, `C_` is the blinded signature on the secret message `B_` sent in the previous step. `id` is the [keyset id][02] of the mint public keys that signed the token. It can be omitted in custom applications where mint keys are never expected to rotate.
 
 ### `Proof`
 
@@ -71,11 +71,10 @@ A `Proof` is sent to `Bob` for [melting tokens][05]. A `Proof` can also be sent 
   "secret": str,
   "C": hex_str,
   "id": str | None,
-  "p2pksig": hex_str | None,
 }
 ```
 
-`amount` is the value of the `Proof`, `secret` is the secret message (no encoding standard), `C` is the unblinded signature on `secret` (hex string), `id` is the [keyset id][02] of the mint public keys that signed the token (string). `p2pksig` is the public key of the recipient that needs to provide a signature as the spending condition for this `Proof` *(P2PK: NUT-TBD)*.
+`amount` is the value of the `Proof`, `secret` is the secret message (no encoding standard), `C` is the unblinded signature on `secret` (hex string), `id` is the [keyset id][02] of the mint public keys that signed the token (string).
 
 ### `Proofs`
 


### PR DESCRIPTION
Remove `p2pksig` reference in `Proof`, will be specified in separate nut for `P2PK`.