### PR TITLE
Add a description for h2c

### DIFF
--- a/00.md
+++ b/00.md
@@ -32,6 +32,16 @@ This document details the notation and models used throughout the specification 
 - `T` blinded message
 - `Z` proof (unblinded signature)
 
+### `hash_to_curve`
+
+Deterministically maps a message to a public key point on the secp256k1 curve, utilizing a domain separator to ensure uniqueness.
+
+`Y = G * SHA256(DOMAIN_SEPARATOR || x || counter)`
+- `Y` derived public key
+- `DOMAIN_SEPARATOR` constant byte string `b"Secp256k1_HashToCurve_Cashu_"`
+- `x` message to hash
+- `counter` uint32 counter(byte order little endian) incremented from 0 until a point is found that lies on the curve
+
 ## Protocol
 
 - Mint `Bob` publishes public key `K = kG` 


### PR DESCRIPTION
I came across this addition to the spec in both nutshell, and in cashu-ts (v1). Maybe this is not ready to get added to the spec, but I figured I would submit a PR anyway for fun.

Also, when I first implemented the BDHKE flow a couple of months ago, the hash_to_curve function took me a while to figure out what it was. Maybe this is because I'm a noob, but I figured a clear explanation would be helpful for future nutty noobs.