### PR TITLE
NUT-10: fix broken link

### DIFF
--- a/10.md
+++ b/10.md
@@ -81,3 +81,4 @@ The [NUT-06][06] `MintMethodSetting` indicates support for this feature:
 [10]: 10.md
 [11]: 11.md
 [12]: 12.md
+[14]: 14.md


### PR DESCRIPTION
link to NUT-14 is broken because there is a missing reference at the end of the document

<img width="440" alt="Captura de pantalla 2024-12-19 a la(s) 13 26 01" src="https://github.com/user-attachments/assets/38d74208-ff8e-4252-ae26-92ff7e17b976" />
