### PR TITLE
Keyset Final Expiry

### DIFF
--- a/02.md
+++ b/02.md
@@ -87,6 +87,9 @@ This effectively implies that the Mint can irrevocably remove all of the nullifi
 
 The final expiry can be `null` if the keyset has no final-expiry.
 
+> [!IMPORTANT]
+> Good final expirations should be years into the future.
+
 ## Example: Get mint keysets
 
 A wallet can ask the mint for a list of all keysets via the `GET /v1/keysets` endpoint.

--- a/02.md
+++ b/02.md
@@ -79,6 +79,14 @@ def derive_keyset_id(keys: Dict[int, PublicKey]) -> str:
     return "00" + hashlib.sha256(pubkeys_concat).hexdigest()[:14]
 ```
 
+### Keyset Final Expiry
+
+A unix epoch number for a future point in time that represents the final expiry of the keyset. After the keyset's final expiry, the Mint is no longer obliged to fulfill promises signed with the keys from that keyset.
+
+This effectively implies that the Mint can irrevocably remove all of the nullifiers (`Y` values/spent ecash) associated with the expired keyset.
+
+The final expiry can be `null` if the keyset has no final-expiry.
+
 ## Example: Get mint keysets
 
 A wallet can ask the mint for a list of all keysets via the `GET /v1/keysets` endpoint.
@@ -105,6 +113,7 @@ Response `GetKeysetsResponse` of `Bob`:
       "unit": <str>,
       "active": <bool>,
       "input_fee_ppk": <int|null>,
+      "final_expiry": <int|null>
     },
     ...
   ]
@@ -122,19 +131,22 @@ Here, `id` is the keyset ID, `unit` is the unit string (e.g. "sat") of the keyse
       "id": "009a1f293253e41e",
       "unit": "sat",
       "active": True,
-      "input_fee_ppk": 100
+      "input_fee_ppk": 100,
+      "final_expiry": 1896187313
     },
     {
       "id": "0042ade98b2a370a",
       "unit": "sat",
       "active": False,
-      "input_fee_ppk": 100
+      "input_fee_ppk": 100,
+      "final_expiry": 1896187313
     },
     {
       "id": "00c074b96c7e2b0e",
       "unit": "usd",
       "active": True,
-      "input_fee_ppk": 100
+      "input_fee_ppk": 100,
+      "final_expiry": 1896187313
     }
   ]
 }


### PR DESCRIPTION
Allow a Mint to get rid of very old keysets and nullifiers (spent ecash) associated with them:
keysets now specify a "final expiry" after which the Mint is no longer obligated to serve ecash signed with keys belonging to that keyset.