### PR TITLE
NUT-12: Chaum-Pedersen DLEQ proofs

### DIFF
--- a/12.md
+++ b/12.md
@@ -1,0 +1,105 @@
+NUT-12: Offline mint signature validation
+==========================
+
+`optional` `author: calle`
+
+---
+
+In this document, we present an extension of Cashu's crypto system to allow a user Alice to verify the mint Bob's signature using only Bob's public keys. We explain how another user Carol who receives ecash from Alice can execute the DLEQ proof as well. Previously, Bob's signature could only be checked by himself using his own private keys ([NUT-00][00]). This is achieved using a Discrete Log Equality (DLEQ) proof.
+
+# The DLEQ proof
+The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01][01]) and for signing the BlindedMessage `B'`. Bob returns the proof with the blind signature `C'` during a mint or split operation. The complete DLEQ proof reads
+```
+# DLEQ Proof
+
+(These steps occur once Bob returns C')
+
+Bob:
+r = random nonce
+R1 = r*G
+R2 = r*B'
+e = hash(R1,R2,A,C')
+s = r + e*a
+return e, s
+
+Alice:
+R1 = s*G - e*A
+R2 = s*B' - e*C'
+e == hash(R1,R2,A,C')
+
+If true, a in A = a*G must be equal to a in C' = a*B'
+```
+
+### DLEQ in `BlindedSignature`
+
+The mint produces these DLEQ proofs when returning `BlindedSignature`'s upon the `POST /mint` and `POST /split` responses. The `BlindedSignature` object is extended in the following way to include the DLEQ proof:
+
+```python
+{
+  "id": <str>,
+  "amount": <int>,
+  "C_": <str>,
+  "dleq": {  # New: DLEQ proof
+    "e": <str>,
+    "s": <str>
+  }
+}
+
+```
+
+`e` and `s` are the challenge and response of the DLEQ proof. 
+
+### DLEQ in `Proof`
+
+In order for Alice to communicate the DLEQ to another user Carol, we extend the `Proof` (see [NUT-00][00]) object and include the DLEQ proof. As explained below, we also need to include the blinding factor `r` for the proof to be convincing to another user Carol.
+
+```
+{
+  "id": <str>,
+  "amount": <int>,
+  "secret": <str>,
+  "C": <str>,
+  "dleq": {# New: DLEQ proof
+    "e": <str>,
+    "s": <str>,
+    "r": <str>
+  }
+}
+```
+`e` and `s` are the challenge and response of the DLEQ proof returned by Bob, `r` is the blinding factor of Alice that was used to generate the `Proof`.
+
+## Alice
+
+Alice is the user interacting with the mint Bob. As described above, Alice receives the DLEQ proof in the `BlindedSignature` response from the mint upon calling `POST /mint` or `POST /split`. Alice checks its validity via the equations:
+
+```
+R1 = s*G - e*A
+R2 = s*B' - e*C'
+e == hash(R1,R2,A,C') # must be True
+```
+
+As we can see, in order to execute the proof, Alice needs `e, s` that are returned in the `BlindedSignature` by Bob. Alice further needs `B'` (the `BlindedMessage` that Bob signed) and `C'` , the blind signature in the `BlindedSignature` response from Bob, and `A`, the public key of Bob with which he signed the BlindedMessage. All these values are available during or after the `/mint` and `/split` operations.
+
+**Note:** If a DLEQ proof is included in the mint's `BlindedSignature` response, wallet **MUST** verify the DLEQ proof. 
+
+## Carol
+
+Carol is a user that receives a token from a user Alice. When Alice sends a token that includes `Proofs` with DLEQ proofs to another user Carol, Carol can execute the DLEQ proof herself to validate Bob's signature without having to talk to Bob. That means, Alice must include the following information in a `Proof` she sends to Carol:
+
+- `(x, C)` – the ecash `Proof`
+- `(e, s)` – the DLEQ proof
+- `r` – Alice's blinding factor
+
+Here, `x` is the Proof's secret, and `C` is the mint's signature on it. To execute the DLEQ proof like Alice above, Carol needs `(B', C')` which she can compute herself using the blinding factor `r` that she receives from Alice.
+
+To verify the DLEQ proof of a received token, Carol needs to reconstruct `B'` and `C'` using the blinding factor `r` that Alice has included in the `Proof` she sent to Carol:
+
+```
+Y = hash_to_curve(x)
+C' = C + r*A
+B' = Y + r*G
+```
+
+Now that Carol has all the necessary variables, she can execute the same equations as Alice did.
+
+**Note:** If a DLEQ proof is included in a received token, wallet **MUST** verify the proof. 

