### PR TITLE
refactor: one error code file

### DIFF
--- a/error_codes.md
+++ b/error_codes.md
@@ -1,0 +1,32 @@
+# NUT Errors
+
+| Code  | Description                                     | Relevant nuts                            |
+| ----- | ----------------------------------------------- | ---------------------------------------- |
+| 10002 | Blinded message of output already signed        | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
+| 10003 | Token could not be verified                     | [NUT-03][03], [NUT-05][05]               |
+| 11001 | Token is already spent                          | [NUT-03][03], [NUT-05][05]               |
+| 11002 | Transaction is not balanced (inputs != outputs) | [NUT-02][02], [NUT-03][03], [NUT-05][05] |
+| 11005 | Unit in request is not supported                | [NUT-04][04], [NUT-05][05]               |
+| 11006 | Amount outside of limit range                   | [NUT-04][04], [NUT-06][06]               |
+| 12001 | Keyset is not known                             | [NUT-02][02], [NUT-04][04]               |
+| 12002 | Keyset is inactive, cannot sign messages        | [NUT-02][02], [NUT-03][03], [NUT-04][04] |
+| 20001 | Quote request is not paid                       | [NUT-04][04]                             |
+| 20002 | Tokens have already been issued for quote       | [NUT-04][04]                             |
+| 20003 | Minting is disabled                             | [NUT-04][04]                             |
+| 20005 | Quote is pending                                | [NUT-04][04], [NUT-05][05]               |
+| 20006 | Invoice already paid                            | [NUT-05][05]                             |
+| 20007 | Quote is expired                                | [NUT-04][04], [NUT-05][05]               |
+
+[00]: 00.md
+[01]: 01.md
+[02]: 02.md
+[03]: 03.md
+[04]: 04.md
+[05]: 05.md
+[06]: 06.md
+[07]: 07.md
+[08]: 08.md
+[09]: 09.md
+[10]: 10.md
+[11]: 11.md
+[12]: 12.md


### PR DESCRIPTION
Alternative to #131 

I found having having the error codes split across multiple files to be confusing since the same error can be used in multiple nuts. This change keep all the error codes in one file while noting what nut(s) each error code is relevant to.

Open to comments on which one others prefer.  