### PR TITLE
NUT-07: Token state check with `Y`

### DIFF
--- a/07.md
+++ b/07.md
@@ -73,7 +73,7 @@ With curl:
 **Request** of `Alice`:
 
 ```bash
-curl -X POST https://mint.host:3338/v1/checkstate -H 'Content-Type: application/json' -d '{                                                                           cc@ddd
+curl -X POST https://mint.host:3338/v1/checkstate -H 'Content-Type: application/json' -d '{
   "Ys": [
     "02599b9ea0a1ad4143706c2a5a4a568ce442dd4313e1cf1f7f0b58a317c1a355ee"
   ]

--- a/07.md
+++ b/07.md
@@ -38,10 +38,7 @@ With the data being of the form `PostCheckStateRequest`:
 
 ```json
 {
-  "Ys": [
-    <Array[hex_str]>,
-    ...
-  ]
+  "Ys": <Array[hex_str]>,
 }
 ```
 

--- a/07.md
+++ b/07.md
@@ -16,7 +16,7 @@ A proof can be in one of the following states
 
 **Note:** Before deleting spent proofs from their database, wallets can check if the proof is `SPENT` to make sure that they don't accidentally delete an unspent proof. Beware that this behavior can make it easier for the mint to correlate the sender to the receiver.
 
-**Important:** Mints **MUST** remember which proofs are currently `PENDING` to avoid reuse of the same token in multiple concurrent transactions. This can be achieved with for example mutex lock whose key is the proof's `secret`.
+**Important:** Mints **MUST** remember which proofs are currently `PENDING` to avoid reuse of the same token in multiple concurrent transactions. This can be achieved with for example mutex lock whose key is the `Proof`'s `Y`.
 
 ## Use cases
 
@@ -38,14 +38,14 @@ With the data being of the form `PostCheckStateRequest`:
 
 ```json
 {
-  "secrets": [
-    <secret_str>,
+  "Ys": [
+    <Array[hex_str]>,
     ...
   ]
 }
 ```
 
-`secret_str` corresponds to `secret` of the `Proof` to check (see [NUT-00][00]).
+Where the elements of the array in `Ys` are the hexadecimal representation of the compressed point `Y = hash_to_curve(secret)` of the `Proof` to check (see [NUT-00][00]).
 
 **Response** of `Bob`:
 
@@ -55,7 +55,7 @@ With the data being of the form `PostCheckStateRequest`:
 {
   "states": [
     {
-      "secret": <str>,
+      "Y": <hex_str>,
       "state": <str_enum[STATE]>,
       "witness": <str|null>,
     },
@@ -64,8 +64,7 @@ With the data being of the form `PostCheckStateRequest`:
 }
 ```
 
-- `secret` corresponds to the proof to check in the request. 
-
+- `Y` corresponds to the `Proof` checked in the request. 
 - `state` is an enum string field with possible values `"UNSPENT"`, `"PENDING"`, `"SPENT"`
 - `witness` is the serialized witness data that was used to spend the `Proof` if the token required it such as in the case of P2PK (see [NUT-11][11]).
 
@@ -74,9 +73,9 @@ With curl:
 **Request** of `Alice`:
 
 ```bash
-curl -X POST https://mint.host:3338/v1/checkstate -H 'Content-Type: application/json' -d '{
-  "secrets": [
-    "[\"P2PK\", {\"data\": \"027a0486a237d985cff2dcbec2c7f472136bc0af6399f28881f7fa5eb1a2244c3e\", \"nonce\": \"4a07f7ce5f9a416a67523a643f1944a5\", \"tags\": [[\"locktime\", \"1704459125\"], [\"sigflag\", \"SIG_ALL\"]]}]"
+curl -X POST https://mint.host:3338/v1/checkstate -H 'Content-Type: application/json' -d '{                                                                           cc@ddd
+  "Ys": [
+    "02629aa7902b1849b4996d8c0ee69cb2d17465c67dd24cd331477f37e711ec0bbb"
   ]
 }'
 ```
@@ -87,16 +86,16 @@ curl -X POST https://mint.host:3338/v1/checkstate -H 'Content-Type: application/
 {
   "states": [
     {
-      "secret": "[\"P2PK\", {\"data\": \"027a0486a237d985cff2dcbec2c7f472136bc0af6399f28881f7fa5eb1a2244c3e\", \"nonce\": \"4a07f7ce5f9a416a67523a643f1944a5\", \"tags\": [[\"locktime\", \"1704459125\"], [\"sigflag\", \"SIG_ALL\"]]}]",
+      "Y": "02599b9ea0a1ad4143706c2a5a4a568ce442dd4313e1cf1f7f0b58a317c1a355ee",
       "state": "SPENT",
-      "witness": "{\"signatures\": [\"c92521e6922da68dbb05b7fb3f3c8004707d57d4379c021e97a9505d875ca100020f85493595578f66e950f383a7671b5d8edaefff5aadb379934cb524744023\"]}"
+      "witness": "{\"signatures\": [\"b2cf120a49cb1ac3cb32e1bf5ccb6425e0a8372affdc1d41912ca35c13908062f269c0caa53607d4e1ac4c8563246c4c8a869e6ee124ea826fd4746f3515dc1e\"]}"
     }
   ]
 }
 ```
 
 
-Where `secret` belongs to the provided `Proof` to check in the request, `state` indicates its state, and `witness` is the witness data that was potentially provided in a previous spend operation (can be empty). 
+Where `Y` belongs to the provided `Proof` to check in the request, `state` indicates its state, and `witness` is the witness data that was potentially provided in a previous spend operation (can be empty). 
 
 [00]: 00.md
 [01]: 01.md

--- a/07.md
+++ b/07.md
@@ -75,7 +75,7 @@ With curl:
 ```bash
 curl -X POST https://mint.host:3338/v1/checkstate -H 'Content-Type: application/json' -d '{                                                                           cc@ddd
   "Ys": [
-    "02629aa7902b1849b4996d8c0ee69cb2d17465c67dd24cd331477f37e711ec0bbb"
+    "02599b9ea0a1ad4143706c2a5a4a568ce442dd4313e1cf1f7f0b58a317c1a355ee"
   ]
 }'
 ```


### PR DESCRIPTION
Instead of using `secret` in the token state check, we use `Y`. 

This allows third parties to check the state of a token for which they have received the `Y` without being able to spend it. 

Wallets that know `secret` can compute `Y` by `Y = hash_to_curve(secret)`.

Closes: https://github.com/cashubtc/nuts/issues/91