### PR TITLE
Improve documentation for NUT-12 and add note tags for NUT-13

### DIFF
--- a/12.md
+++ b/12.md
@@ -33,9 +33,9 @@ e == hash(R1,R2,A,C')
 If true, a in A = a*G must be equal to a in C' = a*B'
 ```
 
-### `hash(x: <Array<[PublicKey]>) -> bytes`
+### Hash function
 
-The hash(x) function generates a deterministic Sha256 hash for a given input list of `PublicKey`. The uncompressed hexadecimal representations of each `PublicKey` is concatenated before taking the Sha256 hash.
+The hash function `hash(x: <Array<[PublicKey]>) -> bytes` generates a deterministic SHA256 hash for a given input list of `PublicKey`. The uncompressed (32+32+1)-byte hexadecimal representations (130 characters) of each `PublicKey` is concatenated before taking the SHA256 hash.
 
 ```python
 def hash_e(*publickeys: PublicKey) -> bytes:
@@ -47,6 +47,8 @@ def hash_e(*publickeys: PublicKey) -> bytes:
     return e
 
 ```
+> [!NOTE]
+> For examples of valid DLEQ proofs, see the [test vectors][tests].
 
 ### Mint to user: DLEQ in `BlindSignature`
 
@@ -86,6 +88,11 @@ In order for `Alice` to communicate the DLEQ to another user `Carol`, we extend 
 ```
 
 `e` and `s` are the challenge and response of the DLEQ proof returned by `Bob`, `r` is the blinding factor of `Alice` that was used to generate the `Proof`. `Alice` serializes these proofs like any other in a token (see [NUT-00][00]) to send it to another user `Carol`.
+
+> [!IMPORTANT]
+>
+> **Privacy:** The blinding factor `r` should not be shared with the mint or otherwise, the mint will be able to associate the `BlindSignature` with the `Proof`.
+
 
 ## Alice (minting user) verifies DLEQ proof
 
@@ -155,3 +162,4 @@ The [NUT-06][06] `MintMethodSetting` indicates support for this feature:
 [10]: 10.md
 [11]: 11.md
 [12]: 12.md
+[tests]: tests/12-tests.md

--- a/13.md
+++ b/13.md
@@ -35,7 +35,8 @@ r_derivation_path = `m/129372'/0'/{keyset_id_k_int}'/{counter_k}'/1`
 
 Here, `{keyset_k_int}` and `{counter_k}` are the only variables that can change. `keyset_id_k_int` is an integer representation (see below) of the keyset ID the token is generated with. This means that the derivation path is unique for each keyset. Note that the coin type is always `0'`, independent of the unit of the ecash.
 
-**Note:** For examples, see the [test vectors][tests].
+> [!NOTE]
+> For examples, see the [test vectors][tests].
 
 #### Counter
 
@@ -84,7 +85,8 @@ The wallet similarly generates a blinding factor `r` from the `r_derivation_path
 r = self.bip32.get_privkey_from_path(r_derivation_path)
 ```
 
-**Note:** For examples, see the [test vectors][tests].
+> [!NOTE]
+> For examples, see the [test vectors][tests].
 
 Using the `secret` string and the private key `r`, the wallet generates a `BlindedMessage`. The wallet then increases the `counter` by `1` and repeats the same process for a given batch size. It is recommended to use a batch size of 100.
 


### PR DESCRIPTION
Enhance clarity in the documentation by refining the hash function description and adding important notes regarding DLEQ proofs and test vectors.