### PR TITLE
NUT-XX: Authentication

### DIFF
--- a/15.md
+++ b/15.md
@@ -1,0 +1,123 @@
+## NUT-15: Authentication with Schnorr Signatures
+==========================
+
+`optional` `use with: NUT-04, NUT-05`
+
+In this document, we describe a mechanism for obtaining time-bounded OAuth bearer tokens using Schnorr signatures for accessing protected endpoints for a mint. This specifically applies only for minting (NUT-04) and melting tokens (NUT-05). This NUT provides the mint with the ability to restrict who can mint and melt cashu tokens or, in some cases, implement temporary time-bound restrictions.
+
+The registration process for authorizing public keys is outside the scope of this NUT and should be implemented separately by the mint. The mint should generate and store auth tokens based on the described authentican flow below. The auth tokens will be time bounded with an explict expiry time, after which the tokens should be destroyed by the mint.  
+
+NOTE: This NUT does not apply to swapping tokens (NUT-03) to preserve users' privacy and utilize spending conditions (NUT-10) to restrict swapping when required. 
+
+# Authentication Flow
+
+**1. Client initiates authentication:** The client application initiates the authentication process by redirecting the user to the designated authorization endpoint. This endpoint is provided by the mint.
+
+Alice wants to access a protected resource on Bob's mint. Her client application initiates the authentication process by redirecting her to Bob's mint authorization endpoint:
+
+```http
+GET https://bob.com/oauth/authorize/challenge?client_id=alice-app&scope=resource1
+```
+Bob's mint generates a random challenge in response, for example:
+
+```json
+{
+challenge : "f7d8c3b2a679e48d"
+}
+```
+
+This challenge is displayed to Alice. Alice's client application then uses her private key to sign the challenge using Schnorr signature scheme. The resulting signature might look like this:
+
+```json
+{
+signature:"2c568f78e4b234a5f7d8c3b2a679e48d1234567890abcdef"
+}
+```
+
+**2. Signature verification and token issuance:** Bob's mint verifies the validity of the Schnorr signature using alice's public key. If the signature is valid, Bob's mint issues a time-bounded OAuth bearer token to the client application. This token represents the user's identity and grants access to specific resources based on the scopes requested by the client.
+
+Alice's client application submits the signature and public key to Bob's mint:
+
+```http
+POST https://bob.com/v1/oauth/authorize
+```
+``` json
+
+Post Data:
+{
+  client_id:alice-app 
+  scope:resource1
+  signature:c568f78e4b234a5f7d8c3b2a679e48d1234567890abcdef
+  pubkey:7345786068584cd33000582ba87a9ddf77db5377c67910ab59d7e9a5f44
+}
+
+Response:
+
+```json
+HTTP/1.1 200 OK
+
+{
+"access_token": "9876543210fedcba",
+"token_type": "Bearer",
+"expires_in": 3600
+}
+```
+
+**3.Client accesses protected resources:** The client application includes the bearer token in the Authorization header of subsequent requests to access protected resources. The mint validates the token and grants access if it is valid and has not expired.
+
+Alice's client application can now access the protected resource on Bob's mint by including the bearer token in the Authorization header of the request:
+
+```http
+POST https://bob.com/v1/mint/quote/bolt11
+
+Authorization: Bearer 9876543210fedcba
+```
+
+Bob's mint validates the token and grants access to the resource if the token is valid and has not expired.
+
+
+# Schnorr Signature Details
+
+- The Schnorr signature scheme is used due to its security properties and its compatibility with existing ecash infrastructure.
+- The user's public key is assumed to be already registered with the mint. This registration process is outside the scope of this NUT.
+- The challenge presented to the user should be sufficiently random to prevent replay attacks.
+- The mint must verify the Schnorr signature using a trusted library or implementation.
+
+# Bearer Token Details
+
+- The bearer token is a string representing the user's identity and access rights.
+- The token is time-bounded with a specific expiry time. This expiry time should be chosen based on security considerations and the desired access duration.
+- The token should be treated as a secret and protected from unauthorized access.
+
+# Benefits of Schnorr-based OAuth Authentication
+
+- **Enhanced security:** Schnorr signatures provide strong cryptographic security for user authentication.
+- **Improved privacy:** Schnorr signatures do not reveal the user's private key, protecting user privacy.
+- **utilizing existing infrastructure:** Leverages existing mint infrastructure and Schnorr signature capabilities.
+- **Standardized approach:** Aligns with the OAuth framework, ensuring compatibility with existing clients and services.
+
+# Implementation Considerations
+
+- Secure storage of user private keys is crucial for the security of this authentication mechanism.
+- The mint must implement robust signature verification and token management processes.
+- Client applications must handle bearer tokens securely and respect their expiry times.
+- If a mint choose to implement this NUT, then add this information to /info endpoint as per NUT-06 spec.
+
+```json
+{
+    "nuts": {
+    "15": {
+      "methods": [
+        {
+          "method": "/quote/bolt11",
+          "restricted": true,     
+        }
+      ],
+      "disabled": false
+    },
+
+}
+
+```
+
+This NUT provides a high-level overview of Schnorr-based OAuth authentication for the cashu protocol. Specific implementation details and security considerations should be further addressed during the development and deployment of this  specification.

--- a/15.md
+++ b/15.md
@@ -16,7 +16,7 @@ NOTE: This NUT does not apply to swapping tokens (NUT-03) to preserve users' pri
 Alice wants to access a protected resource on Bob's mint. Her client application initiates the authentication process by redirecting her to Bob's mint authorization endpoint:
 
 ```http
-GET https://bob.com/oauth/authorize/challenge?client_id=alice-app&scope=resource1
+GET https://bob.com/oauth/authorize/challenge?client_id=alice-app&scope="quote/bolt11"
 ```
 Bob's mint generates a random challenge in response, for example:
 
@@ -46,7 +46,7 @@ POST https://bob.com/v1/oauth/authorize
 Post Data:
 {
   client_id:alice-app 
-  scope:resource1
+  scope:"quote/bolt11"
   signature:c568f78e4b234a5f7d8c3b2a679e48d1234567890abcdef
   pubkey:7345786068584cd33000582ba87a9ddf77db5377c67910ab59d7e9a5f44
 }

--- a/15.md
+++ b/15.md
@@ -3,11 +3,9 @@
 
 `optional` `use with: NUT-04, NUT-05`
 
-In this document, we describe a mechanism for obtaining time-bounded OAuth bearer tokens using Schnorr signatures for accessing protected endpoints for a mint. This specifically applies only for minting (NUT-04) and melting tokens (NUT-05). This NUT provides the mint with the ability to restrict who can mint and melt cashu tokens or, in some cases, implement temporary time-bound restrictions.
+In this document, we describe a mechanism for obtaining time-bounded bearer tokens using Schnorr signatures for accessing protected endpoints for a mint. The registration process for authorizing public keys is outside the scope of this NUT and should be implemented separately by the mint. The auth tokens will be time bounded with an explict expiry time, after which the tokens should be destroyed by the mint.  
 
-The registration process for authorizing public keys is outside the scope of this NUT and should be implemented separately by the mint. The mint should generate and store auth tokens based on the described authentican flow below. The auth tokens will be time bounded with an explict expiry time, after which the tokens should be destroyed by the mint.  
-
-NOTE: This NUT does not apply to swapping tokens (NUT-03) to preserve users' privacy and utilize spending conditions (NUT-10) to restrict swapping when required. 
+NOTE: The authentication of a user through the utilization of a public key adopts an accounting model that may compromise privacy.
 
 # Authentication Flow
 
@@ -16,7 +14,7 @@ NOTE: This NUT does not apply to swapping tokens (NUT-03) to preserve users' pri
 Alice wants to access a protected resource on Bob's mint. Her client application initiates the authentication process by redirecting her to Bob's mint authorization endpoint:
 
 ```http
-GET https://bob.com/oauth/authorize/challenge?client_id=alice-app&scope="quote/bolt11"
+GET https://bob.com/authorize/challenge?client_id=alice-app&scope="quote/bolt11"
 ```
 Bob's mint generates a random challenge in response, for example:
 
@@ -34,12 +32,12 @@ signature:"2c568f78e4b234a5f7d8c3b2a679e48d1234567890abcdef"
 }
 ```
 
-**2. Signature verification and token issuance:** Bob's mint verifies the validity of the Schnorr signature using alice's public key. If the signature is valid, Bob's mint issues a time-bounded OAuth bearer token to the client application. This token represents the user's access to specific resources based on the scopes requested by the client.
+**2. Signature verification and token issuance:** Bob's mint verifies the validity of the Schnorr signature using alice's public key. If the signature is valid, Bob's mint issues a time-bounded bearer token to the client application. This token represents the user's access to specific resources based on the scopes requested by the client.
 
 Alice's client application submits the signature and public key to Bob's mint:
 
 ```http
-POST https://bob.com/v1/oauth/authorize
+POST https://bob.com/v1/authorize
 ```
 ``` json
 
@@ -75,26 +73,12 @@ Authorization: Bearer 9876543210fedcba
 
 Bob's mint validates the token and grants access to the resource if the token is valid and has not expired.
 
-
-# Schnorr Signature Details
-
-- The Schnorr signature scheme is used due to its security properties and its compatibility with existing ecash infrastructure.
-- The user's public key is assumed to be already registered with the mint. This registration process is outside the scope of this NUT.
-- The challenge presented to the user should be sufficiently random to prevent replay attacks.
-- The mint must verify the Schnorr signature using a trusted library or implementation.
-
 # Bearer Token Details
 
 - The bearer token is a string representing the user's access to resources.
 - The token is time-bounded with a specific expiry time. This expiry time should be chosen based on security considerations and the desired access duration.
 - The token should be treated as a secret and protected from unauthorized access.
 
-# Benefits of Schnorr-based OAuth Authentication
-
-- **Enhanced security:** Schnorr signatures provide strong cryptographic security for user authentication.
-- **Improved privacy:** Schnorr signatures do not reveal the user's private key, protecting user privacy.
-- **utilizing existing infrastructure:** Leverages existing mint infrastructure and Schnorr signature capabilities.
-- **Standardized approach:** Aligns with the OAuth framework, ensuring compatibility with existing clients and services.
 
 # Implementation Considerations
 
@@ -119,5 +103,3 @@ Bob's mint validates the token and grants access to the resource if the token is
 }
 
 ```
-
-This NUT provides a high-level overview of Schnorr-based OAuth authentication for the cashu protocol. Specific implementation details and security considerations should be further addressed during the development and deployment of this  specification.

--- a/15.md
+++ b/15.md
@@ -34,7 +34,7 @@ signature:"2c568f78e4b234a5f7d8c3b2a679e48d1234567890abcdef"
 }
 ```
 
-**2. Signature verification and token issuance:** Bob's mint verifies the validity of the Schnorr signature using alice's public key. If the signature is valid, Bob's mint issues a time-bounded OAuth bearer token to the client application. This token represents the user's identity and grants access to specific resources based on the scopes requested by the client.
+**2. Signature verification and token issuance:** Bob's mint verifies the validity of the Schnorr signature using alice's public key. If the signature is valid, Bob's mint issues a time-bounded OAuth bearer token to the client application. This token represents the user's access to specific resources based on the scopes requested by the client.
 
 Alice's client application submits the signature and public key to Bob's mint:
 
@@ -85,7 +85,7 @@ Bob's mint validates the token and grants access to the resource if the token is
 
 # Bearer Token Details
 
-- The bearer token is a string representing the user's identity and access rights.
+- The bearer token is a string representing the user's access to resources.
 - The token is time-bounded with a specific expiry time. This expiry time should be chosen based on security considerations and the desired access duration.
 - The token should be treated as a secret and protected from unauthorized access.
 

--- a/16.md
+++ b/16.md
@@ -1,9 +1,9 @@
-## NUT-16: Authentication with Schnorr Signatures
+## NUT-16: Authentication 
 ==========================
 
-`optional` `use with: NUT-04, NUT-05`
+`optional` 
 
-In this document, we describe a mechanism for obtaining time-bounded bearer tokens using Schnorr signatures for accessing protected endpoints for a mint. The registration process for authorizing public keys is outside the scope of this NUT and should be implemented separately by the mint. The auth tokens will be time bounded with an explict expiry time, after which the tokens should be destroyed by the mint.  
+In this document, we describe a mechanism for obtaining time-bounded bearer tokens using user derived public/private keys for accessing protected endpoints for a mint. The registration process for authorizing public keys is outside the scope of this NUT and should be implemented separately by the mint. We derive a unique public/private key pair unique to each mint by hashing the mint URL. This provides additional privacy, as the user's public key cannot be linked across mints.
 
 NOTE: The authentication of a user through the utilization of a public key adopts an accounting model that may compromise privacy.
 
@@ -11,42 +11,54 @@ NOTE: The authentication of a user through the utilization of a public key adopt
 
 **1. Client initiates authentication:** The client application initiates the authentication process by redirecting the user to the designated authorization endpoint. This endpoint is provided by the mint.
 
-Alice wants to access a protected resource on Bob's mint. Her client application initiates the authentication process by redirecting her to Bob's mint authorization endpoint:
+Alice wants to access a protected resource on Bob's mint. Her client application initiates the authentication process by redirecting her to Bob's mint authorization endpoint with the required action as `tag` :
 
 ```http
