### PR TITLE
NUT-07: explicitly mention order

### DIFF
--- a/07.md
+++ b/07.md
@@ -2,7 +2,7 @@
 
 `optional`
 
-`used in: NUT-17`
+`used in: NUT-17, NUT-11, NUT-14`
 
 ---
 
@@ -50,7 +50,7 @@ Where the elements of the array in `Ys` are the hexadecimal representation of th
 
 **Response** of `Bob`:
 
-`Bob` will respond with a `PostCheckStateResponse`
+`Bob` responds with the states  with a `PostCheckStateResponse`
 
 ```json
 {
@@ -65,9 +65,11 @@ Where the elements of the array in `Ys` are the hexadecimal representation of th
 }
 ```
 
+The elements of the `states` array MUST be returned in the same order as the corresponding `Proofs` checked in the request.
+
 - `Y` corresponds to the `Proof` checked in the request.
 - `state` is an enum string field with possible values `"UNSPENT"`, `"PENDING"`, `"SPENT"`
-- `witness` is the serialized witness data that was used to spend the `Proof` if the token required it such as in the case of P2PK (see [NUT-11][11]).
+- `witness` is the serialized witness data that was used to spend the `Proof` if the token has a [NUT-10][10] spending condition that requires a witness such as in the case of P2PK ([NUT-11][11]) or HTLCs ([NUT-14][14]).
 
 With curl:
 
@@ -110,3 +112,4 @@ Where `Y` belongs to the provided `Proof` to check in the request, `state` indic
 [10]: 10.md
 [11]: 11.md
 [12]: 12.md
+[14]: 14.md

--- a/07.md
+++ b/07.md
@@ -50,7 +50,7 @@ Where the elements of the array in `Ys` are the hexadecimal representation of th
 
 **Response** of `Bob`:
 
-`Bob` responds with the states with a `PostCheckStateResponse`
+`Bob` responds with a `PostCheckStateResponse`:
 
 ```json
 {

--- a/07.md
+++ b/07.md
@@ -50,7 +50,7 @@ Where the elements of the array in `Ys` are the hexadecimal representation of th
 
 **Response** of `Bob`:
 
-`Bob` responds with the states  with a `PostCheckStateResponse`
+`Bob` responds with the states with a `PostCheckStateResponse`
 
 ```json
 {

--- a/07.md
+++ b/07.md
@@ -65,7 +65,7 @@ Where the elements of the array in `Ys` are the hexadecimal representation of th
 }
 ```
 
-The elements of the `states` array MUST be returned in the same order as the corresponding `Proofs` checked in the request.
+The elements of the `states` array MUST be returned in the same order as the corresponding `Ys` checked in the request.
 
 - `Y` corresponds to the `Proof` checked in the request.
 - `state` is an enum string field with possible values `"UNSPENT"`, `"PENDING"`, `"SPENT"`

--- a/10.md
+++ b/10.md
@@ -54,6 +54,7 @@ kind <str>,
 Example use cases of this secret format are
 
 - [NUT-11][11]: Pay-to-Public-Key (P2PK)
+- [NUT-14][14]: Hashed Timelock Contracts (HTLCs)
 
 [00]: 00.md
 [01]: 01.md

--- a/11.md
+++ b/11.md
@@ -118,7 +118,7 @@ The `B_` of each output is **signed as bytes** which comes from the original hex
 }
 ```
 
-The `signatures` are an array of signatures in hex.
+The `signatures` are an array of signatures in hex. The witness for a spent proof can be obtained with a `Proof` state check (see [NUT-07][07]).
 
 ### Multisig
 

--- a/14.md
+++ b/14.md
@@ -58,6 +58,8 @@ See [NUT-11][11] for a description of the signature scheme, the additional use o
 }
 ```
 
+The witness for a spent proof can be obtained with a `Proof` state check (see [NUT-07][07]).
+
 [00]: 00.md
 [01]: 01.md
 [02]: 02.md


### PR DESCRIPTION
The state check MUST return the states in the same order as the Proofs in the request.