### PR TITLE
modify #243 to replace p2pk with nut10

### DIFF
--- a/18.md
+++ b/18.md
@@ -26,7 +26,7 @@ A Payment Request is defined as follows
   "m": Array[str] <optional>,
   "d": str <optional>,
   "t": Array[Transport] <optional>,
-  "p2pk": P2PKOption <optional>,
+  "nut10": NUT10Option <optional>,
 }
 ```
 
@@ -39,24 +39,23 @@ Here, the fields are
 - `m`: A set of mints from which the payment is requested
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)
-- `p2pk`: The required [NUT-11][11] P2PK parameters
+- `nut10`: The required [NUT-10][10] locking condition
 
-## Payment parameters
+## Locking conditions
 
 The payment request can include _optional_ locking conditions the payee requires from the payer. For example, the payee might require a P2PK-locked token so that they can receive payments offline.
 
-### P2PK
-
-The `p2pk` field contains the `P2PKOption` object that specifies the payees requested [NUT-11][11] P2PK locking options. Its elements are derived from the supported [Tags][11-tags] for P2PK locks. The `P2PKOption` read:
+The `nut10` field specifies the payee's requested locking condition as a `NUT10Option` object. Its elements are derived from NUT-10's [well-known secret](10.md#well-known-secret). The `NUT10Option` reads:
 
 ```
 {
-  "pubkeys": Array[str],
-  "sigflag": str <optional>,
-  "locktime": int <optional>,
-  "refund": Array[str] <optional>
+  "kind": str,
+  "data": str,
+  "tags": [[ "key", "value1", "value2", ...],  ... ], // (optional)
 }
 ```
+
+The payer **MUST** create a `nonce` for each proof locked to the specified condition.
 
 > [!IMPORTANT]
 > The payee must validate the incoming tokens themselves in order to decide whether they can accept the payment. This includes checking the DLEQ proof and whether the token includes a long-enough timelock to satisfy the payee.
@@ -152,5 +151,4 @@ creqApWF0gaNhdGVub3N0cmFheKlucHJvZmlsZTFxeTI4d3VtbjhnaGo3dW45ZDNzaGp0bnl2OWtoMnV
 ```
 
 [00]: 00.md
-[11]: 11.md
-[11-tags]: 11.md#tags
+[10]: 10.md


### PR DESCRIPTION
An alternative update to NUT-18 that would allow for payment requests to define any spending condition supported by NUT-10

