### PR TITLE
NUT-06: Add wallet, mint notes for multiple mint URLs

### DIFF
--- a/06.md
+++ b/06.md
@@ -94,7 +94,7 @@ With the mint's response being of the form `GetInfoResponse`:
 - (optional) `contact` is an array of contact objects to reach the mint operator. A contact object consists of two fields. The `method` field denotes the contact method (like "email"), the `info` field denotes the identifier (like "contact@me.com").
 - (optional) `motd` is the message of the day that the wallet must display to the user. It should only be used to display important announcements to users, such as scheduled maintenances.
 - (optional) `icon_url` is the URL pointing to an image to be used as an icon for the mint. Recommended to be squared in shape.
-- (optional) `urls` is the list of endpoint URLs where the mint is reachable from.
+- (optional) `urls` is the list of endpoint URLs where the mint is reachable at. All these URLs must be stripped of any trailing slashes (`/`).
 - (optional) `time` is the current time set on the server. The value is passed as a Unix timestamp integer.
 - (optional) `nuts` indicates each NUT specification that the mint supports and its settings. The settings are defined in each NUT separately.
 
@@ -103,6 +103,16 @@ With curl:
 ```bash
 curl -X GET https://mint.host:3338/v1/info
 ```
+
+### Mint Implementation Notes
+
+- Adding URLs has no impact on existing tokens, however changing or removing URLs may render some wallets unable to redeem previously issued tokens with defunct URLs. The mint should therefore exercise caution when changing or removing URLs. The mint may use the `motd` field to announce such changes in advance.
+
+### Wallet Implementation Notes
+
+- Wallets should periodically query the Mint Info and store the retrieved mint URLs. If the `motd` has changed compared to the last time it was fetched, the wallet must display it to the user.
+- Receiving: if the mint is not known, the wallet should query and store the Mint Info, to ensure the wallet is aware of all the mint's URLs. If it's not possible to do it upon receiving (Offline Receive), the wallet should do it the next time it comes online.
+- Sending: when creating a token for sending, the wallet embeds a single mint URL. For mints with multiple known URLs, the wallet must choose an active mint URL. For this, the client must test the URL first, for example by fetching the Mint's Info at that endpoint.
 
 [00]: 00.md
 [01]: 01.md


### PR DESCRIPTION
Adding multiple Mint URLs (#62, #175) introduces new protocol risks, mentioned at https://github.com/cashubtc/nuts/issues/62#issuecomment-2453029252

The main ones are:
- on the send side: wallets may send tokens with a possibly outdated mint URL
- on the receive side: wallets may never check for (new) mint URLs because the mint is known, or the wallet may want to avoid making unnecessary network calls

The risk in both cases is that of unusable tokens, e.g. when the token has an outdated mint URL and the wallet is not aware of the other mint URLs.

This PR addresses ways in which this can be avoided.