### PR TITLE
fix: link to NUT with [] instead of ()

### DIFF
--- a/12.md
+++ b/12.md
@@ -8,7 +8,7 @@ In this document, we present an extension of Cashu's crypto system to allow a us
 
 # The DLEQ proof
 
-The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01][01)]) and for signing the BlindedMessage `B'`. `Bob` returns the DLEQ proof additional to the blind signature `C'` for a mint or swap operation.
+The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01][01]) and for signing the BlindedMessage `B'`. `Bob` returns the DLEQ proof additional to the blind signature `C'` for a mint or swap operation.
 
 The complete DLEQ proof reads
 

--- a/12.md
+++ b/12.md
@@ -4,11 +4,11 @@
 
 ---
 
-In this document, we present an extension of Cashu's crypto system to allow a user `Alice` to verify the mint `Bob`'s signature using only `Bob`'s public keys. We explain how another user `Carol` who receives ecash from `Alice` can execute the DLEQ proof as well. This is achieved using a Discrete Log Equality (DLEQ) proof. Previously, `Bob`'s signature could only be checked by himself using his own private keys ([NUT-00](00)).
+In this document, we present an extension of Cashu's crypto system to allow a user `Alice` to verify the mint `Bob`'s signature using only `Bob`'s public keys. We explain how another user `Carol` who receives ecash from `Alice` can execute the DLEQ proof as well. This is achieved using a Discrete Log Equality (DLEQ) proof. Previously, `Bob`'s signature could only be checked by himself using his own private keys ([NUT-00][00]).
 
 # The DLEQ proof
 
-The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01](01)) and for signing the BlindedMessage `B'`. `Bob` returns the DLEQ proof additional to the blind signature `C'` for a mint or swap operation.
+The purpose of this DLEQ is to prove that the mint has used the same private key `a` for creating its public key `A` ([NUT-01][01)]) and for signing the BlindedMessage `B'`. `Bob` returns the DLEQ proof additional to the blind signature `C'` for a mint or swap operation.
 
 The complete DLEQ proof reads
 
@@ -69,7 +69,7 @@ The mint produces these DLEQ proofs when returning `BlindSignature`'s in the res
 
 ### User to user: DLEQ in `Proof`
 
-In order for `Alice` to communicate the DLEQ to another user `Carol`, we extend the `Proof` (see [NUT-00](00)) object and include the DLEQ proof. As explained below, we also need to include the blinding factor `r` for the proof to be convincing to another user `Carol`.
+In order for `Alice` to communicate the DLEQ to another user `Carol`, we extend the `Proof` (see [NUT-00][00]) object and include the DLEQ proof. As explained below, we also need to include the blinding factor `r` for the proof to be convincing to another user `Carol`.
 
 ```json
 {


### PR DESCRIPTION
Before: https://github.com/cashubtc/nuts/blob/main/01  

After: https://github.com/cashubtc/nuts/blob/main/01.md