### PR TITLE
NUT-18: Add optional P2PK options and transport field

### DIFF
--- a/18.md
+++ b/18.md
@@ -123,7 +123,7 @@ Here, `id` is the payment id (corresponding to `i` in request), `memo` is an opt
 
 The payment request is serialized using CBOR, encoded in `base64_urlsafe`, together with a prefix `creq` and a version `A`:
 
-`"creq" + "A" + base64(CBOR(PaymentRequest))`
+`"creq" + "A" + base64_urlsafe(CBOR(PaymentRequest))`
 
 ### Example
 

--- a/18.md
+++ b/18.md
@@ -43,9 +43,10 @@ Here, the fields are
 
 ## Payment parameters
 
-The payment request can include *optional* locking conditions the payee requires from the payer. For example, the payee might require a P2PK-locked token so that they can receive payments offline. 
+The payment request can include _optional_ locking conditions the payee requires from the payer. For example, the payee might require a P2PK-locked token so that they can receive payments offline.
 
 ### P2PK
+
 The `p2pk` field contains the `P2PKOption` object that specifies the payees requested [NUT-11][11] P2PK locking options. Its elements are derived from the supported [Tags][11-tags] for P2PK locks. The `P2PKOption` read:
 
 ```
@@ -66,7 +67,6 @@ The `p2pk` field contains the `P2PKOption` object that specifies the payees requ
 
 > [!IMPORTANT]
 > The transport can be empty! If the transport is empty, we implicitly assume that the payment will be in-band. An example is X-Cashu where the payment is expected in the HTTP header of a request. We can only hope that the protocol you're using has a well-defined transport.
-
 
 ```json
 {

--- a/18.md
+++ b/18.md
@@ -25,7 +25,8 @@ A Payment Request is defined as follows
   "s": bool <optional>,
   "m": Array[str] <optional>,
   "d": str <optional>,
-  "t": Array[Transport]
+  "t": Array[Transport] <optional>,
+  "p2pk": P2PKOption <optional>,
 }
 ```
 
@@ -38,10 +39,34 @@ Here, the fields are
 - `m`: A set of mints from which the payment is requested
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)
+- `p2pk`: The required [NUT-11][11] P2PK parameters
+
+## Payment parameters
+
+The payment request can include *optional* locking conditions the payee requires from the payer. For example, the payee might require a P2PK-locked token so that they can receive payments offline. 
+
+### P2PK
+The `p2pk` field contains the `P2PKOption` object that specifies the payees requested [NUT-11][11] P2PK locking options. Its elements are derived from the supported [Tags][11-tags] for P2PK locks. The `P2PKOption` read:
+
+```
+{
+  "pubkeys": Array[str],
+  "sigflag": str <optional>,
+  "locktime": int <optional>,
+  "refund": Array[str] <optional>
+}
+```
+
+> [!IMPORTANT]
+> The payee must validate the incoming tokens themselves in order to decide whether they can accept the payment. This includes checking the DLEQ proof and whether the token includes a long-enough timelock to satisfy the payee.
 
 ## Transport
 
 `Transport` specifies methods for sending the ecash to the receiver. A transport consists of a type and a target.
+
+> [!IMPORTANT]
+> The transport can be empty! If the transport is empty, we implicitly assume that the payment will be in-band. An example is X-Cashu where the payment is expected in the HTTP header of a request. We can only hope that the protocol you're using has a well-defined transport.
+
 
 ```json
 {
@@ -127,3 +152,5 @@ creqApWF0gaNhdGVub3N0cmFheKlucHJvZmlsZTFxeTI4d3VtbjhnaGo3dW45ZDNzaGp0bnl2OWtoMnV
 ```
 
 [00]: 00.md
+[11]: 11.md
+[11-tags]: 11.md#tags


### PR DESCRIPTION
Introduce optional `p2pk` options for specifying P2PK locking parameters in payment requests. Make the `transport` field optional to allow for in-band payment assumptions.

Supersedes and closes #204 
Supersedes and closes #209

Todo:
- [x] use `base64_urlsafe` in encoding example