### PR TITLE
Remove reference to `cashu_wallet_spec.md` file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 These documents each specify parts of the Cashu protocol.
 
-## Wallet protocol
-
-A description of the steps of the protocol is given in the Cashu [wallet specs](/wallet/cashu_wallet_spec.md).
-
 ## Specifications
 Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optional specs.
 


### PR DESCRIPTION
The readme still has a reference to the now removed cashu_wallet_spec file, leaving a link that returns a `404 — Page Not Found` error. This PR removes that section of the readme.