-GET https://bob.com/authorize/challenge?client_id=alice-app&scope="quote/bolt11"
+GET https://bob.com/v1/auth/challenge?&tag=<(action enums)>
 ```
-Bob's mint generates a random challenge in response, for example:
+Bob's mint generates a challenge `k1` consisting of randomly generated 32 bytes, for example:
 
-```json
+``` json
 {
-challenge : "f7d8c3b2a679e48d"
+  "tag": "mint",
+  "k1": "8278e1a48e61c261916791dabb6af760488e4f01932e11fe7054f59754e3de6e"
 }
 ```
 
-This challenge is displayed to Alice. Alice's client application then uses her private key to sign the challenge using Schnorr signature scheme. The resulting signature might look like this:
 
-```json
-{
-signature:"2c568f78e4b234a5f7d8c3b2a679e48d1234567890abcdef"
-}
-```
+`tag` enums meaning:
+- `register`: service is requesting to register a user's `linkingKey`.
+- `mint` user is authed to mint tokens.
+- `melt` user is authed to melt tokens.
+- `...`
 
-**2. Signature verification and token issuance:** Bob's mint verifies the validity of the Schnorr signature using alice's public key. If the signature is valid, Bob's mint issues a time-bounded bearer token to the client application. This token represents the user's access to specific resources based on the scopes requested by the client.
+
+This k1 is displayed to Alice. Alice's client application then uses her `linkingPrivKey` private key to sign the challenge over the secp256k1 curve using the `linkingPrivKey` private key 
+
+## `linkingKey` derivation
+
+ - `linkingKey` This is a public key derived from `linkingPrivKey`
+ - `linkingPrivKey` To keep the derived public key unique to each mint, the `linkingPrivKey` should be derived as follows
+ -  Use the derivation path m/138'/0 from the master key to get `hashingkey`
+ - `linkingPrivKey = PrivateKey(hmacSha256(hashingKey, mint domain name e.g. https://bob.com))`
+ - `linkingKey = PublicKey(linkingPrivKey)`
+
+
+**2. Signature verification and bearer token issuance:** Bob's mint verifies the validity of the signature using alice's linking key. If the signature is valid, Bob's mint issues a time-bounded bearer token to the client application. This token represents the user's access to specific resources based on the action requested by the client.
 
 Alice's client application submits the signature and public key to Bob's mint:
 
 ```http
-POST https://bob.com/v1/authorize
+POST https://bob.com/v1/auth
 ```
 ``` json
 
 Post Data:
-{
-  client_id:alice-app 
-  scope:"quote/bolt11"
+{ 
+  action:"mint", 
+  k1:"8278e1a48e61c261916791dabb6af760488e4f01932e11fe7054f59754e3de6e"
   signature:c568f78e4b234a5f7d8c3b2a679e48d1234567890abcdef
-  pubkey:7345786068584cd33000582ba87a9ddf77db5377c67910ab59d7e9a5f44
+  linkingKey:7345786068584cd33000582ba87a9ddf77db5377c67910ab59d7e9a5f44
 }
 
 Response:
@@ -55,9 +67,9 @@ Response:
 HTTP/1.1 200 OK
 
 {
-"access_token": "9876543210fedcba",
-"token_type": "Bearer",
-"expires_in": 3600
+  "access_token": "9876543210fedcba",
+  "token_type": "Bearer",
+  "expires_in": 3600
 }
 ```
 