--- a/12.md
+++ b/12.md
@@ -34,7 +34,7 @@ If true, a in A = a*G must be equal to a in C' = a*B'
 
 ### DLEQ in `BlindedSignature`
 
-The mint produces these DLEQ proofs when returning `BlindedSignature`'s upon the `POST /mint` and `POST /split` responses. The `BlindedSignature` object is extended in the following way to include the DLEQ proof:
+The mint produces these DLEQ proofs when returning `BlindedSignature`'s in the `POST /mint` and `POST /split` responses. The `BlindedSignature` object is extended in the following way to include the DLEQ proof:
 
 ```python
 {
@@ -49,7 +49,7 @@ The mint produces these DLEQ proofs when returning `BlindedSignature`'s upon the
 
 ```
 
-`e` and `s` are the challenge and response of the DLEQ proof. 
+`e` and `s` are the DLEQ proof. 
 
 ### DLEQ in `Proof`
 

--- a/12.md
+++ b/12.md
@@ -8,7 +8,9 @@ NUT-12: Offline mint signature validation
 In this document, we present an extension of Cashu's crypto system to allow a user Alice to verify the mint Bob's signature using only Bob's public keys. We explain how another user Carol who receives ecash from Alice can execute the DLEQ proof as well. Previously, Bob's signature could only be checked by himself using his own private keys ([NUT-00][00]). This is achieved using a Discrete Log Equality (DLEQ) proof.
 
 # The DLEQ proof
-The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01][01]) and for signing the BlindedMessage `B'`. Bob returns the proof with the blind signature `C'` during a mint or split operation. The complete DLEQ proof reads
+The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01][01]) and for signing the BlindedMessage `B'`. Bob returns the proof with the blind signature `C'` during a mint or split operation. 
+
+The complete DLEQ proof reads
 ```
 # DLEQ Proof
 
@@ -68,7 +70,7 @@ In order for Alice to communicate the DLEQ to another user Carol, we extend the 
 ```
 `e` and `s` are the challenge and response of the DLEQ proof returned by Bob, `r` is the blinding factor of Alice that was used to generate the `Proof`.
 
-## Alice
+## Alice (minting user)
 
 Alice is the user interacting with the mint Bob. As described above, Alice receives the DLEQ proof in the `BlindedSignature` response from the mint upon calling `POST /mint` or `POST /split`. Alice checks its validity via the equations:
 
