### PR TITLE
Nut-05: fix small typo

### DIFF
--- a/05.md
+++ b/05.md
@@ -157,7 +157,7 @@ Response of `Bob`:
 The settings for this nut indicate the supported method-unit pairs for melting. They are part of the info response of the mint ([NUT-06][06]) which in this case reads 
 ```json
 {
-  "4": {
+  "5": {
     "methods": [
       <MeltMethodSetting>,
       ...


### PR DESCRIPTION
The settings for Nut-05 in the info-endpoint should be under the key 5 and not 4