### PR TITLE
Fix: nut-15 methods flag

### DIFF
--- a/15.md
+++ b/15.md
@@ -62,7 +62,7 @@ Example `MultipathPaymentSetting`:
 ```json
 {
   "15": {
-    "supported": [
+    "methods": [
       {
         "method": "bolt11",
         "unit": "sat",

--- a/15.md
+++ b/15.md
@@ -72,7 +72,7 @@ Example `MultipathPaymentSetting`:
         "method": "bolt11",
         "unit": "usd",
         "mpp": true
-      },
+      }
     ]
   }
 }

--- a/15.md
+++ b/15.md
@@ -62,7 +62,7 @@ Example `MultipathPaymentSetting`:
 ```json
 {
   "15": {
-    [
+    "supported": [
       {
         "method": "bolt11",
         "unit": "sat",


### PR DESCRIPTION
Change supported flag for MPP from 

```
"15": []
```
to
```
"15": {
  "methods": []
}
```

Tracking:
- [ ] nutshell (PR: https://github.com/cashubtc/nutshell/pull/672)
- [x] CDK