### PR TITLE
fix: typo in nut13 tests link

### DIFF
--- a/09.md
+++ b/09.md
@@ -42,4 +42,3 @@ The returned arrays `outputs` and `signatures` are of the same length and for ev
 [07]: 07.md
 [09]: 09.md
 [11]: 11.md
-[tests]: tests/09-tests.md

--- a/13.md
+++ b/13.md
@@ -109,4 +109,4 @@ Wallets restore `Proofs` in batches of 100. The wallet starts with a `counter=0`
 [02]: 02.md
 [07]: 07.md
 [09]: 09.md
-[tests]: tests/09-tests.md
+[tests]: tests/13-tests.md


### PR DESCRIPTION
tests link is not used in NUT09 and tests link in NUT13 should be 13 not 09.