### PR TITLE
Fix signature enforcement in Proof class

### DIFF
--- a/11.md
+++ b/11.md
@@ -75,7 +75,7 @@ The signature flag `SIG_ALL` is enforced if at least one of the `Proofs` have th
 
 #### Signature
 
-Signatures must be provided in the field `Proof.signatures` for each `Proof` which is an input. If the signature flags `sigflag` of all `Proofs` is `SIG_ALL`, signatures must also be provided for every output in its field `BlindedMessage.witness.signatures`.
+Signatures must be provided in the field `Proof.signatures` for each `Proof` which is an input. If the signature flag `SIG_ALL` is enforced, signatures must also be provided for every output in its field `BlindedMessage.witness.signatures`.
 
 ##### Signed inputs
 A `Proof` (an input) with a signature `P2PKWitness.signatures` on `secret` is the JSON (see [NUT-00][00]):


### PR DESCRIPTION
This pull request fixes the conditions for enfording `SIG_ALL`