### PR TITLE
NUT-18: fix typo

### DIFF
--- a/18.md
+++ b/18.md
@@ -22,7 +22,7 @@ A Payment Request is defined as follows
   "i": str <optional>,
   "a": int <optional>,
   "u": str <optional>,
-  "r": bool <optional>,
+  "s": bool <optional>,
   "m": Array[str] <optional>,
   "d": str <optional>,
   "t": Array[Transport]


### PR DESCRIPTION
json says `"r"` for single use payments while the description says `"s"`

I think it should be `"s"`