### PR TITLE
NUT-15: Specify MPP amount in millisats (msat)

### DIFF
--- a/15.md
+++ b/15.md
@@ -36,7 +36,7 @@ The wallet `Alice` includes the following `PostMeltQuoteBolt11Request` data in i
 }
 ```
 
-Here, `request` is the bolt11 Lightning invoice to be paid, `unit` is the unit the wallet would like to pay with, and `amount` is the amount for the requested payment. The wallet then pays the returned melt quote the same way as in [NUT-05][05].
+Here, `request` is the bolt11 Lightning invoice to be paid, `unit` is the unit the wallet would like to pay with. `amount` is the partial amount for the requested payment in millisats (msat). The wallet then pays the returned melt quote the same way as in [NUT-05][05].
 
 ## Mint info setting
 


### PR DESCRIPTION
Clarify that the `amount` parameter for the requested payment is specified in millisats (msat) in the documentation.

Tracking:
- [x] nutshell
- [x] cdk
- [ ] ... 