@@ -95,7 +107,7 @@ Bob's mint validates the token and grants access to the resource if the token is
         {
           "method": "/quote/bolt11",
           "restricted": true,
-          "registration": "/user/auth?pubkey=1cr23m29jgcpapdlhchug5dc7cxdtcel4qlgld2azjxvl6jz7wk0qlsejpq"   
+          "registration": "/v1/auth/register"   
         }
       ],
       "disabled": false

--- a/16.md
+++ b/16.md
@@ -1,4 +1,4 @@
-## NUT-15: Authentication with Schnorr Signatures
+## NUT-16: Authentication with Schnorr Signatures
 ==========================
 
 `optional` `use with: NUT-04, NUT-05`

--- a/16.md
+++ b/16.md
@@ -94,7 +94,8 @@ Bob's mint validates the token and grants access to the resource if the token is
       "methods": [
         {
           "method": "/quote/bolt11",
-          "restricted": true,     
+          "restricted": true,
+          "registration": "/user/auth?pubkey=1cr23m29jgcpapdlhchug5dc7cxdtcel4qlgld2azjxvl6jz7wk0qlsejpq"   
         }
       ],
       "disabled": false

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 | [11][11] | Pay-To-Pubkey (P2PK) | [Nutshell][py] | [Nutshell][py] |
 | [12][12] | DLEQ proofs | [Nutshell][py] | [Nutshell][py] |
 | [13][13] | Deterministic secrets | [Nutshell][py], [Moksha][cashume], [cashu-ts][ts] | - |
