### PR TITLE
removed cashu:// and web+cashu:// schemes

### DIFF
--- a/00.md
+++ b/00.md
@@ -137,9 +137,7 @@ This token format has the `[version]` value `A`.
 
 ##### URI tags
 
-To make Cashu tokens clickable on the web, we use the URI tags `cashu:` or `cashu://` or `web+cashu://` (for PWAs).
-
-A serialized token with URI tag becomes 
+To make Cashu tokens clickable on the web, we use the URI scheme `cashu:`. A serialized token with URI tag becomes
 
 ```sh
 cashu:cashuAeyJwcm9vZn...


### PR DESCRIPTION
This PR removes two of the three suggested URI schemes from NUT-00. According to RFC 3986 the `//` indicates the start of the Authority part, which is not applicable to a cashu token.