### PR TITLE
Nut 11 fixes

### DIFF
--- a/11.md
+++ b/11.md
@@ -31,17 +31,17 @@ The recipient who owns the private key of the public key `Secret.data` can spend
 
 ```json
 {
-  "amount": 8, 
-  "secret": '["P2PK",{"nonce": "5d11913ee0f92fefdc82a6764fd2457a","data": "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198",}]',
-  "C": "02250a37a56b78e66674f7f063e6abd3d9345f8761fb90cac0293108910a8c27a3",
-  "id": "1cCNIAZ2X/w1",
-  "witness": {
-    "signatures":
-        [
-          "c43d0090be59340a6364dc1340876211f2173d6a21c391115adf097adb6ea0a3ddbe7fd81b4677281decc77be09c0359faa77416025130e487f8b9169eb0c609"
-        ]
-    }
-  ]
+   "amount":8,
+   "secret":"[\"P2PK\",{\"nonce\": \"5d11913ee0f92fefdc82a6764fd2457a\",\"data\": \"026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198\",}]",
+   "C":"02250a37a56b78e66674f7f063e6abd3d9345f8761fb90cac0293108910a8c27a3",
+   "id":"1cCNIAZ2X/w1",
+   "witness":[
+      {
+         "signatures":[
+            "c43d0090be59340a6364dc1340876211f2173d6a21c391115adf097adb6ea0a3ddbe7fd81b4677281decc77be09c0359faa77416025130e487f8b9169eb0c609"
+         ]
+      }
+   ]
 }
 ```
 
@@ -49,7 +49,7 @@ The recipient who owns the private key of the public key `Secret.data` can spend
 
 To spend a token locked with `P2PK`, the spender needs to include signatures in the spent proofs. We use `libsecp256k1`'s serialized 64 byte Schnorr signatures on the SHA256 hash of the message to sign. The message to sign is the field `Proof.secret` in the inputs. If indicated by `Secret.tags.sigflag` in the inputs, outputs might also require signatures on the message `BlindedMessage.B_`. 
 
-An ecash spending operation like [swap][03]] and [melt][05]] can have multiple inputs and outputs. If we have more than one input or output, we provide signatures in each `Proof` and `BlindedMessage` individually. The inputs are the `Proofs` provided in the `inputs` field and the outputs are the `BlindedMessages` in the `outputs` field in the request body (see `PostMeltRequest` in [NUT-05][05] and `PostSwapRequest` in [NUT-03][03]). 
+An ecash spending operation like [swap][03] and [melt][05] can have multiple inputs and outputs. If we have more than one input or output, we provide signatures in each `Proof` and `BlindedMessage` individually. The inputs are the `Proofs` provided in the `inputs` field and the outputs are the `BlindedMessages` in the `outputs` field in the request body (see `PostMeltRequest` in [NUT-05][05] and `PostSwapRequest` in [NUT-03][03]). 
 
 ### Tags
 More complex spending conditions can be defined in the tags in `Proof.tags`. All tags are optional. Tags are arrays with two or more strings being `["key", "value1", "value2", ...]`.
@@ -181,7 +181,6 @@ The following use cases are unlocked using P2PK:
 [06]: 06.md
 [07]: 07.md
 [08]: 08.md
-[09]: 09.md
 [10]: 10.md
 [11]: 11.md
 [12]: 12.md


### PR DESCRIPTION
* Witness encapsulated as an object 
* Escape inner quotes in secret
* Remove extra bracket on link to nuts
* Unify Array notation signatures
* Remove dead link to NUT09

TODO: 
* There is an extra trailing , in the secret that should likely be removed.
* The ID should be updated to a v1 keyset id.

Note: 
Going to leave this as a draft in case I find anything else while implementing. 

fixes: https://github.com/cashubtc/nuts/issues/61#issue-1966893496