### PR TITLE
NUT-XX:Pay-to-Blinded-Key (P2BK): 

### DIFF
--- a/26.md
+++ b/26.md
@@ -1,0 +1,183 @@
+# NUT-26: Pay-to-Blinded-Key (P2BK)
+
+`optional`
+
+`depends on: NUT-11`
+
+---
+
+## Summary
+
+This NUT defines Pay-to-Blinded-Key (P2BK), a wallet-to-wallet privacy extension of [NUT-11][11] (P2PK). P2BK blinds the public keys contained in a P2PK Secret so the mint cannot learn the true recipient key material when issuing or redeeming ecash. The scheme requires no changes to mint behavior: wallets MUST normalize P2BK Secrets to standard P2PK Secrets before sending requests to a mint. All Schnorr signing and verification at the mint remains exactly as specified in NUT-11.
+
+## Motivation
+
+- In NUT-11, the receiver public key(s) appear in cleartext in the Secret. On redemption, the mint learns the long-term public key(s) that control the ecash.
+- P2BK hides those keys from the mint by blinding each receiver public key P with a random scalar r: P' = P + r·G. The receiver later derives the corresponding private key k = p + r (mod n) to sign per NUT-11. The mint only ever sees normal P2PK Secrets and signatures.
+
+## Definitions and notation
+
+- Curve: secp256k1 with base point G and order n.
+- Unblinded pubkey (compressed hex): P.
+- Blinding scalar: r with 1 ≤ r ≤ n − 1.
+- Blinded pubkey: P' = P + r·G (compressed hex).
+- Derived private key: k = (p + r) mod n.
+
+## Wire format
+
+Secret kind: "P2BK"
+
+P2BK introduces a new well-known Secret kind. It has the same structure as a NUT-10/11 P2PK Secret except for the kind string and an additional tag that carries the blinding scalars:
+
+```json
+[
+  "P2BK",
+  {
+    "nonce": "<hex32>",
+    "data": "<P0'>",
+    "tags": [
+      ["sigflag", "SIG_INPUTS"],
+      ["pubkeys", "<P1'>", "<P2'>"],
+      ["n_sigs", "<int>"],
+      ["locktime", "<unix_seconds>"],
+      ["refund", "<R0'>", "<R1'>"],
+      ["n_sigs_refund", "<int>"],
+      ["r", "<r0>", "<r1>", "<r2>"]
+    ]
+  }
+]
+```
+
+Notes:
+
+- data holds the primary blinded pubkey P0'.
+- pubkeys holds zero or more additional blinded pubkeys P1', P2', … for locktime multisig.
+- refund holds zero or more blinded refund pubkeys R0', R1', … for refund multisig.
+- r is an array of the blinding scalars as fixed-length 32-byte hex strings (lowercase) without prefix. The order of r MUST match the concatenation order of all blinded keys present in the Secret:
+  1) the primary lock key data, then 2) any keys in pubkeys, then 3) any keys in refund.
+  For example, if there are m lock keys in total (1 in data + pubkeys.length) and t refund keys, the r tag contains m + t entries: [r0, r1, …, r(m−1), r(m), …, r(m+t−1)].
+
+## Normalization for mints (wallet MUST)
+
+Mints do not understand "P2BK". Wallets MUST transform a P2BK Secret into a standard P2PK Secret before using it in any request to a mint (swap/melt/etc.). Normalization is purely a string transformation:
+
+1. Parse the JSON Secret [kind, meta]. If kind != "P2BK", return unchanged.
+2. Remove the r tag from meta.tags if present.
+3. Replace kind with "P2PK".
+4. Re-serialize to JSON string. This string is the message to be signed for NUT-11 witnesses and is what wallets MUST send to mints.
+
+No other fields are changed. In particular, data, pubkeys, refund remain the blinded pubkeys P', R'.
+
+## Signing and verification (unchanged at the mint)
+
+- Signature scheme, sigflag semantics, multisig, locktime/refund behavior, and message aggregation (SIG_INPUTS, SIG_ALL) are as in NUT-11. All signatures are Schnorr signatures over the SHA256 hash of the normalized P2PK Secret string (and any aggregated outputs per NUT-11).
+- Mints MUST NOT receive r values and MUST NOT receive Secrets of kind "P2BK". Wallets MUST perform normalization before sending any request to a mint.
+
+## Wallet behavior
+
+### Sender (building P2BK)
+
+- For each recipient lock/refund pubkey Pi, choose fresh ri ∈ [1, n − 1].
+- Compute Pi' = Pi + ri·G.
+- Construct a P2PK Secret as in NUT-11 but replace all pubkeys with their blinded forms. Blind the message as usual to obtain outputs and promises from the mint.
+- After unblinding signatures to proofs, rewrite the proof Secret to kind "P2BK" and append a tag ["r", r0, r1, …] carrying all ris in the order defined above. Deliver these P2BK proofs to the receiver.
+
+### Receiver (spending P2BK)
+
+- Parse the P2BK Secret and extract r values.
+- Derive the signing private keys ki = (pi + ri) mod n for each of its keys pi that are expected to sign under NUT-11 rules (respecting locktime and multisig tags).
+- Normalize the Secret to P2PK (strip r; set kind = "P2PK").
+- Produce Schnorr signature(s) over the normalized P2PK Secret string according to the applicable sigflag and multisig rules.
+- Submit the proofs to the mint. The mint verifies exactly as in NUT-11.
+
+## Determinism and canonicalization
+
+- The r tag MUST contain lowercase hex and be 64 hex chars per entry (32 bytes), matching the conventional encoding used for scalars elsewhere in Cashu.
+- Wallets SHOULD ignore duplicate r entries and MUST deduplicate derived signing keys if the same ri appears multiple times. Ordering rules still apply to allow position-based mapping.
+- Wallets MUST NOT include an empty r tag; if present, mints will never see it due to normalization, but receivers SHOULD treat an empty r tag as equivalent to absence (no blinding information).
+
+## Constraints and errors
+
+- ri MUST satisfy 1 ≤ ri ≤ n − 1. Senders MUST use uniformly random ri and MUST NOT reuse ri across different blinded keys.
+- The derived private key ki = (pi + ri) mod n MUST be non-zero. If ki = 0 (probability ~1/n), the receiver cannot sign; the remedy is to request a re-send with different randomness.
+- Wallets MUST treat any P2BK Secret missing the r tag as a non-blinded P2PK Secret (i.e., treat like NUT-11 where P' are just arbitrary pubkeys).
+
+## Security considerations
+
+- Mint Privacy: Mints never see r nor unblinded P. They see only blinded pubkeys P' inside a standard P2PK Secret, and standard Schnorr signatures. This prevents mints from trivially linking P' to a receiver's long-term P if P is reused elsewhere.
+- Freshness: Reusing `r`s across payments or across keys enables linkability across P' values. Senders MUST generate fresh `r`s for every blinded key instance.
+- Receiver Key Hygiene: Receivers SHOULD avoid reusing the same base key p across many P2BK payments if linkability via off-chain correlation is a concern, although the mint cannot derive P.
+- Metadata Leakage: The presence of P' alone does not reveal P without knowledge of r or p. The r tag is only exchanged wallet-to-wallet and MUST NOT be forwarded to mints or third parties.
+
+## Compatibility
+
+- Backwards Compatibility: Mints require no changes. Wallets that do not understand P2BK will fail to parse the Secret kind and thus cannot accept such proofs. Senders SHOULD only send P2BK proofs to receivers known to support NUT-26.
+- Interop with NUT-11: All NUT-11 tag semantics (sigflag, n_sigs, locktime, refund, n_sigs_refund) apply unchanged when used with blinded keys.
+
+## Mint info
+
+No new mint capability flag is required because mint behavior is unchanged. [NUT-06][06] remains the source of P2PK support (NUT-11). Wallet capability advertisement is out-of-scope for this NUT.
+
+## Worked example
+
+Receiver base pubkey P (compressed):
+
+```
+033281c37677ea273eb7183b783067f5244933ef78d8c3f15b1a77cb246099c26e
+```
+
+Sender samples r0 (hex):
+
+```
+1f3a... (64 hex chars)
+```
+
+Blinded lock key:
+
+```
+P0' = P + r0·G
+```
+
+P2BK Secret (SIG_INPUTS, no multisig):
+
+```json
+[
+  "P2BK",
+  {
+    "nonce": "da62796403af76c80cd6ce9153ed3746",
+    "data": "03ab...<P0'>",
+    "tags": [["sigflag", "SIG_INPUTS"], ["r", "1f3a..."]]
+  }
+]
+```
+
+Normalization for mint/signing (wallet-side):
+
+```json
+[
+  "P2PK",
+  {
+    "nonce": "da62796403af76c80cd6ce9153ed3746",
+    "data": "03ab...<P0'>",
+    "tags": [["sigflag", "SIG_INPUTS"]]
+  }
+]
+```
+
+Receiver derives k0 = p + r0 (mod n) and signs the normalized P2PK Secret per NUT-11.
+
+## Implementation notes (informative)
+
+- A reference TypeScript implementation is available in cashu-ts, which:
+  - Creates blinded pubkeys and tracks the corresponding r values in order.
+  - Emits proofs to receivers with Secret kind "P2BK" and an r tag.
+  - Normalizes Secrets back to kind "P2PK" (stripping r) for all mint interactions and hashes/signs over that normalized string.
+  - Derives signing keys k = p + r from provided base keys and r values when spending.
+
+[00]: 00.md
+[03]: 03.md
+[05]: 05.md
+[06]: 06.md
+[08]: 08.md
+[10]: 10.md
+[11]: 11.md

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 | [05][05] | Melting tokens          |
 | [06][06] | Mint info               |
 
-### Optional
-
-| #        | Description                       | Wallets                                                                            | Mints                                            |
-| -------- | --------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------ |
 | [07][07] | Token state check                 | [Nutshell][py], [Nutstash][ns], [cashu-ts][ts], [cdk-cli], [Minibits], [macadamia] | [Nutshell][py], [cdk-mintd], [nutmix]            |
 | [08][08] | Overpaid Lightning fees           | [Nutshell][py], [Nutstash][ns], [cashu-ts][ts], [cdk-cli], [Minibits], [macadamia] | [Nutshell][py], [cdk-mintd], [nutmix]            |
 | [09][09] | Signature restore                 | [Nutshell][py], [cdk-cli], [Cashu.me][cashume], [Minibits], [macadamia]            | [Nutshell][py], [cdk-mintd]                      |
@@ -41,6 +37,7 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 | [23][23] | Payment Method: BOLT11            | [Nutshell][py], [cdk-cli]                                                          | [Nutshell][py], [cdk-mintd], [nutmix]            |
 | [24][24] | HTTP 402 Payment Required         | -                                                                                  | -                                                |
 | [25][25] | Payment Method: BOLT12            | [cdk-cli], [cashu-ts][ts]                                                          | [cdk-mintd]                                      |
+| [26][26] | Pay-to-Blinded-Key (P2BK)         | [cashu-ts][ts]                                                                     | -                                                |
 
 #### Wallets:
 


### PR DESCRIPTION
formalize public key blinding atop NUT-11;
add spec and README entry;
ensure proper Markdown formatting