### PR TITLE
Nut-04/05: add amount, unit, request to quotes

### DIFF
--- a/04.md
+++ b/04.md
@@ -38,12 +38,14 @@ The mint `Bob` then responds with a `PostMintQuoteBolt11Response`:
 {
   "quote": <str>,
   "request": <str>,
+  "amount": <int>,
+  "unit":  <str_enum["sat"]>,
   "state": <str_enum[STATE]>,
   "expiry": <int>
 }
 ```
 
-Where `quote` is the quote ID and `request` is the payment request to fulfill. `expiry` is the Unix timestamp until which the mint quote is valid.
+Where `quote` is the quote ID and `request` is the payment request to fulfill. `expiry` is the Unix timestamp until which the mint quote is valid. `amount` and `unit` correspond to the same values provided in the request.
 
 `state` is an enum string field with possible values `"UNPAID"`, `"PAID"`, `"ISSUED"`:
 
@@ -69,6 +71,8 @@ Response of `Bob`:
 {
   "quote": "DSGLX9kevM...",
   "request": "lnbc100n1pj4apw9...",
+  "amount": 10,
+  "unit": "sat",
   "state": "UNPAID",
   "expiry": 1701704757
 }

--- a/05.md
+++ b/05.md
@@ -38,7 +38,9 @@ The mint `Bob` then responds with a `PostMeltQuoteBolt11Response`:
 ```json
 {
   "quote": <str>,
+  "request": <str>,
   "amount": <int>,
+  "unit": <str_enum["sat"]>,
   "fee_reserve": <int>,
   "state": <str_enum[STATE]>,
   "expiry": <int>,
@@ -46,7 +48,7 @@ The mint `Bob` then responds with a `PostMeltQuoteBolt11Response`:
 }
 ```
 
-Where `quote` is the quote ID, `amount` the amount that needs to be provided, and `fee_reserve` the additional fee reserve that is required. The mint expects `Alice` to include `Proofs` of _at least_ `total_amount = amount + fee_reserve`. `expiry` is the Unix timestamp until which the melt quote is valid. `payment_preimage` is the bolt11 payment preimage in case of a successful payment.
+Where `quote` is the quote ID, `amount` and `unit` the amount and unit that need to be provided, `request` the payment request from the quote request, and `fee_reserve` the additional fee reserve that is required. The mint expects `Alice` to include `Proofs` of _at least_ `total_amount = amount + fee_reserve`. `expiry` is the Unix timestamp until which the melt quote is valid. `payment_preimage` is the bolt11 payment preimage in case of a successful payment.
 
 `state` is an enum string field with possible values `"UNPAID"`, `"PENDING"`, `"PAID"`:
 
@@ -71,7 +73,9 @@ Response of `Bob`:
 ```json
 {
   "quote": "TRmjduhIsPxd...",
+  "request": "lnbc100n1p3kdrv5sp5lpdxzghe5j67q...",
   "amount": 10,
+  "unit": "sat",
   "fee_reserve": 2,
   "state": "UNPAID",
   "expiry": 1701704757
@@ -149,7 +153,9 @@ Response `PostMeltQuoteBolt11Response` of `Bob`:
 ```json
 {
   "quote": "TRmjduhIsPxd...",
+  "request": "lnbc100n1p3kdrv5sp5lpdxzghe5j67q...",
   "amount": 10,
+  "unit": "sat",
   "fee_reserve": 2,
   "state": "PAID",
   "expiry": 1701704757,


### PR DESCRIPTION
This **mandatory** change of NUT-04 and NUT-05 adds new fields to the `MintQuoteResponse` and `MeltQuoteResponse` objects to make it easier for stateless clients to use the API. 



Fixes https://github.com/cashubtc/nuts/issues/232