-
+| [15][15] |Authentication with Schnorr Signatures |
 #### Wallets:
 
  - [Nutshell][py]
@@ -74,3 +74,4 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 [11]: 11.md
 [12]: 12.md
 [13]: 13.md
+[15]: 15.md

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 | [11][11] | Pay-To-Pubkey (P2PK) | [Nutshell][py] | [Nutshell][py] |
 | [12][12] | DLEQ proofs | [Nutshell][py] | [Nutshell][py] |
 | [13][13] | Deterministic secrets | [Nutshell][py], [Moksha][cashume], [cashu-ts][ts] | - |
-| [15][15] |Authentication with Schnorr Signatures |
+| [15][16] |Authentication with Schnorr Signatures |
 #### Wallets:
 
  - [Nutshell][py]


### PR DESCRIPTION
Currently, access to mint endpoints are open to anyone. Since Cashu tokens are IOUs, the mint should have an optional way of restricting access to some end points if needed. We propose a new feature to provide optional access control for specific endpoints. This will address the need to restrict sensitive operations like minting and melting to authorized parties. This NUT is completely optional and may not be supported by mints and wallets. 

We have developed a (NUT) specification for implementing authentication through bearer tokens. This approach is easy to integrate into wallet provdiders, allowing mints to control access to their endpoints.

Selective Endpoint Authentication

Mints have the flexibility to authenticate certain endpoints selectively. For example, they could restrict minting while allowing unrestricted swapping and melting.

Ofcourse, this will compromise privacy. Both the mint and wallet should be explicit in informing the users about this. 

Example Scenario

Consider a mint such as the one I am currently running (https://stablenut.umint.cash) connected to Strike, a platform enforcing KYC for users transacting with its API. By enabling authentication, the mint can limit minting and melting only to KYC-compliant users. Meanwhile, tokens minted through this restricted channel can continue to be swapped between users freely without restrictions. (Calle can still post them on Nostr/twitter)

Each mint will clearly indicate its access policy on their /info endpoint, empowering wallet providers with the necessary information to guide their users' decisions.

Registration Process is out of scope for this NUT - The registration process for authorized public keys is scoped out of this NUT. Mints can implement their own authentication mechanisms and include authed pubkeys table inside mint database

We invite your review and comments on this proposal. 

