### PR TITLE
NUT-4/NUT-5: Method-unit pair is object with settings

### DIFF
--- a/04.md
+++ b/04.md
@@ -199,6 +199,7 @@ The settings for this nut indicate the supported method-unit pairs for minting a
   "max_amount": <int|null>
 }
 ```
+`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair.
 
 Example `MintMethodSetting`:
 

--- a/04.md
+++ b/04.md
@@ -180,13 +180,36 @@ The settings for this nut indicate the supported method-unit pairs for minting a
 {
   "4": {
     "methods": [
-      ["bolt11", "sat"]
+      <MintMethodSetting>,
+      ...
     ],
-    "disabled": false
+    "disabled": <bool>
   }
 }
 ```
-Here, `methods` is an array of arrays with `[method, unit]` pairs. `disabled` indicates whether this minting is disabled and the mint only allows melting ecash.
+
+`MintMethodSetting` indicates supported `method` and `unit` pairs and additional settings of the mint. `disabled` indicates whether this minting is disabled.
+
+`MintMethodSetting` is of the form:
+```json
+{
+  "method": <str>,
+  "unit": <str>,
+  "min_amount": <int|null>,
+  "max_amount": <int|null>
+}
+```
+
+Example `MintMethodSetting`:
+
+```json
+{
+  "method": "bolt11",
+  "unit": "sat",
+  "min_amount": 0,
+  "max_amount": 10000        
+}
+```
 
 [00]: 00.md
 [01]: 01.md

--- a/05.md
+++ b/05.md
@@ -178,6 +178,7 @@ The settings for this nut indicate the supported method-unit pairs for melting. 
   "max_amount": <int|null>
 }
 ```
+`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair.
 
 Example `MeltMethodSetting`:
 

--- a/05.md
+++ b/05.md
@@ -157,14 +157,38 @@ Response of `Bob`:
 The settings for this nut indicate the supported method-unit pairs for melting. They are part of the info response of the mint ([NUT-06][06]) which in this case reads 
 ```json
 {
-  "5": {
+  "4": {
     "methods": [
-      ["bolt11", "sat"]
+      <MeltMethodSetting>,
+      ...
     ],
+    "disabled": <bool>
   }
 }
 ```
-Here, `methods` is an array of arrays with `[method, unit]` pairs.
+
+`MeltMethodSetting` indicates supported `method` and `unit` pairs and additional settings of the mint. `disabled` indicates whether this melting is disabled.
+
+`MeltMethodSetting` is of the form:
+```json
+{
+  "method": <str>,
+  "unit": <str>,
+  "min_amount": <int|null>,
+  "max_amount": <int|null>
+}
+```
+
+Example `MeltMethodSetting`:
+
+```json
+{
+  "method": "bolt11",
+  "unit": "sat",
+  "min_amount": 100,
+  "max_amount": 10000        
+}
+```
 
 [00]: 00.md
 [01]: 01.md

--- a/06.md
+++ b/06.md
@@ -33,13 +33,24 @@ With the mint's response being of the form `GetInfoResponse`:
   "nuts": {
     "4": {
       "methods": [
-        ["bolt11", "sat"]
+        {
+          "method": "bolt11",
+          "unit": "sat",
+          "min_amount": 0,
+          "max_amount": 10000        
+        }
       ],
       "disabled": false
     },
     "5": {
       "methods": [
-        ["bolt11", "sat"]
+        {
+          "method": "bolt11",
+          "unit": "sat",
+          "min_amount": 100,
+          "max_amount": 10000        
+        },
+        "disabled": false
       ]
     },
     "7": {"supported": true},


### PR DESCRIPTION
This PR changes the "settings" for NUT-4/NUT-5 (minting and melting) that are shown in the `/v1/info` response.

The unit pairs are changed from an array `["method", "unit"]` to an object that now also carries settings for the endpoints.

Example:
```json
{
  "method": "bolt11",
  "unit": "sat",
  "min_amount": 0,
  "max_amount": 10000        
}
```
