### PR TITLE
Add mandatory DLEQs to nut-22

### DIFF
--- a/22.md
+++ b/22.md
@@ -162,6 +162,8 @@ The wallet un-blinds the response to obtain the signatures `C` as described in [
 }
 ```
 
+To prevent pinning, wallets MUST validate the DLEQ proofs `dleq` as defined in [NUT-12](./12.md). Should `AuthProofs` be sent to another user of the mint, it MUST include the `dleq` proof so that the receiving user can validate it.
+
 ## Using blind authentication tokens
 
 The wallet checks the `MintBlindAuthSetting` of the mint to determine which endpoints require blind authentication. Similar to `NUT-21`, the wallet performs a match on the `protected_endpoints` in the `MintBlindAuthSetting` before attempting a request to one of the mint's endpoints. If the match is positive, the wallet needs to add a blind authentication token (BAT) to the request header.
@@ -176,6 +178,10 @@ authA[base64_authproof_json]
 
 This string is a BAT.
 
+> [!CAUTION]
+>
+> To protect the privacy of the wallet, the BAT MUST NOT contain the `dleq` proof when it is sent to the mint in the request header.
+
 ### Request header
 
 We add this serialized BAT to the request header:
@@ -188,15 +194,11 @@ and make the request as we usually would.
 
 `AuthProofs` are single-use. The wallet MUST delete the `AuthProof` after a successful request, and SHOULD delete it even if request results in an error. If the wallet runs out of `AuthProofs`, it can [mint new ones](#minting-blind-authentication-tokens) using its clear authentication token (CAT).
 
-### DLEQs
-
-To prevent pinning, wallets MUST validate the DLEQ proofs contained in each `AuthProof` as defined in [NUT-12](./12.md).
-
 ## Mint
 
 ### DLEQs
 
-The mint MUST return DLEQ proofs for every signature it returns as defined in [NUT-12](./12.md)
+The mint MUST return DLEQ proofs for every blind signature in `PostAuthBlindMintResponse` as defined in [NUT-12](./12.md)
 
 ### Signaling protected endpoints and settings
 

--- a/22.md
+++ b/22.md
@@ -191,7 +191,7 @@ To prevent a mint pinning blind authentication token wallets SHOULD check that t
 
 ### DLEQs
 
-The mint MUST return a DLEQ proof with all signatures it returns as defined in [NUT-12](./12.md)
+The mint MUST return DLEQ proofs for every signature it returns as defined in [NUT-12](./12.md)
 
 ### Signaling protected endpoints and settings
 

--- a/22.md
+++ b/22.md
@@ -2,7 +2,7 @@
 
 `optional`
 
-`depends on: NUT-21`
+`depends on: NUT-21, NUT-12`
 
 ---
 
@@ -183,7 +183,15 @@ and make the request as we usually would.
 
 `AuthProofs` are single-use. The wallet MUST delete the `AuthProof` after a successful request, and SHOULD delete it even if request results in an error. If the wallet runs out of `AuthProofs`, it can [mint new ones](#minting-blind-authentication-tokens) using its clear authentication token (CAT).
 
+### DLEQs
+
+To prevent a mint pinning blind authentication token wallets SHOULD check that the returned `AuthProofs` contain a valid DLEQ as defined in [NUT-12](./12.md).
+
 ## Mint
+
+### DLEQs
+
+The mint MUST return a DLEQ proof with all signatures it returns as defined in [NUT-12](./12.md)
 
 ### Signaling protected endpoints and settings
 

--- a/22.md
+++ b/22.md
@@ -153,7 +153,7 @@ The wallet un-blinds the response to obtain the signatures `C` as described in [
 {
   "id": <hex_str>,
   "secret": <str>,
-  "C": <hex_str>
+  "C": <hex_str>,
   "dleq": {
     "e": <str>,
     "s": <str>,

--- a/22.md
+++ b/22.md
@@ -185,7 +185,7 @@ and make the request as we usually would.
 
 ### DLEQs
 
-To prevent a mint pinning blind authentication token wallets SHOULD check that the returned `AuthProofs` contain a valid DLEQ as defined in [NUT-12](./12.md).
+To prevent pinning, wallets MUST validate the DLEQ proofs contained in each `AuthProof` as defined in [NUT-12](./12.md).
 
 ## Mint
 

--- a/22.md
+++ b/22.md
@@ -151,9 +151,14 @@ The wallet un-blinds the response to obtain the signatures `C` as described in [
 
 ```json
 {
-  "id": hex_str,
-  "secret": str,
-  "C": hex_str
+  "id": <hex_str>,
+  "secret": <str>,
+  "C": <hex_str>
+  "dleq": {
+    "e": <str>,
+    "s": <str>,
+    "r": <str>
+  }
 }
 ```
 


### PR DESCRIPTION
This addition makes sure that `AuthProofs` can not be pinned by enforcing NUT-12 DLEQ proofs on signature reponses