### PR TITLE
NUT-13 specify keyset ID integer size: 32 bits

### DIFF
--- a/13.md
+++ b/13.md
@@ -42,7 +42,7 @@ The wallet starts with `counter_k := 0` upon encountering a new keyset and incre
 
 #### Keyset ID
 
-The integer representation `keyset_id_int` of a keyset is calculated from its [hexadecimal ID][02] which has a length of 8 bytes or 16 hex characters. First, we convert the hex string to a big-endian sequence of bytes. This value is then modulo reduced by `2^31 - 1` to arrive at an integer that is a unique identifier `keyset_id_int`.
+The 32 bit integer representation `keyset_id_int` of a keyset is calculated from its [hexadecimal ID][02] which has a length of 8 bytes or 16 hex characters. First, we convert the hex string to a big-endian sequence of bytes. This value is then modulo reduced by `2^31 - 1` to arrive at an integer that is a unique identifier `keyset_id_int`.
 
 Example in Python:
 ```python


### PR DESCRIPTION
Is the intention of this integer representation of keyset ID to fit it into 32 bits? I ran into this implementation in cdk that produces a u64 output which seems wrong to me.

https://github.com/cashubtc/cdk/blob/main/crates/cdk/src/nuts/nut02.rs#L117
```
impl TryFrom<Id> for u64 {
    type Error = Error;
    fn try_from(value: Id) -> Result<Self, Self::Error> {
        let hex_bytes: [u8; 8] = value.to_bytes().try_into().map_err(|_| Error::Length)?;

        let int = u64::from_be_bytes(hex_bytes);

        Ok(int % (2_u64.pow(31) - 1))
    }
}
```

I am opening this PR to get some clarity.