### PR TITLE
Add heartbeats to WebSockets

### DIFF
--- a/17.md
+++ b/17.md
@@ -228,6 +228,32 @@ Wallet:
 }
 ```
 
+## Heartbeats
+
+Because some WebSocket implementations do not support native heartbeat control frames (many browser clients), this protocol defines it's own heartbeat mechanism. Wallets are expected to send a heartbeat-request at least every 30 seconds. Mints are expected to return a heartbeat-response (if there are multiple queued, responding to the latest one is sufficient).
+
+Note: As wallets are expected to send a heartbeat at least every 30 seconds, mints can assume connections that have been idling for at least 45 seconds to be stale and close the connection.
+
+### Heartbeat request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "heartbeat"
+}
+```
+
+### Heartbeat response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "heartbeat"
+}
+```
+
 ## Mint info setting
 
 Mints signal websocket support via [NUT-06][06] using the following setting:


### PR DESCRIPTION
Because many client implementations do not support native WebSocket control frames for ping/pong, this adds out own application-level protocol for it.