### PR TITLE
error code for failed lightning payments

### DIFF
--- a/error_codes.md
+++ b/error_codes.md
@@ -13,6 +13,7 @@
 | 20001 | Quote request is not paid                       | [NUT-04][04]                             |
 | 20002 | Tokens have already been issued for quote       | [NUT-04][04]                             |
 | 20003 | Minting is disabled                             | [NUT-04][04]                             |
+| 20004 | Lightning payment failed                        | [NUT-05][05]                             |
 | 20005 | Quote is pending                                | [NUT-04][04], [NUT-05][05]               |
 | 20006 | Invoice already paid                            | [NUT-05][05]                             |
 | 20007 | Quote is expired                                | [NUT-04][04], [NUT-05][05]               |


### PR DESCRIPTION
add error code for failed lightning payments in melts. If wallets see this error they can be sure the proofs are not stuck in a pending state.