@@ -78,19 +80,25 @@ R2 = s*B' - e*C'
 e == hash(R1,R2,A,C') # must be True
 ```
 
+Here, the variables are
+- `A` – the public key Bob used to sign this Proof
+- `(e, s)` – the DLEQ proof returned by Bob
+- `B'` – Alice's `BlindedMessage`
+- `C'` – Bob's `BlindedSignature` on `B'`
+
 As we can see, in order to execute the proof, Alice needs `e, s` that are returned in the `BlindedSignature` by Bob. Alice further needs `B'` (the `BlindedMessage` that Bob signed) and `C'` , the blind signature in the `BlindedSignature` response from Bob, and `A`, the public key of Bob with which he signed the BlindedMessage. All these values are available during or after the `/mint` and `/split` operations.
 
 **Note:** If a DLEQ proof is included in the mint's `BlindedSignature` response, wallet **MUST** verify the DLEQ proof. 
 
-## Carol
+## Carol (third-party user)
 
-Carol is a user that receives a token from a user Alice. When Alice sends a token that includes `Proofs` with DLEQ proofs to another user Carol, Carol can execute the DLEQ proof herself to validate Bob's signature without having to talk to Bob. That means, Alice must include the following information in a `Proof` she sends to Carol:
+Carol is a user that validates a `Proof` from another user Alice. When Alice sends a token that includes `Proofs` with DLEQ proofs to Carol or when Alice posts a `Proof` publicly, Carol can execute the DLEQ proof herself to validate Bob's signature without having to talk to Bob. Alice must include the following information in the `Proof`:
 
 - `(x, C)` – the ecash `Proof`
-- `(e, s)` – the DLEQ proof
+- `(e, s)` – the DLEQ proof revealed by Alice
 - `r` – Alice's blinding factor
 
-Here, `x` is the Proof's secret, and `C` is the mint's signature on it. To execute the DLEQ proof like Alice above, Carol needs `(B', C')` which she can compute herself using the blinding factor `r` that she receives from Alice.
+Here, `x` is the Proof's secret, and `C` is the mint's signature on it. To execute the DLEQ proof like Alice did above, Carol needs `(B', C')` which she can compute herself using the blinding factor `r` that she receives from Alice.
 
 To verify the DLEQ proof of a received token, Carol needs to reconstruct `B'` and `C'` using the blinding factor `r` that Alice has included in the `Proof` she sent to Carol:
 
@@ -98,6 +106,7 @@ To verify the DLEQ proof of a received token, Carol needs to reconstruct `B'` an
 Y = hash_to_curve(x)
 C' = C + r*A
 B' = Y + r*G
+... (same as Alice)
 ```
 
 Now that Carol has all the necessary variables, she can execute the same equations as Alice did.

--- a/12.md
+++ b/12.md
@@ -5,10 +5,10 @@ NUT-12: Offline mint signature validation
 
 ---
 
-In this document, we present an extension of Cashu's crypto system to allow a user Alice to verify the mint Bob's signature using only Bob's public keys. We explain how another user Carol who receives ecash from Alice can execute the DLEQ proof as well. Previously, Bob's signature could only be checked by himself using his own private keys ([NUT-00][00]). This is achieved using a Discrete Log Equality (DLEQ) proof.
+In this document, we present an extension of Cashu's crypto system to allow a user Alice to verify the mint Bob's signature using only Bob's public keys. We explain how another user Carol who receives ecash from Alice can execute the DLEQ proof as well. This is achieved using a Discrete Log Equality (DLEQ) proof. Previously, Bob's signature could only be checked by himself using his own private keys ([NUT-00](00)). 
 
 # The DLEQ proof
-The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01][01]) and for signing the BlindedMessage `B'`. Bob returns the proof with the blind signature `C'` during a mint or split operation. 
+The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01](01)) and for signing the BlindedMessage `B'`. Bob returns the proof with the blind signature `C'` during a mint or split operation. 
 
 The complete DLEQ proof reads
 ```
@@ -53,7 +53,7 @@ The mint produces these DLEQ proofs when returning `BlindedSignature`'s upon the
 
 ### DLEQ in `Proof`
 
-In order for Alice to communicate the DLEQ to another user Carol, we extend the `Proof` (see [NUT-00][00]) object and include the DLEQ proof. As explained below, we also need to include the blinding factor `r` for the proof to be convincing to another user Carol.
+In order for Alice to communicate the DLEQ to another user Carol, we extend the `Proof` (see [NUT-00](00)) object and include the DLEQ proof. As explained below, we also need to include the blinding factor `r` for the proof to be convincing to another user Carol.
 
 ```
 {

--- a/12.md
+++ b/12.md
@@ -1,4 +1,4 @@
-NUT-12: Offline mint signature validation
+NUT-12: Offline ecash signature validation
 ==========================
 
 `optional` `author: calle`

--- a/12.md
+++ b/12.md
@@ -8,13 +8,13 @@ NUT-12: Offline ecash signature validation
 In this document, we present an extension of Cashu's crypto system to allow a user Alice to verify the mint Bob's signature using only Bob's public keys. We explain how another user Carol who receives ecash from Alice can execute the DLEQ proof as well. This is achieved using a Discrete Log Equality (DLEQ) proof. Previously, Bob's signature could only be checked by himself using his own private keys ([NUT-00](00)). 
 
 # The DLEQ proof
-The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01](01)) and for signing the BlindedMessage `B'`. Bob returns the proof with the blind signature `C'` during a mint or split operation. 
+The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01](01)) and for signing the BlindedMessage `B'`. Bob returns the DLEQ proof additional to the blind signature `C'` for a mint or split operation. 
 
 The complete DLEQ proof reads
 ```
 # DLEQ Proof
 
-(These steps occur once Bob returns C')
+(These steps occur when Bob returns C')
 
 Bob:
 r = random nonce
@@ -32,9 +32,9 @@ e == hash(R1,R2,A,C')
 If true, a in A = a*G must be equal to a in C' = a*B'
 ```
 
-### DLEQ in `BlindedSignature`
+### Mint to user: DLEQ in `BlindedSignature`
 
-The mint produces these DLEQ proofs when returning `BlindedSignature`'s in the `POST /mint` and `POST /split` responses. The `BlindedSignature` object is extended in the following way to include the DLEQ proof:
+The mint produces these DLEQ proofs when returning `BlindedSignature`'s in the responses for minting ([NUT-04][04]) and splitting ([NUT-06][06]) tokens. The `BlindedSignature` object is extended in the following way to include the DLEQ proof:
 
 ```python
 {
@@ -51,7 +51,7 @@ The mint produces these DLEQ proofs when returning `BlindedSignature`'s in the `
 
 `e` and `s` are the DLEQ proof. 
 
-### DLEQ in `Proof`
+### User to user: DLEQ in `Proof`
 
 In order for Alice to communicate the DLEQ to another user Carol, we extend the `Proof` (see [NUT-00](00)) object and include the DLEQ proof. As explained below, we also need to include the blinding factor `r` for the proof to be convincing to another user Carol.
 
@@ -68,11 +68,11 @@ In order for Alice to communicate the DLEQ to another user Carol, we extend the 
   }
 }
 ```
-`e` and `s` are the challenge and response of the DLEQ proof returned by Bob, `r` is the blinding factor of Alice that was used to generate the `Proof`.
+`e` and `s` are the challenge and response of the DLEQ proof returned by Bob, `r` is the blinding factor of Alice that was used to generate the `Proof`. Alice serializes these proofs like any other in a token (see [NUT-00][00]) to send it to another user Carol.
 
-## Alice (minting user)
+## Alice (minting user) verifies DLEQ proof
 
-Alice is the user interacting with the mint Bob. As described above, Alice receives the DLEQ proof in the `BlindedSignature` response from the mint upon calling `POST /mint` or `POST /split`. Alice checks its validity via the equations:
+When minting or splitting tokens, Alice receives DLEQ proofs in the `BlindedSignature` response from the mint Bob. Alice checks the validity of the DLEQ proofs for each ecash token she receives via the equations:
 
 ```
 R1 = s*G - e*A
@@ -86,13 +86,13 @@ Here, the variables are
 - `B'` – Alice's `BlindedMessage`
 - `C'` – Bob's `BlindedSignature` on `B'`
 
-As we can see, in order to execute the proof, Alice needs `e, s` that are returned in the `BlindedSignature` by Bob. Alice further needs `B'` (the `BlindedMessage` that Bob signed) and `C'` , the blind signature in the `BlindedSignature` response from Bob, and `A`, the public key of Bob with which he signed the BlindedMessage. All these values are available during or after the `/mint` and `/split` operations.
+In order to execute the proof, Alice needs `e, s` that are returned in the `BlindedSignature` by Bob. Alice further needs `B'` (the `BlindedMessage` Alice created and Bob signed) and `C'` (the blind signature in the `BlindedSignature` response) from Bob, and `A` (the public key of Bob with which he signed the BlindedMessage). All these values are available to Alice during or after calling the mint and split operations.
 
-**Note:** If a DLEQ proof is included in the mint's `BlindedSignature` response, wallet **MUST** verify the DLEQ proof. 
+If a DLEQ proof is included in the mint's `BlindedSignature` response, wallets **MUST** verify the DLEQ proof. 
 
-## Carol (third-party user)
+## Carol (another user) verifies DLEQ proof
 
-Carol is a user that validates a `Proof` from another user Alice. When Alice sends a token that includes `Proofs` with DLEQ proofs to Carol or when Alice posts a `Proof` publicly, Carol can execute the DLEQ proof herself to validate Bob's signature without having to talk to Bob. Alice must include the following information in the `Proof`:
+Carol is a user that receives `Proofs` in a token from another user Alice. When Alice sends `Proofs` with DLEQ proofs to Carol or when Alice posts the `Proofs` publicly, Carol can validate the DLEQ proof herself and verify Bob's signature without having to talk to Bob. Alice includes the following information in the `Proof` (see above):
 
 - `(x, C)` – the ecash `Proof`
 - `(e, s)` – the DLEQ proof revealed by Alice
@@ -100,15 +100,36 @@ Carol is a user that validates a `Proof` from another user Alice. When Alice sen
 
 Here, `x` is the Proof's secret, and `C` is the mint's signature on it. To execute the DLEQ proof like Alice did above, Carol needs `(B', C')` which she can compute herself using the blinding factor `r` that she receives from Alice.
 
-To verify the DLEQ proof of a received token, Carol needs to reconstruct `B'` and `C'` using the blinding factor `r` that Alice has included in the `Proof` she sent to Carol:
+To verify the DLEQ proof of a received token, Carol needs to reconstruct `B'` and `C'` using the blinding factor `r` that Alice has included in the `Proof` she sent to Carol. Since Carol now has all the necessary information, she can execute the same equations to verify the DLEQ proof as Alice did:
 
 ```
 Y = hash_to_curve(x)
 C' = C + r*A
 B' = Y + r*G
-... (same as Alice)
+
+R1 = ... (same as Alice)
 ```
 
-Now that Carol has all the necessary variables, she can execute the same equations as Alice did.
+If a DLEQ proof is included in a received token, wallets **MUST** verify the proof. 
 
-**Note:** If a DLEQ proof is included in a received token, wallet **MUST** verify the proof. 
+[00]: 00.md
+[01]: 01.md
+[02]: 02.md
+[03]: 03.md
+[04]: 04.md
+[05]: 05.md
+[06]: 06.md
+[07]: 07.md
+[08]: 08.md
+[09]: 09.md
+[10]: 10.md
+[11]: 11.md
+[12]: 12.md
+[13]: 13.md
+[14]: 14.md
+[15]: 15.md
+[16]: 16.md
+[17]: 17.md
+[18]: 18.md
+[19]: 19.md
+[20]: 20.md

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 | [09][09] | Mint info | [Nutshell][py], [eNuts][enuts] | [Nutshell][py], [cashu-rs-mint][cashu-rs-mint]
 | [10][10] | Spending conditions | [Nutshell][py] | [Nutshell][py]
 | [11][11] | Pay-To-Pubkey (P2PK) | [Nutshell][py] | [Nutshell][py]
-| TBD | DLEQ proofs | - | -
+| [12][12] | DLEQ proofs | [Nutshell][py] | [Nutshell][py]
 
 [py]: https://github.com/cashubtc/cashu
 [feni]: https://github.com/cashubtc/cashu-feni


### PR DESCRIPTION
## Chaum-Pedersen DLEQ proofs


> In this document, we present an extension of Cashu's crypto system to allow a user Alice to verify the mint Bob's signature using only Bob's public keys. We explain how another user Carol who receives ecash from Alice can execute the DLEQ proof as well. This is achieved using a Discrete Log Equality (DLEQ) proof. Previously, Bob's signature could only be checked by himself using his own private keys ([NUT-00](00)). 

**More resources:**
- Implementation in Nutshell: https://github.com/cashubtc/cashu/pull/175
- A discussion about the DLEQ proof on Somsens's [gist](https://gist.github.com/RubenSomsen/be7a4760dd4596d06963d67baf140406)
- A discussion on the pros and cons compared to an alternative approach: https://github.com/cashubtc/nutshell/pull/295

**Todo:**

- [x] Describe DLEQ proof
- [x] Alice validates Bob's DLEQ proof
- [x] Carol validates Alice's DLEQ proof