### PR TITLE
Fix nut numbers 21 and 22 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 | [18][18] | Payment requests                  | [Cashu.me][cashume], [Boardwalk][bwc], [cdk-cli]                            | -                                                       |
 | [19][19] | Cached Responses                  | -                                                                           | [Nutshell][py], [cdk-mintd]                             |
 | [20][20] | Signature on Mint Quote           | [cdk-cli], [Nutshell][py]                                                   | [cdk-mintd],[Nutshell][py]                              |
-| [20][20] | Clear authentication              | [cdk-cli], [Nutshell][py]                                                   | [cdk-mintd],[Nutshell][py]                              |
-| [20][20] | Blind authentication              | [cdk-cli], [Nutshell][py]                                                   | [cdk-mintd],[Nutshell][py]                              |
+| [21][21] | Clear authentication              | [cdk-cli], [Nutshell][py]                                                   | [cdk-mintd],[Nutshell][py]                              |
+| [22][22] | Blind authentication              | [cdk-cli], [Nutshell][py]                                                   | [cdk-mintd],[Nutshell][py]                              |
 
 #### Wallets:
 


### PR DESCRIPTION
Correct the numbering for the Clear and Blind authentication specifications in the documentation.