### PR TITLE
Added x-cashu method to NUT-18

### DIFF
--- a/18.md
+++ b/18.md
@@ -78,6 +78,15 @@ The `n` tag specifies the NIPs the receiver supports. At least one tag value MUS
 
 The execute the payment, the sender makes a `POST` request to the specified endpoint URL with the `PaymentRequestPayload` as the body.
 
+#### X-Cashu
+
+- type: `x-cashu`
+- target: `<endpoint-url>`
+- tags: `[["c", "replay"]]`
+
+The payment is expected in the X-Cashu header on a request to the specified endpoint.
+The tags specify constraints that the request MUST have. `replay` can be found in Payment Requests on HTTP 402 responses and requires that the exact same request is send again, but with a X-Cashu header paying the PR.
+
 ## Payment payload
 
 If not specified otherwise, the payload sent to the receiver is a `PaymentRequestPayload` JSON serialized object as follows:


### PR DESCRIPTION
This adds a new method to NUT-18, that allows payment requests to be used with the X-Cashu protocol. This is an attempt to standardize the flow around x-cashu further, to enable interoperability between protected endpoints and wallets.