### PR TITLE
NUT-18 Payment Requests: Make mints mandatory

### DIFF
--- a/18.md
+++ b/18.md
@@ -11,7 +11,8 @@ This NUT introduces a standardised format for payment requests, that supply a se
 1. Receiver creates a payment request, encodes it and displays it to the sender
 2. Sender scans the request and constructs a matching token
 3. Sender sends the token according to the transport specified in the payment request
-4. Receiver receives the token and finalises the transaction
+4. Receiver receives and validates the token, for example checks that it is for a mint indicated in the payment request
+5. If token is valid, Receiver finalises the transaction
 
 ## Payment Request
 
@@ -23,7 +24,7 @@ A Payment Request is defined as follows
   "a": int <optional>,
   "u": str <optional>,
   "s": bool <optional>,
-  "m": Array[str] <optional>,
+  "m": Array[str],
   "d": str <optional>,
   "t": Array[Transport]
 }
@@ -38,6 +39,8 @@ Here, the fields are
 - `m`: A set of mints from which the payment is requested
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)
+
+A payment request MUST include at least one trusted mint in its field `m`.
 
 ## Transport
 

--- a/18.md
+++ b/18.md
@@ -11,7 +11,7 @@ This NUT introduces a standardised format for payment requests, that supply a se
 1. Receiver creates a payment request, encodes it and displays it to the sender
 2. Sender scans the request and constructs a matching token
 3. Sender sends the token according to the transport specified in the payment request
-4. Receiver receives and validates the token, for example checks that it is for a mint indicated in the payment request
+4. Receiver receives and validates the token, checking that the Mint matches one of the indicated trusted Mints.
 5. If token is valid, Receiver finalises the transaction
 
 ## Payment Request

--- a/18.md
+++ b/18.md
@@ -40,7 +40,7 @@ Here, the fields are
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)
 
-A payment request MUST include at least one trusted mint in its field `m`.
+A payment request **MUST** include at least one trusted mint in its field `m`.
 
 ## Transport
 


### PR DESCRIPTION
A core aspect of cashu is that users must somewhat trust the mints. This means receivers shouldn't receive tokens from just any mint. For merchants this is an existential distinction, so for them this becomes less a recommendation and more an imperative. Otherwise, accepting tokens from any mint as payment for goods and services is a sure way to be defrauded, allowing e.g. any fakewallet payment to be accepted as real.

Since this NUT is targeted at merchants, it has to indicate that receivers MUST indicate a list of trusted mints in their Payment Requests.