### PR TITLE
NUT-05: Remove reference to old `paid` flag and `proof`

### DIFF
--- a/05.md
+++ b/05.md
@@ -10,7 +10,7 @@ Melting tokens is the opposite of minting tokens (see [NUT-04][04]). Like mintin
 
 In the first request the wallet asks the mint for a quote for a `request` it wants paid by the mint and the `unit` the wallet would like to spend as inputs. The mint responds with a quote that includes a `quote` id and an `amount` the mint demands in the requested unit. For the method `bolt11`, the mint includes a `fee_reserve` field indicating the reserve fee for a Lightning payment.
 
-In the second request, the wallet includes the `quote` id and provides `inputs` that sum up to `amount+fee_reserve` in the first response. For the method `bolt11`, the wallet can also include `outputs` in order for the mint to return overpaid Lightning fees (see [NUT-08][08]). The mint responds with a payment `state` and, if `"PAID"`, with a `payment_preimage` as a proof of payment. If the request included `outputs`, the mint may respond with `change` for the overpaid fees (see [NUT-08][08]).
+In the second request, the wallet includes the `quote` id and provides `inputs` that sum up to `amount+fee_reserve` in the first response. For the method `bolt11`, the wallet can also include `outputs` in order for the mint to return overpaid Lightning fees (see [NUT-08][08]). The mint responds with a payment `state`. If the `state` is `"PAID"` the response includes a `payment_preimage` as a proof of payment. If the request included `outputs`, the mint may respond with `change` for the overpaid fees (see [NUT-08][08]).
 
 We limit this document to mint quotes of `unit="sat"` and `method="bolt11"` which requests a bolt11 Lightning payment (typically paid by the mint from its Bitcoin reserves) using ecash denominated in Satoshis.
 

--- a/05.md
+++ b/05.md
@@ -10,7 +10,7 @@ Melting tokens is the opposite of minting tokens (see [NUT-04][04]). Like mintin
 
 In the first request the wallet asks the mint for a quote for a `request` it wants paid by the mint and the `unit` the wallet would like to spend as inputs. The mint responds with a quote that includes a `quote` id and an `amount` the mint demands in the requested unit. For the method `bolt11`, the mint includes a `fee_reserve` field indicating the reserve fee for a Lightning payment.
 
-In the second request, the wallet includes the `quote` id and provides `inputs` that sum up to `amount+fee_reserve` in the first response. For the method `bolt11`, the wallet can also include `outputs` in order for the mint to return overpaid Lightning fees (see [NUT-08][08]). The mint responds with a payment status `paid` and a `proof` of payment. If the request included `outputs`, the mint may respond with `change` for the overpaid fees (see [NUT-08][08]).
+In the second request, the wallet includes the `quote` id and provides `inputs` that sum up to `amount+fee_reserve` in the first response. For the method `bolt11`, the wallet can also include `outputs` in order for the mint to return overpaid Lightning fees (see [NUT-08][08]). The mint responds with a payment `state` and, if `"PAID"`, with a `payment_preimage` as a proof of payment. If the request included `outputs`, the mint may respond with `change` for the overpaid fees (see [NUT-08][08]).
 
 We limit this document to mint quotes of `unit="sat"` and `method="bolt11"` which requests a bolt11 Lightning payment (typically paid by the mint from its Bitcoin reserves) using ecash denominated in Satoshis.
 


### PR DESCRIPTION
This pull request removes the reference to the old `paid` flag and `proof` in the code. The second request now includes a payment `state` and, if `"PAID"`, a `payment_preimage` as a proof of payment.