### PR TITLE
NUT-XX: Offline Spilman (unidirectional) channel

### DIFF
--- a/XX.md
+++ b/XX.md
@@ -336,14 +336,25 @@ As recommended in NUT-03, the outputs are in ascending order of amount.
 
 The outputs includes all the commitment outputs for Charlie and also
 those for Alice.
-They are ordered for by amount (increasing). For any given amount,
+They are ordered by amount (increasing). For any given amount,
 we have Charlie's deterministic outputs first, ordered by _index_ (increasing),
-and then Alice's similarly ordered
+and then Alice's similarly ordered. For example, if you're distributing
+a few hundred sats to each party, the first few outputs of the swap are:
+
+```
+context    | amount | index
+
+"receiver" | 100    |     0
+"receiver" | 100    |     1
+"sender"   | 100    |     0
+"sender"   | 100    |     1
+...
+```
 
 > [!NOTE]
 > If you have a vector of Charlie's outputs, ordered by amount and index, and then you append
 > Alice's similarly ordered,
-> then you can apply a _stable sort_, such as Rust's `all_outputs.sort_by_key(|(output, _)| output.amount)` or Python's `sorted(all_outputs, key = lambma o: o.amount` to get this ordering.
+> then you can apply a _stable sort_, such as Rust's `all_outputs.sort_by_key(|(output, _)| output.amount)` or Python's `sorted(all_outputs, key = lambma o: o.amount` to get the required ordering.
 
 Alice then signs this (SIG_ALL). Alice can then send three pieces of data to Charlie: the `channel_id`, the balance for Charlie, and her signature.
 

--- a/XX.md
+++ b/XX.md
@@ -2,52 +2,65 @@
 
 `optional`
 
-`depends on: NUT-11, NUT-12 (or we allow 07 as a substitute for 12?)`
+`depends on: NUT-11 (P2PK), NUT-12 (DLEQ)`
 
 ---
 
-Alice and Bob wish to set up a payment channel, such that Bob's balance starts at zero and his balance
+Alice and Bob wish to set up a payment channel, funded by Alice, such that Bob's balance starts at zero and his balance
 increases (unidirectional) over time. This is 'offline' because it allows - once the channel has been
 set up - for the two parties to transact simply by Alice sending signatures to Bob which Bob can verify
 without needing to contact the mint after each micropayment.
 
-Bob can then unilaterally exit at any time, by taking the latest signature to the mint.
-Alice can redeem the remainder after a certain pre-defined time has elapsed. A collaborative exit is
-also possible, allowing both parties to immediately redeem their closing balances.
+Both parties trust the mint, but not each other. This works with any mint that supports NUT-11 and NUT-12.
 
-One simple alternative is for Alice to prepare a large number (millions perhaps) of tiny-denomination proofs
+Bob can then unilaterally exit at any time, by taking the latest signature to the mint.
+If, after this exit, Bob doesn't sign a transaction which releases Alice's remaining balance to her immediately,
+she can redeem the remainder after a certain pre-defined time has elapsed.
+
+One simple alternative is for Alice to prepare a large number (millions perhaps) of tiny-amount proofs
 in advance. However, that requires a lot of bandwidth and places heavy strain on the mint.
-This NUT describes how a smaller set of proofs, of various denominations, can solve the same
+This NUT describes how a smaller set of proofs, of various amounts, can solve the same
 problem, allowing potentially billions of payments with only a few dozen proofs.
 
-# Opening the channel
+# The channel
 
-Alice takes Bob's public key and, with any mint supporting NUT-11, creates a set of 2-of-2 multisig proofs
-of various denominations, where both Alice and Bob's signature is needed. Each of these proofs refunds to Alice after a pre-defined time (e.g. one week).
-SIG_ALL is used.
+Alice takes Bob's public key and 'outputs' provided by him and, with any mint supporting NUT-11, creates a set of 2-of-2 multisig proofs
+of various amounts, where both Alice and Bob's signature is needed to redeem.
+Each of these proofs refunds to Alice after a pre-defined 'locktime' (e.g. one week).
+Before the locktime, the proofs can only be redeemed with a signature from both. After the locktime, Alice's signature is sufficient.
+`SIG_ALL` is used, for reasons described in 'double-spending' below.
+The signature scheme and locktime and `SIG_ALL`, are as described in NUT-11.
 
-## Denominations
+The details of the amounts and outputs are described next.
+
+## Amounts, and the details of opening and funding the channel
 
 _This assumes that 1 millisat is the smallest 'resolution' of interest, but another resolution may be agreed_
 
-Alice shall prepare _2_ such proofs with 1-millisat value.
+_This assumes that the mint's amounts are in powers of two. While that appears to be the typical case, it's not required by the protocol_
+
+There shall be _2_ such proofs with 1-millisat value, and one proof for every other power of 2: 2-millisats, 4-millisats, 8-millisats, ..., up to some pre-agreed maximum.
+The total value of all those proofs is the channel capacity and is the maximum amount that Alice can send to Bob through this channel.
+
+First, Bob prepares his outputs (BlindedMessage), one for each of those amounts (two 1-millisat outputs).
+These are where Bob's final balance will be sent. Bob is free to choose any output, and will typically prepare an anyone-can-spend output with a random secret that he created.
+
+Alice then takes Bob's outputs and funds a 'swap' with her own inputs. The result is a set of proofs with the 2-of-2-multisig rules mentioned above, including the refund to Alice after a locktime has expired.
+
+Alice then sends all those proofs to Bob. Bob can verify all of these proofs with the mint using NUT-12, and also check  that the signatures and locktimes have been set up correctly, before going offline.
+
 One of these 1-millisat proofs is a special proof that will be included in every transaction.
-Alice shall prepare one proof for every other power of 2: 2-millisats, 4-millisats, 8-millisats, ..., up to some pre-agreed maximum.
-The total value of all those proofs is the channel capacity and is the maximum amount that Alice can send to Bob through this channel
-
-Bob can verify all of these proofs with the mint using NUT-12, before going offline.
-
-When both Alice and Bob have all the following, the channel is open:
-
- - Bob prepares one _output_ for each of the proofs that Alice prepares. These are where Bob's final balance will be sent. In principle, Bob is free to choose any output, but Alice may require that they are locked up for a period of time in order to give Bob an incentive to cooperate with a cooperative close.
- - The proofs prepared prepared by Alice, each one based on an output prepared by Bob, which Bob can verify with the mint
 
 # transactions
 
 To update the balance, Alice shall take the special 1-millisat proof mentioned above, and combine it with
-whatever subset of the other proofs is needed to reach the new balance, and sign the combination spending those proofs to the corresponding outputs prepared by Bob, and give the signature to Bob. Bob can verify this signature offline
+whatever subset of the other proofs is needed to reach the new balance, and sign the combination spending those proofs to the corresponding outputs prepared by Bob, and give the signature to Bob.
+For example, to update the balance to 16 msat, Alice will take the special proof and the unique set of proofs which add to 15, because 16=1+15=1+1+2+4+8.
 
-For each update, Alice simply sends a number recording the new balance, and her signature on the updated transaction. That is sufficient to allow Bob to construct the updated transaction and verify the signature. This can allow a very high frequency of updates
+Bob can verify this signature offline. Bob _could_ sign this transaction himself immediately and 'swap' it for the proofs, but he will not do so until he is ready to exit and close the channel.
+
+For each update, Alice simply sends a number recording the new balance, and her signature on the updated transaction. That is sufficient to allow Bob to construct the updated transaction and verify the signature; he has the same proofs and outputs that Alice is working on and therefore he can reconstruct the same updated transaction that Alice just signed.
+This can allow a very high frequency of updates
 
 # double-spending, and unidirecionality
 
@@ -55,9 +68,15 @@ As Alice is using SIG_ALL, and the special 1-millisat proof is used in all of th
 Bob can redeem only one of the transactions. If he attempts to redeem a second transaction, he will need to
 include the special proof (SIG_ALL), and the mint will see that the special proof has already been redeemed.
 As he can only redeem one transaction, and therefore one set of proofs that were signed together, he will redeem
-the most valuable transaction. This explains why these are unidirectional.
+the most valuable transaction.
+This explains why these are unidirectional.
 
 # cooperative channel close
 
-The above gives Bob unilateral exit with immediate access. Alice has to wait some time before she can collect the refund
+The above gives Bob unilateral exit with immediate access. Alice has to wait some time before she can collect the refund.
+When closing the channel, Bob should sign a similar transaction returning the remaining proofs to Alice,
+but we cannot force him to do so and therefore Alice may need to way until the locktime has expired.
 
+# proof-of-concept
+
+There is a proof of concept based on the CDK, showing how both parties can do the verification at each step. TODO: link to it

--- a/XX.md
+++ b/XX.md
@@ -6,6 +6,8 @@
 
 ---
 
+_TODO: the 'funding token' should be somewhat deterministic too, or at least some mechanism to ensure that Alice can't reuse one token in a second channel_
+
 This describes how Alice can set up a one-way payment channel from herself to Charlie.
 Using public information such as Charlie's public key and his preferred mints,
 Alice prepares a _funding token_

--- a/XX.md
+++ b/XX.md
@@ -37,11 +37,15 @@ The total value of all those proofs is the channel capacity and is the maximum a
 
 Bob can verify all of these proofs with the mint using NUT-07, before going offline.
 
+When both Alice and Bob have all the following, the channel is open:
+
+ - Bob prepares one _output_ for each of the proofs that Alice prepares. These are where Bob's final balance will be sent. In principle, Bob is free to choose any output, but Alice may require that they are locked up for a period of time in order to give Bob an incentive to cooperate with a cooperative close.
+ - The proofs prepared prepared by Alice, each one based on an output prepared by Bob, which Bob can verify with the mint
+
 # transactions
 
 To update the balance, Alice shall take the special 1-millisat proof mentioned above, and combine it with
-whatever subset of the other proofs is needed to reach the new balance, and sign the combination and give the
-signature to Bob. Bob can verify this signature offline
+whatever subset of the other proofs is needed to reach the new balance, and sign the combination spending those proofs to the corresponding outputs prepared by Bob, and give the signature to Bob. Bob can verify this signature offline
 
 # double-spending, and unidirecionality
 
@@ -51,6 +55,7 @@ include the special proof (SIG_ALL), and the mint will see that the special proo
 As he can only redeem one transaction, and therefore one set of proofs that were signed together, he will redeem
 the most valuable transaction. This explains why these are unidirectional.
 
-# Fees
+# cooperative channel close
 
-???
+?
+

--- a/XX.md
+++ b/XX.md
@@ -6,7 +6,11 @@
 
 ---
 
-_TODO: For a little more privacy (for those not using P2BPK) Alice and Charlie could easy specify two public keys, one for the 2-of-2 multisig in the funding and another in the 1-of-1 multisig that pays to each specificcally. What do you think?_
+_TODO: should this, or another NUT, talked about the transport for all of this, e.g. JSON over Websockets? I guess not_
+
+_TODO: the mint could notice that the 2x2 P2PK swap happens just before two separate 1x1 swaps that add to the same amount, and therefore reasonably conclude that this was a channel. Should Alice and Charlie delay stage 2 in order to have a little more privacy?_
+
+_TODO: For a little more privacy (for those not using P2BPK) Alice and Charlie could specify two public keys, one for the 2-of-2 multisig in the funding and another in the 1-of-1 multisig that pays to each specificcally?_
 
 This describes how Alice can set up a one-way payment channel from herself to Charlie.
 Using public information such as Charlie's public key and his preferred mints and keysets,
@@ -29,28 +33,35 @@ The mint, Bob, is involved only at the start for the initial swap where Alice pr
 the _funding token_, and at the end where each of the two parties swap their
 final balances into their wallets.
 
-# Exiting, fees, the `capacity` of the channel, and "impossible" balances
+# The commitment transaction, and the two-stage exit
 
 This text is followed by an ASCII art diagram, showing all the fees and the two-stage exit process.
-
-An important parameter is the `capacity`; it's the maximum balance that can be sent to Charlie in this channel.
-If the fee-rate is non-zero, then Alice is responsible for the fees, as described here:
 
 When the channel is closing, there are two stages, and there are fees to be paid
 in each of those two stages.
 In the first stage, the _funding token_ token is swapped to create the _commitment outputs_
 for each of the two parties.
+This first stage is a _swap_, and it happens when Charlie adds his signature to the
+signature from Alice to he performs the swap with the mint.
+
 Some of the commitment outputs are P2PK-locked to Charlie's public key, and the remainder
 are of the commitment outputs are P2PK-locked to Alice's public key.
-This first swap will cost fees.
+This first swap will cost fees. All of the proofs in the _funding token_ are in the
+same _keyset_ and therefore they have the same fee rate and this simplifies
+the calculation of the fees in the first stage.
 
 In the second stage of the exit, Alice and Charlie each separately swap their commitment outputs - which are locked to them via 1-of-1 P2PK -
 for conventional anyone-can-spend proofs to store in their wallet.
-This second swap also requires paying fees.
 
-All of the P2PK outputs discussed above, those in the _funding token_ and in the
-_commitment outputs_, are in the same keyset and therefore a single feerate `input_fee_ppk`
-applies to all.
+_Keyset malleability:_ When Charlie performs the first stage, he can choose which keyset - among the _active_ keysets (with suitable amounts) for that unit, to use for the commitment outputs.
+He has this freedom because Alice's signature commits to the _amounts_, but not the _keysets_, of
+the outputs; see the SIG_ALL docs (...) .
+Charlie should use the same keyset as the proofs in the _funding token_, if it's still active, but Charlie might choose not to.
+This means that the fee rate in the second stage may be different from the fee rate in the first stage.
+When computing the _capacity_, we assume the fees rates will be the same in both stages.
+
+An important parameter is the `capacity`; it's the maximum balance that can be sent to Charlie in this channel.
+If the fee-rate is non-zero, then Alice is responsible for the fees, as described here.
 
 The method for constructing the _secrets_ and _blinding factors_ for all those P2PK
 outputs is deterministic; the details and motivation are given below.
@@ -73,22 +84,22 @@ Sometimes, due to fees, there is no value `y` for which equality can be attained
 in this case Charlie will find he is slightly overpaid as the desired balance
 is impossible.
 
-As there are two stages to the swapping, and each costs fees, Alice must
-create the _funding token_ with value:
+As there are two stages to the swapping, and each costs fees, and Alice is responsible for the fees,
+she must create the _funding token_ with value:
 
 ```
 total_funding_token_amount = inverse_deterministic_value(inverse_deterministic_value(capacity))
 ```
 
 The fees in the first stage will always be `total_funding_token_amount - deterministic_value_after_fees(total_funding_token_amount)`.
-The fees in the second stage can vary, as they depend on the distribution between the two parties.
+The fees in the second stage can vary, as they depend on the distribution between the two parties (and also on which keyset Charlie chooses.
 
 To make a payment which brings Charlie's balance to `charlies_balance`, the following describes how Alice computes the values of the various parts. Where `deterministic_value_after_fees(total_funding_token_amount)` is the nominal value when the _funding token_ goes through the first swap:
 
  - `charlies_balance`, we start our computation with this, the balance that we wish Charlie to have in this transaction.
- - `p` = `inverse_deterministic_value(charlies_balance)`, the nominal value of Charlie's commitment outputs.
- - `q` = `deterministic_value_after_fees(total_funding_token_amount) - p`, the value that is left from the funding token to create Alice's commitment outputs, after the fees and creating Charlie's commitment outputs.
- - Alice is then left with `deterministic_value_after_fees(q)`, the final amount left in her wallet after swapping her commitment outputs into her wallet
+ - `p` = `inverse_deterministic_value(charlies_balance)`, the nominal value of Charlie's commitment outputs. This is to take account of the fees from the second stage, assuming it has the same keyset as the funding token.
+ - `q` = `deterministic_value_after_fees(total_funding_token_amount) - p`, the value that is left from the funding token to create Alice's commitment outputs, after the stage1 fees and creating Charlie's commitment outputs.
+ - Alice is then left with `deterministic_value_after_fees(q)`, the final amount left in her wallet after swapping her commitment outputs into her wallet, assuming the keyset is the same 
 
 ## Fee and value distribution diagram
 
@@ -136,7 +147,8 @@ To make a payment which brings Charlie's balance to `charlies_balance`, the foll
 
 # The channel parameters, and channel_id
 
-Knowing Charlie's public key, and the set of mints and _units_ that are trusted by Charlie, and a minimum channel lifetime that Charlie requires, Alice defines the channel parameters as follows:
+Knowing Charlie's public key, and the set of mints and _units_ and keysets that are trusted by Charlie,
+and a minimum channel lifetime that Charlie requires, Alice defines the channel parameters as follows:
 
  - `sender_pubkey`: Alice's key ?how exactly to encode this?
  - `receiver_pubkey`: Charlie's key ?how exactly to encode this?
@@ -147,19 +159,20 @@ Knowing Charlie's public key, and the set of mints and _units_ that are trusted 
 
  - `active_keyset_id`: An _active_ keyset for that unit at that mint
  - `input_fee_ppk`: As all the proofs in the funding token, and in the commitment outputs, are in the same keyset, the `input_fee_ppk` is fixed.
- - `maximum_amount_for_one_output`: used in the deterministic amount-selection algorithm as an upper bound on the size of any output in the funding token or in the commitment outputs.
+ - `maximum_amount_for_one_output`: used in the deterministic amount-selection algorithm as an upper bound on the size of any individual output in the funding token or in the commitment outputs. Maybe help with privacy, in the case of large-capacity channels.
 
  - `expiry`  unix timestamp: If Charlie doesn't close before this time, Alice can re-claim all the funds after this has expired
  - `setup_timestamp` unix timestamp: the time when Alice is setting up this channel
  - `sender_nonce`: Random data selected by Alice to add more randomness. May be useful if Alice and Charlie have multiple concurrent channels.
 
-The `channel_id` is the SHA256 hash of the '|'-delimited concatenation of all the above.
+The `channel_id` is the SHA256 hash of the concatenation of all the above.
 
 # Funding the channel
 
 Alice, with the mint, creates a _funding token_ worth `total_funding_token_amount` units.
 Each proof in this token is a P2PK (NUT-11) proof which requires both signatures
 before the expiry of the channel, and where Alice's signature alone is sufficient after the expiry:
+
 
  - `data`: Alice's key
  - `pubkeys`: Charlie's key
@@ -168,11 +181,23 @@ before the expiry of the channel, and where Alice's signature alone is sufficien
  - `refund`: Alice's key
  - `sig_flag`: `SIG_ALL`
 
+for example:
+```
+    let conditions = Conditions::new(
+        Some(locktime),                       // Locktime for Alice's refund
+        Some(vec![*charlie_pubkey]),          // Charlie's key as additional pubkey for 2-of-2
+        Some(vec![*alice_pubkey]),            // Alice can refund after locktime
+        Some(2),                              // Require 2 signatures (Alice + Charlie) before locktime
+        Some(SigFlag::SigAll),                // SigAll: signatures commit to outputs
+        Some(1),                              // Only 1 signature needed for refund (Alice)
+    )?;
+```
+
 _TODO: replace that list of 6 items with the correspoding Json of the secret
 
 # Charlie's verification
 
-The following information should be sent to Charlie with, or before, the first payment in this channel,
+The following information should be sent by Alice to Charlie with, or before, the first payment in this channel,
 enabling Charlie to verify everything. He can verify without communicating with the mint:
 
  - the channel parameters
@@ -181,30 +206,26 @@ enabling Charlie to verify everything. He can verify without communicating with 
 Both sides should store the funding proofs in the order that Alice created them, to ensure both sides can construct the relevant transactions deterministically.
 
 The secrets and blinding factors in the outputs that created this funding token are created
-deterministically. Charlie can verify these. _TODO: clarify the full verification details somewhere_
-
-# Payments
-
-Each payment requires Alice to update the balance and then construct the updated
-'commitment' transaction. She then signs the transaction and sends her signature
-and the new balance to Charlie. This signature and amount, combined with the `channel_id`,
-is sufficient for Charlie to reconstruct the commitment transaction and verify the signature,
-as long as Alice has sent all the channel parameters with - or before - the first payment.
+deterministically. Charlie can verify these. _TODO: expand the 'Charlie's security' section below. Maybe move this 'Charlie's verification' section down there?_
 
 ## deterministic outputs, for the funding token and also for the commitment outputs
+
+The deterministic output algorithm described here is using both to create
+the 2-of-2 P2PK outputs that are in the _funding token_ and also to create
+the per-partner 1-of-1 P2PK outputs that are created by the commitment transaction.
 
 To construct the deterministic outputs in the funding token and also
 in the commitment outputs, we start with the target amount we
 wish to reach and the set
 of amounts that are available in the keyset of the `active_keyset_id`.
-A _deterministic output_ is a _secret_ and a _blinding factor_ constructed deterministically.
-
 We ignore any amounts greater than `params.maximum_amount_for_one_output`.
+
 The algorithm greedily takes the largest amount,
 smaller than that maximum amount,
 until it can't take any more as it would overflow the target.
 Then it moves on to the next-smallest amount repeatedly
 until the target is reached
+
 
 ```
 
@@ -224,9 +245,11 @@ def compute_the_set_of_deterministic_amounts(target):
     return selected_amounts
 ```
 
-While it is common for mints to use powers-of-2, it is not required.
+While it is common for mints to use powers-of-2 for all the amounts in a given keyset,
+it is not required by the protocol.
 In a power-of-2 mint, there will be at most one selected for each available amount.
 But for other mints, a given _amount_ may be selected more than once.
+
 
 For example, if the target is 543 sats, and the keyset has powers of ten
 (1, 10, 100, 100 ...) as the amounts, then we'll use 5 of the 100-sat
@@ -254,6 +277,8 @@ amount | index
 1      |     2
 ```
 
+A _deterministic output_ is a _secret_ and a _blinding factor_ constructed deterministically.
+
 The deterministic outputs are created in one of three contexts:
  - `context = "funding"` for creating the funding token, where each secret is 2-of-2 P2PK
  - `context = "receiver"` for creating the commitment outputs for Charlie, which result from swapping the funding token, which are P2PK-locked to him.
@@ -270,10 +295,10 @@ The deterministic process is a function of four things:
  - the `index`
 
 As these are all deterministic and based on information known to both parties,
-both parties can construct all these outputs.
+both parties can construct all these outputs and secrets.
 We use P2PK to stop either party from stealing the other's funds.
 
-Each output iso be constructed as follows: the channel_id, context, amount, and the index are combined and hashed to compute the _deterministic nonce_:
+Each output is constructed as follows: the channel_id, context, amount, and the index are combined and hashed to compute the _deterministic nonce_:
 
 ```
 deterministic_nonce(...)
@@ -315,7 +340,7 @@ secret_for_alices_commitment_output = [
 ]
 ```
 
-_TODO? Optional: If Charlie, along with his public key, advertizes that he supports pay-to-blinded-pubkey, we could determistically compute an ephemeral private key for blinding, and include the corresponding ephemeral public key in the proof, as per the P2BPK NUT_
+_TODO? Optional: If Charlie advertizes that he supports receiving pay-to-blinded-pubkey, we could determistically compute an ephemeral private key for blinding, and include the corresponding ephemeral public key in the proof, to be compatible the P2BPK NUT_
 
 The corresponding blinding factor is `SHA256(channel_id || context || amount || index || "blinding")`,
 and so the deterministic output (BlindedMessage) is contructed by applying that
@@ -325,16 +350,21 @@ We use determinism as it minimizes the communication that is required,
 in particular it allows Alice to send the initial payment with zero
 prior communication with Charlie and also minimizing the bandwidth.
 If Charlie sees a payment from a new `channel_id`, he knows that the
-funding token is new, i.e. it hasn't been used in a previous channel.
+funding token is new, i.e. it hasn't been used in a previous channel, and
+he also knows that the outputs of the first stage will also be new and
+therefore can't have been spent already.
 
 # Commitment transaction, and balance update, in detail
 
 The commitment transaction can now be specified more clearly.
 It is a _swap_ which takes the _funding proof_ as input.
 
+_TODO: Should we make the order of these funding inputs deterministic, or simply let Alice
+decide the order as the order that she sends the funding proofs to Bob within the first payment?
+
 As recommended in NUT-03, the outputs are in ascending order of amount.
 
-The outputs includes all the commitment outputs for Charlie and also
+The outputs include all the commitment outputs for Charlie and also
 those for Alice.
 They are ordered by amount (increasing). For any given amount,
 we have Charlie's deterministic outputs first, ordered by _index_ (increasing),
@@ -361,8 +391,6 @@ Alice then signs this (SIG_ALL). Alice can then send three pieces of data to Cha
 As already mentioned, Alice must send the full set of channel parameters to Charlie in the first payment - if she hasn't already sent them beforehard -
 but after this it is sufficient for her to send those three pieces of data.
 
-Charlie can reconstruct the transaction and verify the signature.
-
 # Closing the channel
 
 Most of the commitment transactions are never sent to the mint.
@@ -377,10 +405,14 @@ via NUT-07 (token state check). NUT-17, if supported by the mint, helps here too
 
 Charlie should return Alice's blind signatures to her, but if he doesn't then Alice
 can use NUT-09 to restore the signatures.
+If Charlie chooses a different keyset (not `params.active_keyset_id`), Alice can
+use NUT-09 to learn the keyset that he selected.
+
 While we assume that Charlie will usually take the most recent commitment, as it's
 the most valuable, it is not guaranteed that he will do that.
 
-To restore, Alice can iterate over the amounts available in this keyset, and - for each amount - loop over the indices - restarting the index at `0` for each amount -
+To restore the signatures, where she isn't sure which particular balance
+Charlie exited with, Alice can iterate over the amounts available, and - for each amount - loop over the indices - restarting the index at `0` for each amount -
 in order to reconstruct the deterministic output and restore the signature.
 When a given restoration fails, she can stop increasing the _index_ and
 move on to the next amount instead.
@@ -395,17 +427,18 @@ for amount in amounts_in_this_keyset:
             .. unblind the signature and add the proof to Alice's wallet
 ```
 
-# Expiry
+This ensures she will get all the outputs and BlindedSignatures which Charlie
+created when he did the swap, even if she doesn't know which balance he exited with.
+
+# Expiry, and Charlie's security
 
 Charlie should remember to close channels as the expiry time closes.
 He should also keep a record of channel_ids that he has closed, where
 the expiry time has not been reached, in order to ensure that
 Alice does not attempt to reuse a channel that was already closed.
 
-# Charlie's security
-
 To ensure that Charlie can trust that a given payment is valid without needing to check
-with the mint, Charlie should be careful to check everything.
+with the mint, Charlie should be careful to check everything ....
 
 Charlie should maintain a mapping from the channel_id to the balance, to ensure that
 Alice doesn't attempt to decrease the balance or otherwise attempt to reuse an older channel.

--- a/XX.md
+++ b/XX.md
@@ -32,19 +32,19 @@ There is an ASCII art diagram below, showing all the fees and the two-stage exit
 
 When the channel is closing, there are two stages, and there are fees to be paid
 in each of those two stages.
-First, the _funding token_ token is swapped to create the _deterministic outputs_
+In the first stage, the _funding token_ token is swapped to create the _deterministic outputs_
 (defined below) for each of the two parties.
 Some of the deterministic outputs are P2PK-locked to Charlie's public key, and the remainder
 are of the deterministic outputs are P2PK-locked to Alice's public key.
 
 All the proofs in the _funding token_ are in the same _active_ keyset, with fee rate `input_fee_ppk`.
-If there are `n_funding_proofs` proofs in that funding token, the fees of that swap cost
+If there are `n_funding_proofs` proofs in that funding token, the fees of that first stage are
 `(input_fee_ppk * n_funding_proofs + 999) // 1000`,
 where `//` rounds non-integer results down to an integer.
 
 In the second stage of the exit, Alice and Charlie swap their deterministic outputs
 for conventional anyone-can-spend proofs.
-This also requires paying fees. These outputs are also in the same keyset as the funding token.
+This also requires paying fees. These deterministic outputs are also in the same keyset as the funding token.
 
 The method for constructing the deterministic outputs is described in more detail later in this document.
 For now, we focus on the fees.
@@ -65,7 +65,8 @@ which is the smallest `x` such that `deterministic_value_after_fees(x) = charlie
 
 To make a payment which brings Charlie's balance to `charlies_balance`, the following summarizes the values and fees:
 
- - `x` = `inverse_deterministic_value(charlies_balance)`, the nominal value of Charlie's deterministic outputs
+ - `charlies_balance`, we start our computation with this, the balance that we wish Charlie to have in this transaction.
+ - `x` = `inverse_deterministic_value(charlies_balance)`, the nominal value of Charlie's deterministic outputs.
  - `y` = `funding_token_total_value - x - (input_fee_ppk * n_funding_proofs + 999) // 1000`, the value that is left in the funding token to create Alice's deterministic outputs, after the remaining value is used for paying fees and creating Charlie's deterministic outputs.
  - Alice is then left with `deterministic_value_after_fees(y)`, the final amount left in her wallet after swapping her determististic outputs into her wallet
 
@@ -90,7 +91,7 @@ with `charlies_balance = 0`.
 │  Created by Alice with P2PK proofs requiring both signatures (SIG_ALL)  │
 └─────────────────────────────────────────────────────────────────────────┘
                                   │
-                                  │ STAGE 1: Swap funding token
+                                  │ STAGE 1 of channel closure: Swap funding token
                                   │
                                   │
                     ┌─────────────┼─────────────┐
@@ -138,7 +139,6 @@ Maximum Charlie can receive (capacity):
 ... TODO: recommend that the first payment be for zero sats, to allow the channel to be instantly closed if Charlie is unable to provide service now. Typically, therefore, Alice will provide two payments immediately the at the start ...
 
 
-
 # The channel parameters, and channel_id
 
 Knowing Charlie's public key, and the set of mints and _units_ that are trusted by Charlie, and a minimum channel lifetime that Charlie requires, Alice defines the channel parameters as follows:
@@ -163,7 +163,7 @@ _TODO: should the channel parameters have a `maximum_output_size`, to put an upp
 
 Alice, with the mint, creates a _funding token_ worth `total_value_of_funding_token` units.
 Each proof in this token is a P2PK (NUT-11) proof which requires both signatures
-before the expiry of the channel, and where Alice's signature alone is sufficient afterwards:
+before the expiry of the channel, and where Alice's signature alone is sufficient after the expiry:
 
  - `data`: Alice's key
  - `pubkeys`: Charlie's key
@@ -190,17 +190,13 @@ Each payment requires Alice to update the balance and then construct the updated
 and the new balance to Charlie. This signature and amount, combined with the channel parameters,
 is sufficient for Charlie to reconstruct the commitment transaction and verify the signature
 
-The commitment transaction spends all of the _funding token_, sending Charlie's balance
-to deterministic outputs (defined below) that only Charlie can redeem, and the remainder
-are sent to deterministic outputs that are redeemable only by Alice
-
 ## deterministic outputs
 
 To construct the deterministic outputs, i.e. the set of _Blinded Messages_ that
 transfer a given amount to one of the two parties, we start with the set
 of amounts that are available in the keyset of the `active_keyset_id`.
 
-While it is common for mints to use powers-of-2, it is not required. (TODO: or is it?)
+While it is common for mints to use powers-of-2, it is not required.
 
 Remember, the 'outputs' described here are just BlindedMessages and their blinding factors
 that are computed by Alice and Charlie.
@@ -211,8 +207,6 @@ For a given target amount (Charlie's balance, or Alice's remainder),
 we first identify the largest amount in the keyset which is less than
 the target amount. We'll use as many proofs as possible of this largest
 amount, as long as we don't exceed the target.
-
-_TODO: don't forget about fees!_
 
 For example, if the target is 543 sats, and the keyset has powers of 
 ten (1, 10, 100, 100 ...) as the amounts, then we'll use 5 of the 100-sat
@@ -250,6 +244,24 @@ Deterministic Secret:
 ]
 ```
 
+In our 543-sat example, where the available amounts are powers of 10, there are 12 determistic outputs:
+
+```
+amount | index
+100    |     0
+100    |     1
+100    |     2
+100    |     3
+100    |     4
+10     |     0
+10     |     1
+10     |     2
+10     |     3
+1      |     0
+1      |     1
+1      |     2
+```
+
 _TODO? Optional: If Charlie, along with his public key, advertizes that he supports pay-to-blinded-pubkey, we could determistically compute an ephemeral private key for blinding, and include the corresponding ephemeral public key in the proof, as per the P2BPK NUT_
 
 The corresponding blinding factor is `SHA256(channel_id || pubkey || amount || "blinding" || index)`,
@@ -264,7 +276,7 @@ The same process is applied to send the remainder to Alice.
 The commitment transaction can now be specified more clearly.
 It is a _swap_ which takes the _funding proof_ as input.
 The outputs start with the payments to Charlie, ordered
-by amount and then by index, followed by Alice's outputs similarly ordered.
+by decreasing amount and then by increasing index, followed by Alice's outputs similarly ordered.
 
 Alice then signs this (SIG_ALL). Alice can then send three pieces of data to Charlie: the `channel_id`, the balance for Charlie, and her signature.
 
@@ -294,7 +306,7 @@ Charlie should return Alice's blind signatures to her, but if he doesn't then Al
 can use NUT-09 to restore the signatures.
 While we assume that Charlie will usually take the most recent commitment, as it's
 the most valuable, it is not guaranteed that he will do that.
-Alice can iterate over the amounts, and - for each amount - loop over the indices
+Alice can iterate over the amounts available in this keyset, and - for each amount - loop over the indices
 in order to reconstruct the deterministic output and restore the signature.
 When a given restoration fails, she can stop increasing the _index_ and
 move on to the next amount instead.
@@ -316,15 +328,33 @@ He should also keep a record of channel_ids that he has closed, where
 the expiry time has not been reached, in order to ensure that
 Alice does not attempt to reuse a channel that was already closed.
 
+# Charlie's security
 
-# Channel capacity
+To ensure that Charlie can trust that a given payment is valid without needing to check
+with the mint, Charlie should be careful to check everything.
 
-The channel capacity is ??? _depends on the fee policy. As mentioned at the top, there are mulitiple swaps; how is responsible for
-paying all those swaps?_
+Charlie should maintain a mapping from the channel_id to the balance, to ensure that
+Alice doesn't attempt to decrease the balance in his favour.
+This map should also store the channel parameters.
+
+As the expiry time approach, Charlie should close the channel as he will lose the balance if the
+expiry time is reached.
+When Charlie closes the channel, he should keep a set of all the closed channels to avoid
+Alice reusing a closed channel.
+
+The record of a closed channel should not be deleted until after it has expired.
+
+If Alice pays using a channel that is not in either of the two datasets mentioned above,
+then Alice appears to be opening a new channel, and Charlie should check:
+ - that the expiry time is reasonably far in the future
+ - that the mint is a mint that he trusts, and the keyset is active
+ - that the channel_id is computed correctly
+ - the DLEQ proofs in the funding token are correct
+ - The proofs in the funding token have the correct P2PK setup, with the keys and expiry and so on
 
 # proof-of-concept
 
-_This PoC is now (2025-11-17) quite out of date. It has deterministic outputs and so on, and makes use of NUT-09 and NUT-07, but it doesn't follow the above closely_
+_This PoC is now (2025-11-23) quite out of date. It has deterministic outputs and so on, and makes use of NUT-09 and NUT-07, but it doesn't follow the above closely_
 
 There is a proof of concept based on the CDK, showing how both parties can do the verification at each step, also including
 the latest SIG_ALL message update. _TODO: link to it. As of 2025-11-02, it's implemented and working with this new deterministic output setup, but the latest code isn't on github yet_

--- a/XX.md
+++ b/XX.md
@@ -47,6 +47,8 @@ When both Alice and Bob have all the following, the channel is open:
 To update the balance, Alice shall take the special 1-millisat proof mentioned above, and combine it with
 whatever subset of the other proofs is needed to reach the new balance, and sign the combination spending those proofs to the corresponding outputs prepared by Bob, and give the signature to Bob. Bob can verify this signature offline
 
+For each update, Alice simply sends a number recording the new balance, and her signature on the updated transaction. That is sufficient to allow Bob to construct the updated transaction and verify the signature. This can allow a very high frequency of updates
+
 # double-spending, and unidirecionality
 
 As Alice is using SIG_ALL, and the special 1-millisat proof is used in all of the transactions,

--- a/XX.md
+++ b/XX.md
@@ -10,7 +10,7 @@ _TODO: should this, or a separate NUT, talked about the transport for all of thi
 
 _TODO: the mint could notice that the 2x2 P2PK swap happens just before two separate 1x1 swaps that add to the same amount, and therefore reasonably conclude that this was a channel. Should Alice and Charlie delay stage 2 in order to have a little more privacy?_
 
-_TODO: For a little more privacy (for those not using P2BPK) Alice and Charlie could specify two public keys, one for the 2-of-2 multisig in the funding and another in the 1-of-1 multisig that pays to each specifically? Or maybe we ignore this issue and just make use of Blinded keys throughout the channel, in cases where the receiver's wallet support it_
+_TODO: P2BPK is mentioned briefly as an option below; in theory it could be used if Charlie advertizes that he supports receiving payment that way. For those not using P2BPK, Alice and Charlie could specify two public keys, one for the 2-of-2 multisig in the funding and another in the 1-of-1 multisig that pays to each specifically. This might increase the privacy of non-P2BPK slightly._
 
 ---
 

--- a/XX.md
+++ b/XX.md
@@ -35,7 +35,7 @@ One of these 1-millisat proofs is a special proof that will be included in every
 Alice shall prepare one proof for every other power of 2: 2-millisats, 4-millisats, 8-millisats, ..., up to some pre-agreed maximum.
 The total value of all those proofs is the channel capacity and is the maximum amount that Alice can send to Bob through this channel
 
-Bob can verify all of these proofs with the mint, before going offline.
+Bob can verify all of these proofs with the mint using NUT-07, before going offline.
 
 # transactions
 

--- a/XX.md
+++ b/XX.md
@@ -46,7 +46,7 @@ In the second stage of the exit, Alice and Charlie swap their deterministic outp
 for conventional anyone-can-spend proofs.
 This also requires paying fees. These outputs are also in the same keyset as the funding token.
 
-The method for constructing the determistic outputs is described in more detail later in this document.
+The method for constructing the deterministic outputs is described in more detail later in this document.
 For now, we focus on the fees.
 Consider a function `deterministic_value_after_fees(x)` which constructs the
 deterministic outputs with _nominal_ value `x` and then substracts the fees that would
@@ -110,17 +110,15 @@ with `charlies_balance = 0`.
                     │ Charlie swaps                      │ Alice swaps
                     │ his outputs                        │ her outputs
                     ▼                                    ▼
-          ┌─────────┼─────────┐                ┌────────┼────────┐
-          │         │         │                │        │        │
-          ▼         ▼         │                ▼        ▼        │
-    ┌─────────┐ ┌──────────┐ │          ┌─────────┐ ┌──────────┐│
-    │Charlie's│ │Charlie's │ │          │ Alice's │ │ Alice's  ││
-    │ Final   │ │ Stage 2  │ │          │ Final   │ │ Stage 2  ││
-    │ Balance │ │ Fees     │ │          │ Balance │ │ Fees     ││
-    │         │ │          │ │          │         │ │          ││
-    └─────────┘ └──────────┘ │          └─────────┘ └──────────┘│
-                              │                                   │
-                              └───────────────────────────────────┘
+              ┌─────┴─────┐                        ┌─────┴─────┐
+              │           │                        │           │
+              ▼           ▼                        ▼           ▼
+        ┌─────────┐ ┌──────────┐            ┌─────────┐ ┌──────────┐
+        │Charlie's│ │Charlie's │            │ Alice's │ │ Alice's  │
+        │ Final   │ │ Stage 2  │            │ Final   │ │ Stage 2  │
+        │ Balance │ │ Fees     │            │ Balance │ │ Fees     │
+        │         │ │          │            │         │ │          │
+        └─────────┘ └──────────┘            └─────────┘ └──────────┘
 
 Where:
   Stage 1 Fees = (input_fee_ppk * n_funding_proofs + 999) // 1000
@@ -196,7 +194,7 @@ The commitment transaction spends all of the _funding token_, sending Charlie's 
 to deterministic outputs (defined below) that only Charlie can redeem, and the remainder
 are sent to deterministic outputs that are redeemable only by Alice
 
-## determistic outputs
+## deterministic outputs
 
 To construct the deterministic outputs, i.e. the set of _Blinded Messages_ that
 transfer a given amount to one of the two parties, we start with the set

--- a/XX.md
+++ b/XX.md
@@ -86,13 +86,13 @@ with `charlies_balance = 0`.
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                         FUNDING TOKEN                                   │
 │                  (total_value_of_funding_token)                         │
-│                                                                          │
-│  Created by Alice with P2PK proofs requiring both signatures (SIG_ALL) │
+│                                                                         │
+│  Created by Alice with P2PK proofs requiring both signatures (SIG_ALL)  │
 └─────────────────────────────────────────────────────────────────────────┘
                                   │
                                   │ STAGE 1: Swap funding token
                                   │
-                                  ▼
+                                  │
                     ┌─────────────┼─────────────┐
                     │             │             │
                     ▼             ▼             ▼
@@ -109,7 +109,7 @@ with `charlies_balance = 0`.
                     │ STAGE 2:                           │ STAGE 2:
                     │ Charlie swaps                      │ Alice swaps
                     │ his outputs                        │ her outputs
-                    ▼                                    ▼
+                    │                                    │
               ┌─────┴─────┐                        ┌─────┴─────┐
               │           │                        │           │
               ▼           ▼                        ▼           ▼

--- a/XX.md
+++ b/XX.md
@@ -32,7 +32,7 @@ When the channel is closing, there are two stages, and there are fees to be paid
 in each of those two stages.
 First, the _funding token_ token is swapped to create the _deterministic outputs_
 (defined below) for each of the two parties.
-Some of the deterministic outputs are P2PK-locked to Bob's public key, and the remainder
+Some of the deterministic outputs are P2PK-locked to Charlie's public key, and the remainder
 are of the deterministic outputs are P2PK-locked to Alice's public key.
 
 All the proofs in the _funding token_ are in the same _active_ keyset, with fee rate `input_fee_ppk`.
@@ -57,27 +57,33 @@ deterministic_value_after_fees(x)
     x - (input_fee_ppk * num_deterministic_outputs(x) + 999) // 1000
 ```
 
-To ensure that Bob's final balance is `bobs_balance`, Alice must compute the inverse
-of `deterministic_value_after_fees`, i.e. `x = inverse_deterministic_value(bobs_balance)`,
-which is the smallest `x` such that `deterministic_value_after_fees(x) = bobs_balance`.
+To ensure that Charlie's final balance is `charlies_balance`, Alice must compute the inverse
+of `deterministic_value_after_fees`, i.e. `x = inverse_deterministic_value(charlies_balance)`,
+which is the smallest `x` such that `deterministic_value_after_fees(x) = charlies_balance`.
 
-To make a payment which brings Bob's balance to `bobs_balance`, the following summarizes the values and fees:
+To make a payment which brings Charlie's balance to `charlies_balance`, the following summarizes the values and fees:
 
- - `x` = `inverse_deterministic_value(bobs_balance)`, the nominal value of Bob's deterministic outputs
- - `y` = `funding_token_total_value - x - (input_fee_ppk * n_funding_proofs + 999) // 1000`, the value that is left in the funding token to create Alice's deterministic outputs, after the remaining value is used for paying fees and creating Bob's deterministic outputs.
+ - `x` = `inverse_deterministic_value(charlies_balance)`, the nominal value of Charlie's deterministic outputs
+ - `y` = `funding_token_total_value - x - (input_fee_ppk * n_funding_proofs + 999) // 1000`, the value that is left in the funding token to create Alice's deterministic outputs, after the remaining value is used for paying fees and creating Charlie's deterministic outputs.
  - Alice is then left with `deterministic_value_after_fees(y)`, the final amount left in her wallet after swapping her determististic outputs into her wallet
 
-If the nominal value of the funding token is `total_value_of_funding_token`, then Bob's maximum balance is
-`total_value_of_funding_token - (input_fee_ppk * n_funding_proofs + 999) // 1000`.
-This is the `capacity`, and also represents that value that Alice can reclaim if the channel is closed
-with `bobs_balance = 0`.
+If the nominal value of the funding token is `total_value_of_funding_token`, then Charlie's maximum balance is
+
+```
+capacity
+ = 
+   deterministic_value_after_fees(total_value_of_funding_token - (input_fee_ppk * n_funding_proofs + 999) // 1000)
+```
+
+This `capacity`, and also represents that value that Alice can reclaim if the channel is closed
+with `charlies_balance = 0`.
 
 
 .... TODO: Ascii art showing the fees and how the values is distributed?
 
 .... TODO: tidy up the remainder of this, especially to sync with the fees issue discussed above
 
-... TODO: recommend that the first payment be for zero sats, to allow the channel to be instantly closed if Bob is unable to provide service now. Typically, therefore, Alice will provide two payments immediately the at the start ...
+... TODO: recommend that the first payment be for zero sats, to allow the channel to be instantly closed if Charlie is unable to provide service now. Typically, therefore, Alice will provide two payments immediately the at the start ...
 
 
 
@@ -90,7 +96,7 @@ Knowing Charlie's public key, and the set of mints and _units_ that are trusted 
  - `mint` string: URL of mint
  - `unit`: typically `sat` or `msat`
  - `total_value_of_funding_token`
- - `capacity`: the maximum balance that will be payable to Bob. Equals `total_value_of_funding_token - (input_fee_ppk * n_funding_proofs + 999) // 1000`, where `n_funding_proofs` is the number of proofs in the funding token.
+ - `capacity`: the maximum balance that will be payable to Charlie. Equals `total_value_of_funding_token - (input_fee_ppk * n_funding_proofs + 999) // 1000`, where `n_funding_proofs` is the number of proofs in the funding token.
  - `active_keyset_id`: An _active_ keyset for that unit at that mint
  - `input_fee_ppk`: As all the proofs in the funding token, and in the deterministic outputs, are in the same keyset, the `input_fee_ppk` is fixed.
  - `expiry`  unix timestamp: If Charlie doesn't close before this time, Alice can re-claim all the funds after this has expired
@@ -192,7 +198,7 @@ Deterministic Secret:
 ]
 ```
 
-_TODO? Optional: If Bob, along with his public key, advertizes that he supports pay-to-blinded-pubkey, we could determistically compute an ephemeral private key for blinding, and include the corresponding ephemeral public key in the proof, as per the P2BPK NUT_
+_TODO? Optional: If Charlie, along with his public key, advertizes that he supports pay-to-blinded-pubkey, we could determistically compute an ephemeral private key for blinding, and include the corresponding ephemeral public key in the proof, as per the P2BPK NUT_
 
 The corresponding blinding factor is `SHA256(channel_id || pubkey || amount || "blinding" || index)`,
 and so the deterministic output (BlindedMessage) is contructed by applying that

--- a/XX.md
+++ b/XX.md
@@ -1,0 +1,56 @@
+# NUT-XX: Offline Spillman (unidirectional) channel 
+
+`optional`
+
+`depends on: NUT-11`
+
+---
+
+Alice and Bob wish to set up a payment channel, such that Bob's balance starts at zero and his balance
+increases (unidirectional) over time. This is 'offline' because it allows - once the channel has been
+set up - for the two parties to transact simply by Alice sending signatures to Bob which Bob can verify
+without needing to contact the mint after each micropayment.
+
+Bob can then unilaterally exit at any time, by taking the latest signature to the mint.
+Alice can redeem the remainder after a certain pre-defined time has elapsed. A collaborative exit is
+also possible, allowing both parties to immediately redeem their closing balances.
+
+One simple alternative is for Alice to prepare a large number (millions perhaps) of tiny-denomination proofs
+in advance. However, that requires a lot of bandwidth and places heavy strain on the mint.
+This NUT describes how a smaller set of proofs, of various denominations, can solve the same
+problem, allowing potentially billions of payments with only a few dozen proofs.
+
+# Opening the channel
+
+Alice takes Bob's public key and, with any mint supporting NUT-11, creates a set of 2-of-2 multisig proofs
+of various denominations, where both Alice and Bob's signature is needed. Each of these proofs refunds to Alice after a pre-defined time (e.g. one week).
+SIG_ALL is used.
+
+## Denominations
+
+_This assumes that 1 millisat is the smallest 'resolution' of interest, but another resolution may be agreed_
+
+Alice shall prepare _2_ such proofs with 1-millisat value.
+One of these 1-millisat proofs is a special proof that will be included in every transaction.
+Alice shall prepare one proof for every other power of 2: 2-millisats, 4-millisats, 8-millisats, ..., up to some pre-agreed maximum.
+The total value of all those proofs is the channel capacity and is the maximum amount that Alice can send to Bob through this channel
+
+Bob can verify all of these proofs with the mint, before going offline.
+
+# transactions
+
+To update the balance, Alice shall take the special 1-millisat proof mentioned above, and combine it with
+whatever subset of the other proofs is needed to reach the new balance, and sign the combination and give the
+signature to Bob. Bob can verify this signature offline
+
+# double-spending, and unidirecionality
+
+As Alice is using SIG_ALL, and the special 1-millisat proof is used in all of the transactions,
+Bob can redeem only one of the transactions. If he attempts to redeem a second transaction, he will need to
+include the special proof (SIG_ALL), and the mint will see that the special proof has already been redeemed.
+As he can only redeem one transaction, and therefore one set of proofs that were signed together, he will redeem
+the most valuable transaction. This explains why these are unidirectional.
+
+# Fees
+
+???

--- a/XX.md
+++ b/XX.md
@@ -2,7 +2,7 @@
 
 `optional`
 
-`depends on: NUT-11, NUT-12`
+`depends on: NUT-11, NUT-12 (or we allow 07 as a substitute for 12?)`
 
 ---
 

--- a/XX.md
+++ b/XX.md
@@ -40,11 +40,9 @@ If there are `n_funding_proofs` proofs in that funding token, the fees of that s
 `(input_fee_ppk * n_funding_proofs + 999) // 1000`,
 where `//` rounds non-integer results down to an integer.
 
-In the second stage of the exit, Alice and Charlie swap these deterministic outputs
+In the second stage of the exit, Alice and Charlie swap their deterministic outputs
 for conventional anyone-can-spend proofs.
-This also requires paying fees. these outputs are also in the same keyset as the funding token.
-
-If there are non-zero fees, i.e. `input_fee_ppk > 0', Alice is responsible for paying all the fees.
+This also requires paying fees. These outputs are also in the same keyset as the funding token.
 
 The method for constructing the determistic outputs is described in more detail later in this document.
 For now, we focus on the fees.
@@ -69,8 +67,8 @@ To make a payment which brings Bob's balance to `bobs_balance`, the following su
  - `y` = `funding_token_total_value - x - (input_fee_ppk * n_funding_proofs + 999) // 1000`, the value that is left in the funding token to create Alice's deterministic outputs, after the remaining value is used for paying fees and creating Bob's deterministic outputs.
  - Alice is then left with `deterministic_value_after_fees(y)`, the final amount left in her wallet after swapping her determististic outputs into her wallet
 
-If the nominal value of the funding token is `raw_total_value_of_funding`, then Bob's maximum balance is
-`raw_total_value_of_funding - (input_fee_ppk * n_funding_proofs + 999) // 1000`.
+If the nominal value of the funding token is `total_value_of_funding_token`, then Bob's maximum balance is
+`total_value_of_funding_token - (input_fee_ppk * n_funding_proofs + 999) // 1000`.
 This is the `capacity`, and also represents that value that Alice can reclaim if the channel is closed
 with `bobs_balance = 0`.
 
@@ -91,7 +89,8 @@ Knowing Charlie's public key, and the set of mints and _units_ that are trusted 
  - `receiver_pubkey`: Charlie's key ?how exactly to encode this?
  - `mint` string: URL of mint
  - `unit`: typically `sat` or `msat`
- - `capacity`: the number of sats in the _funding token_ that Alice will create while funding the channel. _**If the fees are non-zero, Charlie's maximum possible balance will be less than the `capacity`**_
+ - `total_value_of_funding_token`
+ - `capacity`: the maximum balance that will be payable to Bob. Equals `total_value_of_funding_token - (input_fee_ppk * n_funding_proofs + 999) // 1000`, where `n_funding_proofs` is the number of proofs in the funding token.
  - `active_keyset_id`: An _active_ keyset for that unit at that mint
  - `input_fee_ppk`: As all the proofs in the funding token, and in the deterministic outputs, are in the same keyset, the `input_fee_ppk` is fixed.
  - `expiry`  unix timestamp: If Charlie doesn't close before this time, Alice can re-claim all the funds after this has expired
@@ -100,9 +99,11 @@ Knowing Charlie's public key, and the set of mints and _units_ that are trusted 
 
 The `channel_id` is the SHA256 hash of the '|'-delimited concatenation of all the above.
 
+_TODO: should the channel parameters have a `maximum_output_size`, to put an upper bound on the size of any deterministic output? This could help a little with privacy._
+
 # Funding the channel
 
-Alice, with the mint, creates a _funding token_ worth `capacity` units.
+Alice, with the mint, creates a _funding token_ worth `total_value_of_funding_token` units.
 Each proof in this token is a P2PK (NUT-11) proof which requires both signatures
 before the expiry of the channel, and where Alice's signature alone is sufficient afterwards:
 

--- a/XX.md
+++ b/XX.md
@@ -2,7 +2,7 @@
 
 `optional`
 
-`depends on: NUT-11`
+`depends on: NUT-11, NUT-12`
 
 ---
 
@@ -35,7 +35,7 @@ One of these 1-millisat proofs is a special proof that will be included in every
 Alice shall prepare one proof for every other power of 2: 2-millisats, 4-millisats, 8-millisats, ..., up to some pre-agreed maximum.
 The total value of all those proofs is the channel capacity and is the maximum amount that Alice can send to Bob through this channel
 
-Bob can verify all of these proofs with the mint using NUT-07, before going offline.
+Bob can verify all of these proofs with the mint using NUT-12, before going offline.
 
 When both Alice and Bob have all the following, the channel is open:
 
@@ -59,5 +59,5 @@ the most valuable transaction. This explains why these are unidirectional.
 
 # cooperative channel close
 
-?
+The above gives Bob unilateral exit with immediate access. Alice has to wait some time before she can collect the refund
 

--- a/XX.md
+++ b/XX.md
@@ -4,45 +4,45 @@
 
 `depends on: NUT-11 (P2PK), NUT-12 (DLEQ), NUT-09 (restore signatures), NUT-07 (token state check) (NUT-17 is beneficial, but not required)`
 
-_TODO: who pays the fees? (see the multi-swap zero-receiver-setup deterministic outputs below) If Alice spends 101 sats to fund the 'funding token' which has a _nominal_ value of 100 sats, and Bob's exit with the full capacity gives him just nominal 99 sats in his 1-of-1 P2PK outputs, which decrease to 98 sats when he finally swaps them to anyone-can-spend tokens in his wallet, then who should pay those fees? Which of those four numbers is the capacity of the network?_
+_TODO: who pays the fees? (see the multi-swap zero-receiver-setup deterministic outputs below) If Alice spends 101 sats to fund the 'funding token' which has a _nominal_ value of 100 sats, and Charlie's exit with the full capacity gives him just nominal 99 sats in his 1-of-1 P2PK outputs, which decrease to 98 sats when he finally swaps them to anyone-can-spend tokens in his wallet, then who should pay those fees? Which of those four numbers is the capacity of the network?_
 
 _TODO: question for the reviewer: Could we use pay-to-blinded-pubkey here? Where exactly? And should we make P2BPK required or optional?_
 
 ---
 
-Alice and Bob wish to set up a payment channel, funded by Alice, such that Bob's balance starts at zero and his balance
+Alice and Charlie wish to set up a payment channel, funded by Alice, such that Charlie's balance starts at zero and his balance
 increases (unidirectional) over time. This is 'offline' because it allows - once the channel has been
-set up - for the two parties to transact simply by Alice sending signatures to Bob which Bob can verify
+set up - for the two parties to transact simply by Alice sending signatures to Charlie which Charlie can verify
 without needing to contact the mint after each micropayment.
 A small number of swaps are needed to setup and to close the channel, but there is no mint involvement
 while the channel is open and while the channel payments are made.
 
-Knowing only Bob's pubkey and a mint trusted by him, Alice can set up the channel - via one swap with the mint - and make the
-first payment to Bob without any setup from Bob.
+Knowing only Charlie's pubkey and a mint trusted by him, Alice can set up the channel - via one swap with the mint - and make the
+first payment to Charlie without any setup from Charlie.
 
 # Trust
 
 Both parties trust the mint, but not each other.
-Bob can unilaterally exit at any time, by adding his signature to Alice's and swapping at the mint.
+Charlie can unilaterally exit at any time, by adding his signature to Alice's and swapping at the mint.
 That swap will spend all the 'funding proofs' that Alice prepared in the funding token, and the swap
 will also unlock Alice's outputs allowing her to immediately exit with her balance.
 
-If Bob never exits, then - after the predefined locktime has expired - all the funding becomes spendable
+If Charlie never exits, then - after the predefined locktime has expired - all the funding becomes spendable
 by Alice alone, allowing her to reclaim her funds.
 
 # The channel parameters, and channel_id
 
-Knowing Bob's public key, and the set of mints and _units_ that are trusted by Bob, and a minimum channel lifetime that Bob requires, Alice defines the channel parameters as follows:
+Knowing Charlie's public key, and the set of mints and _units_ that are trusted by Charlie, and a minimum channel lifetime that Charlie requires, Alice defines the channel parameters as follows:
 
  - `sender_pubkey`: Alice's key ?how exactly to encode this?
- - `receiver_pubkey`: Bob's key ?how exactly to encode this?
+ - `receiver_pubkey`: Charlie's key ?how exactly to encode this?
  - `mint` string: URL of mint
  - `unit`: typically `sat` or `msat`
- - `capacity`: the number of sats in the _funding token_ that Alice will create while funding the channel. _**If the fees are non-zero, Bob's maximum possible balance will be less than the `capacity`**_
+ - `capacity`: the number of sats in the _funding token_ that Alice will create while funding the channel. _**If the fees are non-zero, Charlie's maximum possible balance will be less than the `capacity`**_
  - `active_keyset_id`: An _active_ keyset for that unit at that mint
- - `expiry`  unix timestamp: If Bob doesn't close before this time, Alice can re-claim all the funds after this has expired
+ - `expiry`  unix timestamp: If Charlie doesn't close before this time, Alice can re-claim all the funds after this has expired
  - `setup_timestamp`: unix timestamp: the time when Alice is setting up this channel
- - `sender_nonce`: Random data selected by Alice to add more randomness. May be useful if Alice and Bob have multiple concurrent channels.
+ - `sender_nonce`: Random data selected by Alice to add more randomness. May be useful if Alice and Charlie have multiple concurrent channels.
 
 The `channel_id` is the SHA256 hash of the '|'-delimited concatenation of all the above.
 
@@ -53,20 +53,20 @@ Each proof in this token is a P2PK (NUT-11) proof which requires both signatures
 before the expiry of the channel, and where Alice's signature alone is sufficient afterwards:
 
  - `data`: Alice's key
- - `pubkeys`: Bob's key
+ - `pubkeys`: Charlie's key
  - `n_sigs`: 2
  - `locktime`: the `expiry` timestamp defined in the channel parameters
  - `refund`: Alice's key
  - `sig_flag`: `SIG_ALL`
 
 
-# Bob's verification
+# Charlie's verification
 
-The following information should be sent to Bob with, or before, the first payment in this channel,
-enabling Bob to verify everything. He can verify without communicating with the mint:
+The following information should be sent to Charlie with, or before, the first payment in this channel,
+enabling Charlie to verify everything. He can verify without communicating with the mint:
 
  - the channel parameters
- - the funding token, including the DLEQ proofs (NUT-12) allowing Bob to verify that the funding proofs have been signed.
+ - the funding token, including the DLEQ proofs (NUT-12) allowing Charlie to verify that the funding proofs have been signed.
 
 Both sides should store the funding proofs in the order that Alice created them, to ensure both sides can construct the relevant transactions deterministically.
 
@@ -74,11 +74,11 @@ Both sides should store the funding proofs in the order that Alice created them,
 
 Each payment requires Alice to update the balance and then construct the updated
 'commitment' transaction. She then signs the transaction and sends her signature
-and the new balance to Bob. This signature and amount, combined with the channel parameters,
-is sufficient for Bob to reconstruct the commitment transaction and verify the signature
+and the new balance to Charlie. This signature and amount, combined with the channel parameters,
+is sufficient for Charlie to reconstruct the commitment transaction and verify the signature
 
-The commitment transaction spends all of the _funding token_, sending Bob's balance
-to deterministic outputs (defined below) that only Bob can redeem, and the remainder
+The commitment transaction spends all of the _funding token_, sending Charlie's balance
+to deterministic outputs (defined below) that only Charlie can redeem, and the remainder
 are sent to deterministic outputs that are redeemable only by Alice
 
 ## determistic outputs
@@ -90,11 +90,11 @@ of amounts that are available in the keyset of the `active_keyset_id`.
 While it is common for mints to use powers-of-2, it is not required. (TODO: or is it?)
 
 Remember, the 'outputs' described here are just BlindedMessages and their blinding factors
-that are computed by Alice and Bob.
-They are _not_ sent to the mint until Bob decides to exit; many of the outputs computed
+that are computed by Alice and Charlie.
+They are _not_ sent to the mint until Charlie decides to exit; many of the outputs computed
 during the lifetime of a channel will never be seen by the mint.
 
-For a given target amount (Bob's balance, or Alice's remainder),
+For a given target amount (Charlie's balance, or Alice's remainder),
 we first identify the largest amount in the keyset which is less than
 the target amount. We'll use as many proofs as possible of this largest
 amount, as long as we don't exceed the target.
@@ -114,7 +114,7 @@ be created an ordered from smallest to biggest
 
 1, 1, 1, 10, 10, 10 , 10,  100, 100, 100, 100, 100
 
-Assuming these outputs are for Bob (the same procedure will be repeated for Alice's remainder),
+Assuming these outputs are for Charlie (the same procedure will be repeated for Alice's remainder),
 each output is created deterministically.
 Everything about the output (the secret, the BlindMessage, and the blinding factor)
 can be constructed by either party (and by any third party that knows all the channel parameters).
@@ -122,7 +122,7 @@ can be constructed by either party (and by any third party that knows all the ch
 When contructing the four 10-sat amounts, in this example, we have an _index_
 ranging from 0 to 3 inclusive to identify each of those four outputs.
 (Where the keyset amounts are just powers of 2, the index will never be non-zero.)
-Each output will be constructed as follows: the channel_id, pubkey(Bob in this case), amount (in this example, the power of ten), and the index are combined and hashed to compute the _deterministic nonce_ `SHA256(channel_id || pubkey || amount || "nonce" || index)`
+Each output will be constructed as follows: the channel_id, pubkey(Charlie in this case), amount (in this example, the power of ten), and the index are combined and hashed to compute the _deterministic nonce_ `SHA256(channel_id || pubkey || amount || "nonce" || index)`
 
 Deterministic Secret:
 
@@ -131,7 +131,7 @@ Deterministic Secret:
   "P2PK",
   {
     "nonce": "<deterministic nonce computed above>",
-    "data": "<Bob's pubkey>",
+    "data": "<Charlie's pubkey>",
     "tags": [["sigflag", "SIG_INPUTS"]]
   }
 ]
@@ -141,25 +141,25 @@ The corresponding blinding factor is `SHA256(channel_id || pubkey || amount || "
 and so the deterministic output (BlindedMessage) is contructed by applying that
 blinding factor to that secret in the usual way.
 
-That describes how Bob's balance is paid in the commitment transaction.
+That describes how Charlie's balance is paid in the commitment transaction.
 The same process is applied to send the remainder to Alice.
 
 # Commitment transaction, and balance update, in detail
 
 The commitment transaction can now be specified more clearly.
 It is a _swap_ which takes the _funding proof_ as input.
-The outputs start with the payments to Bob, ordered
+The outputs start with the payments to Charlie, ordered
 by amount and then by index, followed by Alice's outputs similarly ordered.
 
-Alice then signs this (SIG_ALL). Alice can then send three pieces of data to Bob: the `channel_id`, the balance for Bob, and her signature.
+Alice then signs this (SIG_ALL). Alice can then send three pieces of data to Charlie: the `channel_id`, the balance for Charlie, and her signature.
 
-As already mentioned, Alice must send the full set of channel parameters to Bob in the first payment -
+As already mentioned, Alice must send the full set of channel parameters to Charlie in the first payment -
 if she hasn't already sent them beforehard - but after this it is sufficient for her to send those
 three pieces of data.
 
-Bob can reconstruct the transaction and verify the signature.
+Charlie can reconstruct the transaction and verify the signature.
 
-Bob should maintain a dictionary mapping the `channel_id` to the current balance of that channel,
+Charlie should maintain a dictionary mapping the `channel_id` to the current balance of that channel,
 in order to ensure that Alice doesn't decrease the balance and to allow him to identify
 the magnitude of the increase in each payment.
 This map doesn't need to store any channels that have expired.
@@ -168,16 +168,16 @@ This map doesn't need to store any channels that have expired.
 
 Most of the commitment transactions are never sent to the mint.
 
-When Bob exits, he adds his signature to Alice's on the most recent transaction and sends the complete
+When Charlie exits, he adds his signature to Alice's on the most recent transaction and sends the complete
 swap to the mint. This swap spends the _funding token_ and returns
 blind signatures (the deterministic outputs, signed by the mint) for both parties.
 
-As the swap spends the entire funding token, Alice can detect Bob's spend
+As the swap spends the entire funding token, Alice can detect Charlie's spend
 via NUT-07 (token state check). NUT-17, if supported by the mint, helps here too.
 
-Bob should return Alice's blind signatures to her, but if he doesn't then Alice
+Charlie should return Alice's blind signatures to her, but if he doesn't then Alice
 can use NUT-09 to restore the signatures.
-While we assume that Bob will usually take the most recent commitment, as it's
+While we assume that Charlie will usually take the most recent commitment, as it's
 the most valuable, it is not guaranteed that he will do that.
 Alice can iterate over the amounts, and - for each amount - loop over the indices
 in order to reconstruct the deterministic output and restore the signature.
@@ -196,7 +196,7 @@ for amount in amounts_in_this_keyset:
 
 # Expiry
 
-Bob should remember to close channels as the expiry time closes.
+Charlie should remember to close channels as the expiry time closes.
 He should also keep a record of channel_ids that he has closed, where
 the expiry time has not been reached, in order to ensure that
 Alice does not attempt to reuse a channel that was already closed.

--- a/XX.md
+++ b/XX.md
@@ -2,7 +2,10 @@
 
 `optional`
 
-`depends on: NUT-11 (P2PK), NUT-12 (DLEQ)`
+`depends on: NUT-11 (P2PK), NUT-12 (DLEQ), (and probably NUT-09) too`
+
+_2025-11-01: we'll likely make a change to this, by signing over _all_ inputs, not just the inputs that are sufficient to cover Bob's latest balance.
+Combined with the restore endpoint (NUT-09), Alice will be able to get her refund immediately in the case of an uncooperative close.`._
 
 ---
 

--- a/XX.md
+++ b/XX.md
@@ -89,6 +89,11 @@ of amounts that are available in the keyset of the `active_keyset_id`.
 
 While it is common for mints to use powers-of-2, it is not required. (TODO: or is it?)
 
+Remember, the 'outputs' described here are just BlindedMessages and their blinding factors
+that are computed by Alice and Bob.
+They are _not_ sent to the mint until Bob decides to exit; many of the outputs computed
+during the lifetime of a channel will never be seen by the mint.
+
 For a given target amount (Bob's balance, or Alice's remainder),
 we first identify the largest amount in the keyset which is less than
 the target amount. We'll use as many proofs as possible of this largest
@@ -116,7 +121,7 @@ can be constructed by either party (and by any third party that knows all the ch
 
 When contructing the four 10-sat amounts, in this example, we have an _index_
 ranging from 0 to 3 inclusive to identify each of those four outputs.
-(Where the keyset amounts are just powers of 2, the index will never be non-zero)
+(Where the keyset amounts are just powers of 2, the index will never be non-zero.)
 Each output will be constructed as follows: the channel_id, pubkey(Bob in this case), amount (in this example, the power of ten), and the index are combined and hashed to compute the _deterministic nonce_ `SHA256(channel_id || pubkey || amount || "nonce" || index)`
 
 Deterministic Secret:
@@ -154,7 +159,7 @@ three pieces of data.
 
 Bob can reconstruct the transaction and verify the signature.
 
-Bob should maintain a dictionary mapping the channel to the current balance of that channel,
+Bob should maintain a dictionary mapping the `channel_id` to the current balance of that channel,
 in order to ensure that Alice doesn't decrease the balance and to allow him to identify
 the magnitude of the increase in each payment.
 This map doesn't need to store any channels that have expired.
@@ -174,7 +179,7 @@ Bob should return Alice's blind signatures to her, but if he doesn't then Alice
 can use NUT-09 to restore the signatures.
 While we assume that Bob will usually take the most recent commitment, as it's
 the most valuable, it is not guaranteed that he will do that.
-Alice can iterate over the amounts, for - for each amount - loop over the indices
+Alice can iterate over the amounts, and - for each amount - loop over the indices
 in order to reconstruct the deterministic output and restore the signature.
 When a given restoration fails, she can stop increasing the _index_ and
 move on to the next amount instead.
@@ -194,7 +199,7 @@ for amount in amounts_in_this_keyset:
 Bob should remember to close channels as the expiry time closes.
 He should also keep a record of channel_ids that he has closed, where
 the expiry time has not been reached, in order to ensure that
-Alice does not attempt to reuse a channel.
+Alice does not attempt to reuse a channel that was already closed.
 
 
 # Channel capacity

--- a/XX.md
+++ b/XX.md
@@ -49,9 +49,9 @@ Alice, the sender, takes Charlie's public information - such as his public key a
 and units and keysets that he trusts - and she defines the _channel parameters_ including
 the capacity and the expiry and so on.
 There is a corresponding _channel id_, which is defined deterministically from those parameters
-and also from a _channel secret_ derived via Diffie Hellman.
+and also from a _channel secret_ derived via Diffie-Hellman.
 
-*Determinism*. From this point onwards, everything - except the the signatures from the mint and the
+*Determinism*. From this point onwards, everything - except the signatures from the mint and the
 signatures from both parties - is
 deterministic and is known to both parties.
 The amounts of the individual outputs and blinding factors in the
@@ -120,7 +120,7 @@ until he decides to close the channel.
 
 > [!NOTE]
 > _Blinding_ The term 'blinding' is used in two different contexts here.
-> One context is the _blinding factor_ which is applied to every every secret in Cashu,
+> One context is the _blinding factor_ which is applied to every secret in Cashu,
 > creating the `BlindedMessage` (aka _output_) which is then signed by the mint.
 > This blinding factor is computed deterministically as described below.
 > Also, we blind the public keys that are used as the pubkeys to which the tokens
@@ -250,9 +250,9 @@ they are not considered as available to this amount-selection algorithm.
 If `params.maximum_amount_for_one_output` is zero, then no filtering is
 applied and all the keyset's amounts are available.
 
-The algorithm greedily takes the largest amount,
-smaller than that maximum amount,
-until it can't take any more as it would overflow the target.
+The algorithm greedily takes the largest available amount
+that is allowed by `maximum_amount_for_one_output`,
+until it can't take any more without overflowing the target.
 Then it moves on to the next-smallest amount repeatedly
 until the target is reached. Here is a pseudocode implementation:
 
@@ -323,7 +323,7 @@ The fee rate is `input_fee_ppk` for all the outputs in the channel,
 as we assume the same keyset is used in all outputs,
 Therefore, the post-swap value of any set of deterministic outputs
 can be computed as follows, where `num_deterministic_outputs(x)` is
-the number of outputs selected by the determistic algorithm described
+the number of outputs selected by the deterministic algorithm described
 above.
 
 ```
@@ -473,8 +473,9 @@ they are blinded differently because they use different derivation contexts
 (`sender_stage1` and `sender_stage1_refund`), and therefore the mint cannot
 see that `data` and `refund` correspond to the same underlying party.
 
-As the swap that spends this funding token use SIG_ALL, the same blinding is used for every output
-in the funding token.
+As the swap that spends this funding token uses SIG_ALL, the same stage-1 pubkey blinding applies
+to every funding output. The deterministic nonce and blind-signature blinding factor are still
+derived separately for each output.
 
 Example funding token secret (JSON):
 
@@ -594,12 +595,12 @@ context    | amount | index
 > [!NOTE]
 > If you have a vector of Charlie's outputs, ordered by increasing amount and index,
 > and then you append Alice's similarly ordered,
-> then you can apply a _stable sort_, such as Rust's `all_outputs.sort_by_key(|(output, _)| output.amount)` or Python's `sorted(all_outputs, key = lambma o: o.amount` to get the required ordering.
+> then you can apply a _stable sort_, such as Rust's `all_outputs.sort_by_key(|(output, _)| output.amount)` or Python's `sorted(all_outputs, key=lambda o: o.amount)` to get the required ordering.
 
 Alice then signs this (`SIG_ALL`).
 Alice can then send three pieces of data to Charlie: the `channel_id`, the balance for Charlie, and her signature.
 
-As already mentioned, Alice must send the full set of channel parameters to Charlie in the first payment - if she hasn't already sent them beforehard -
+As already mentioned, Alice must send the full set of channel parameters to Charlie in the first payment - if she hasn't already sent them beforehand -
 but after this it is sufficient for her to send those three pieces of data.
 
 # Closing the channel

--- a/XX.md
+++ b/XX.md
@@ -184,9 +184,8 @@ and a minimum channel lifetime that Charlie requires, Alice defines the channel 
  - `input_fee_ppk`: the fee rate for that keyset.
  - `maximum_amount_for_one_output`: used in the deterministic amount-selection algorithm as an upper bound on the size of any individual output in the funding token or in the commitment outputs. May be helpful with privacy, in the case of large-capacity channels.
 
- - `expiry`  unix timestamp: If Charlie doesn't close before this time, Alice can re-claim all the funds after this has expired
+ - `expiry_timestamp`  unix timestamp: If Charlie doesn't close before this time, Alice can re-claim all the funds after this has expired
  - `setup_timestamp` unix timestamp: the time when Alice is setting up this channel
- - `sender_nonce`: Random data selected by Alice to add more randomness. May be useful if Alice and Charlie have multiple channels with otherwise-identical parameters.
 
 There is also a _shared secret_, computed via Diffie Helman using the
 keys of the two parties.
@@ -430,8 +429,8 @@ Where:
 - `"data"` contains Alice's blinded pubkey.
 - The `"pubkeys"` tag contains Charlie's blinded pubkey.
 - The `"refund"` tag contains Alice's blinded pubkey.
-- `"n_sigs": "2"` requires both Alice and Charlie's signatures before locktime
-- After locktime, Alice can spend alone using her refund blinded secret key
+- `"n_sigs": "2"` requires both Alice and Charlie's signatures before the NUT-11 `locktime` tag, which is derived from the channel's `expiry_timestamp`
+- After that `locktime`, Alice can spend alone using her refund blinded secret key
 
 ## Commitment Output Secrets (1-of-1 with Per-Proof Blinded Pubkeys)
 
@@ -552,7 +551,7 @@ When closing the channel, both parties sign with their **blinded** secret keys:
 
 These signatures verify against the blinded pubkeys in the funding token.
 
-For the **locktime refund path**, Alice signs with her **refund** blinded secret key derived from `p2bk_context = "sender_stage1_refund"`. This key corresponds to the blinded pubkey in the `refund` tag.
+For the refund path controlled by the NUT-11 `locktime` tag (derived from `expiry_timestamp`), Alice signs with her **refund** blinded secret key derived from `p2bk_context = "sender_stage1_refund"`. This key corresponds to the blinded pubkey in the `refund` tag.
 
 When spending the commitment outputs in stage 2:
 - **Charlie** signs each of his proofs with the per-proof blinded secret key for that `(amount, index)`, as described above.

--- a/XX.md
+++ b/XX.md
@@ -2,7 +2,7 @@
 
 `optional`
 
-`depends on: NUT-11 (P2PK), NUT-12 (DLEQ), NUT-09 (restore signatures), NUT-07 (token state check), NUT-?28? P2BK, (NUT-17 is beneficial, but not required)`
+`depends on: NUT-11 (P2PK), NUT-12 (DLEQ), NUT-09 (restore signatures), NUT-07 (token state check), NUT-28 (P2BK), (NUT-17 is beneficial, but not required)`
 
 ---
 
@@ -32,7 +32,7 @@ final balances into their wallets.
 No change or extension to the mint's behaviour is needed.
 The mint simply sees and executes standard P2PK swaps.
 The mint doesn't know that there is a channel, due to various techniques - including
-pay-to-blinded-pubkey (... NUT-28? ...) - which make it difficult for
+pay-to-blinded-pubkey (NUT-28) - which make it difficult for
 the mint to correlate the swaps and tokens.
 
 This document doesn't discuss transport of the payments.
@@ -423,18 +423,27 @@ The deterministic process is a function of five things:
 As these are all deterministic and based on information known to both parties,
 both parties can construct all these outputs and secrets and blinding factors.
 
-The secret's _nonce_ is computed as follows:
+The secret's _nonce_ and the blind-signature _blinding factor_ are computed as follows:
 
 ```
 deterministic_nonce(...)
  =
    SHA256(channel_secret || "{channel_id}|{output_context}|{amount}|nonce|{index}")
+
+blinding_factor(...)
+ =
+   SHA256(channel_secret || "{channel_id}|{output_context}|{amount}|blinding|{index}")
 ```
+
+where `output_context` is one of `funding`, `sender` or `receiver`.
+The `blinding_factor` here is the per-proof factor used in the Cashu blind-signature
+scheme; it is separate from the pubkey-tweak derivations described below.
 
 ## Funding Token Secret (2-of-2 with Blinded Pubkeys)
 
 The keys are blinded. Later, we discuss how the 1-of-1 keys for the commitment outputs
-are blinded using a NUT-28-style shared-secret scheme. But a simpler deterministic
+are blinded using a NUT-28-style shared-secret scheme.
+But (for now, we should change to NUT-28 for this too), a simpler deterministic
 scalar-tweak scheme is used for the 2-of-2 keys - and refund key - in the funding token.
 For the funding token, the blinded pubkeys are derived directly from
 context-specific scalars of the form:
@@ -448,7 +457,8 @@ where `context` is one of:
 - `receiver_stage1`
 - `sender_stage1_refund`
 
-The `retry_counter` is incremented until a valid nonzero scalar is found.
+The `retry_counter` is incremented until a valid scalar is found,
+i.e. one in the range `1 <= s < n` where `n` is the secp256k1 group order.
 That scalar is then applied directly to the relevant party's pubkey, with
 BIP-340 parity handling, to derive the blinded pubkey.
 While Alice and Charlie know the tweaks that are applied, the mint (Bob) does not.
@@ -488,8 +498,8 @@ Example funding token secret (JSON):
 Where:
 - `"data"` contains Alice's blinded pubkey.
 - The `"pubkeys"` tag contains Charlie's blinded pubkey.
-- The `"refund"` tag contains Alice's blinded pubkey.
-- `"n_sigs": "2"` requires both Alice and Charlie's signatures before the NUT-11 `locktime` tag, which is derived from the channel's `expiry_timestamp`
+- The `"refund"` tag contains Alice's blinded _refund_ pubkey.
+- `"n_sigs": "2"` requires both Alice and Charlie's signatures before the NUT-11 `locktime` tag, which is the channel's `expiry_timestamp`
 - After that `locktime`, Alice can spend alone using her refund blinded secret key
 
 ## Commitment Output Secrets (1-of-1 with Per-Proof Blinded Pubkeys)
@@ -507,8 +517,9 @@ ephemeral_secret = SHA256(
 )
 ```
 
-where `stage2_context` is `receiver_stage2` or `sender_stage2`.
-The `retry_counter` is incremented until a valid secret key is found.
+where `stage2_context` is `receiver_stage2` or `sender_stage2`, for Charlie's balance and Alice's remainder respectively.
+The `retry_counter` is incremented until the hash yields such a valid scalar
+for use as the ephemeral secret key.
 
 Then an ECDH shared secret is computed between that ephemeral private key and
 the recipient's public key, and the NUT-28 tweak scalar is derived as:
@@ -517,13 +528,12 @@ the recipient's public key, and the NUT-28 tweak scalar is derived as:
 stage2_tweak_scalar = SHA256("Cashu_P2BK_v1" || shared_secret_x || 0x00)
 ```
 
-If that does not yield a valid nonzero scalar, the current implementation
-retries with an extra trailing `0xff` byte, matching the NUT-28-style fallback
-used in the code.
+If that does not yield a valid scalar, the current implementation
+retries with an extra trailing `0xff` byte.
 
-That scalar is then applied to the recipient's pubkey using the
-NUT-28 / BIP-340 parity rules to derive the blinded pubkey for that
-specific `(amount, index)` output.
+That scalar is then applied to the recipient's pubkey, where the recipient
+can then use the NUT-28 / BIP-340 parity rules to derive the corresponding private key
+for that specific `(amount, index)` output.
 
 Example commitment output secret for Charlie (JSON):
 
@@ -556,24 +566,6 @@ Example commitment output secret for Alice (JSON):
 The `"data"` field contains Alice's blinded pubkey derived as described above.
 No explicit `sigflag` tag is required here; a missing or `null` tag set is interpreted as the default `SIG_INPUTS` behavior.
 
-## Blinding Factor for Blind Signatures
-
-The blinding factor (for the Cashu blind signature scheme) is computed separately from the P2BK blinding:
-
-```
-blinding_factor = SHA256(channel_secret || "{channel_id}|{context}|{amount}|blinding|{index}")
-```
-
-where `context` is one of "funding", "sender" or "receiver".
-
-This is used to blind the secret before sending to the mint, and to unblind the mint's signature.
-
-Every output in this system, i.e. those in the funding token and also those which result when
-spending the funding, is fully deterministic and can be created by either party but not by the mint.
-The determinism covers the amounts, the `Secret.nonce`, the blinding of the pubkeys, and
-also the blinding factor that is applied to the Secret to generate the BlindedMessage which
-is sent to the mint as input to any swap.
-
 # Order of outputs in the commitment transaction
 
 The commitment transaction can now be specified more completely.
@@ -587,16 +579,16 @@ those for Alice.
 They are ordered by amount (increasing). For any given amount,
 we have Charlie's deterministic outputs first, ordered by _index_ (increasing),
 and then Alice's similarly ordered. For example, if you're distributing
-a few hundred sats to each party, the first few outputs of the swap are:
+a few hundred sats to each party with a powers-of-10 mint, the last few outputs of the swap are:
 
 ```
 context    | amount | index
 
+... preceded by the 10-sat outputs ...
 "receiver" | 100    |     0
 "receiver" | 100    |     1
 "sender"   | 100    |     0
 "sender"   | 100    |     1
-... followed by the 10-sat outputs ...
 ```
 
 > [!NOTE]
@@ -619,9 +611,13 @@ sends the complete swap to the mint.
 This swap spends the _funding token_ and returns
 blind signatures (the deterministic outputs, signed by the mint) for both parties.
 
-The two parties can cooperatively close using any balance, including a balance
+Alternatively, the two parties can cooperatively close using any balance, including a balance
 smaller than the most recent signed transaction, by applying both of their signatures
 and swapping.
+Some systems using these channel payments will involve some overpayments by the client,
+for example where the precise cost of a given request isn't known in advance, and therefore
+an honest server will allow the client to close the channel with the exact final payment instead of
+the overpayment.
 
 ## Signing with Blinded Secret Keys
 
@@ -684,11 +680,11 @@ enabling Charlie to verify everything. He can verify without communicating with 
  - the channel parameters
  - the funding token, including the DLEQ proofs (NUT-12)
 
-Charlie can then verify that the parameters are acceptable to him; he can check:
+Charlie can then verify that the parameters are acceptable to him, by checking:
 
  - that the expiry time is reasonably far in the future
  - that the mint is a mint that he trusts, and the keyset is active for the correct `unit`
- - that the channel_id is computed correctly
+ - that the channel_id is computed correctly based on the parameters and the _channel secret_
  - the DLEQ proofs in the funding token are correct
  - the secrets in the funding token have the correct deterministic P2PK setup, with the keys and expiry and so on
  - the blinded pubkeys in the funding token are correctly derived:
@@ -711,7 +707,7 @@ Alice does not attempt to reuse a pre-expiry channel that was already closed.
 Charlie should maintain a mapping from the channel_id to the balance, to ensure that
 Alice doesn't attempt to decrease the balance or otherwise attempt to reuse an older channel.
 Alternatively, Charlie could maintain a per-channel record of the amount of service that
-has been provided (image files server, LLM tokens used, kilobytes of data routed by a router ...)
+has been provided (image files served, LLM tokens used, kilobytes of data routed by a router ...)
 and ensure that each new balance is sufficient to cover the amount due to Charlie for
 the service.
 
@@ -728,9 +724,9 @@ commitment transaction that is formed deterministically will also have unspent o
 
 To improve privacy further, when the channel is closed and the first of the two stages
 is executed, both parties should delay the second stage.
-This delay is to make it more difficult for the mint to correlate the swaps with each other.
+This delay is to make it more difficult for the mint to correlate the three 'exit swaps' with each other.
 
 
 # proof-of-concept
 
-_As of 2026-01-13, the implementation includes P2BK (Pay-to-Blinded-Key) with per-proof blinding for stage 2 outputs. The funding and commitment outputs are deterministic with blinded pubkeys. Fees are taken into account fully. The token-state-check and token-restore endpoints are used. The implementation is [here](https://github.com/SatsAndSports/demo_of_spillman_cashu_channel/tree/spilman.channel/crates/cdk/src/spilman), with integration tests verifying blinded signatures are accepted by the mint._
+_As of 2026-03-20, the implementation includes P2BK (Pay-to-Blinded-Key) with per-proof blinding for stage 2 outputs. The funding and commitment outputs are deterministic with blinded pubkeys. Fees are taken into account fully. The token-state-check and token-restore endpoints are used. The implementation is [here](https://github.com/SatsAndSports/demo_of_spillman_cashu_channel/tree/spilman.channel/crates/cdk/src/spilman), with many integration tests._

--- a/XX.md
+++ b/XX.md
@@ -40,15 +40,26 @@ This doesn't discuss how prices will be negotiated.
 This document is purely cryptographic, specifying the outputs (`BlindedMessage`) to use, and
 what is needed to construct and sign and verify the transactions.
 
-# Overview and terminology
+# Overview and terminology and determinism
 
 Before defining everything in detail, we summarize the overall flow in order
 to introduce and clarify terminology.
 
 Alice, the sender, takes Charlie's public information - such as his public key and the mints
-and units and keysets that he trusts - and defines the _channel parameters_.
+and units and keysets that he trusts - and she defines the _channel parameters_ including
+the capacity and the expiry and so on.
 There is a corresponding _channel id_, which is defined deterministically from those parameters
 and also from a _channel secret_ derived via Diffie Hellman.
+
+*Determinism*. From this point onwards, everything - except the the signatures from the mint and the
+signatures from both parties - is
+deterministic and is known to both parties.
+The amounts of the individual outputs and blinding factors in the
+funding token are a deterministic function of the channel parameters,
+as are the tweaks that are applied to the public keys
+of both parties.
+Given a payment amount (the 'balance'), the swap which redistributes the funding
+token to both parties is deterministic.
 
 Alice computes the _funding outputs_ , i.e. BlindedMessages, and then pays
 the mint (Bob) via a _swap_ or _mint_ to sign those outputs.
@@ -72,8 +83,8 @@ Each payment increases the balance in favour of Charlie.
 Unless otherwise specified, _balance_ will always refer to
 Charlie's balance.
 
-Alice makes the payment by sending three pieces of data to Charlie:
-the channel id, the new balance for charlie, and her signature.
+Alice makes a payment by sending three pieces of data to Charlie:
+the channel id, the new balance for Charlie, and her signature.
 For every payment except the final payment for a given channel, Charlie
 will simply verify and store the payment and will not contact the mint.
 For each channel, Charlie needs to store only one balance and signature.
@@ -95,10 +106,10 @@ and then she can spend all of the _funding token_ with just her signature.
 There are three kinds of blinded P2PK outputs, the _funding outputs_ and the
 _commitment outputs_ for each of the two parties.
 All of these outputs are _deterministic_; the output's _secret_ (including the _nonce_)
-and the _blinding factor_ can be computed by both Alice and Bob
+and the _blinding factor_ can be computed by both Alice and Charlie
 based on the data available to both of them:
 the channel parameters, the channel secret, and the amount of the current _balance_.
-This determinism minimizes the communication that is needed between Alice and Bob.
+This determinism minimizes the communication that is needed between Alice and Charlie.
 
 At the end of this NUT, we define all the steps that Charlie should take
 to verify everything.
@@ -113,7 +124,7 @@ until he decides to close the channel.
 > creating the `BlindedMessage` (aka _output_) which is then signed by the mint.
 > This blinding factor is computed deterministically as described below.
 > Also, we blind the public keys that are used as the pubkeys to which the tokens
-> are locked, in accordance with NUT-28, as described below.
+> are locked.
 
 # Fees
 
@@ -187,8 +198,15 @@ and a minimum channel lifetime that Charlie requires, Alice defines the channel 
  - `mint` string: URL of mint
  - `unit`: typically `sat` or `msat`
  - `capacity`: the maximum balance that will be payable to Charlie.
+ - `funding_token_amount`: the total nominal value of the funding token.
+   This is an explicit channel parameter.
+   It must satisfy
+   `capacity <= deterministic_value_after_fees(deterministic_value_after_fees(funding_token_amount))`.
+   Typically Alice chooses the minimum value satisfying that constraint, as described below.
 
- - `active_keyset_id`: An _active_ keyset for that unit at that mint
+ - `keyset_id`: a keyset for that unit at that mint.
+   It would normally be active when the channel is created, but it is not required
+   to remain active throughout the lifetime of the channel.
  - `input_fee_ppk`: the fee rate for that keyset.
  - `maximum_amount_for_one_output`: used in the deterministic amount-selection algorithm as an upper bound on the size of any individual output in the funding token or in the commitment outputs. May be helpful with privacy, in the case of large-capacity channels.
 
@@ -203,7 +221,17 @@ Diffie-Hellman value is never used directly:
 channel_secret = SHA256("Cashu_Spilman_channel_secret_v1" || ECDH(alice_secret, charlie_pubkey))
 ```
 
-The `channel_id` is the SHA256 hash of the concatenation of all the parameters, including the _channel secret_.
+The `channel_id` is the SHA256 hash of the following pipe-delimited string:
+
+```
+mint | unit | capacity | funding_token_amount |
+keyset_id | input_fee_ppk | maximum_amount_for_one_output |
+setup_timestamp | sender_pubkey | receiver_pubkey |
+expiry_timestamp | hex(channel_secret)
+```
+
+The public keys are represented in hex, and `channel_secret` is hex-encoded before
+being inserted into that string.
 
 The channel secret is to add a little extra privacy here, by making it more difficult
 for a third party, especially the mint, to predict what the `channel_id` might be.
@@ -213,9 +241,10 @@ want any third party, especially the mint, to be able to tie that id to the publ
 # Deterministic selection of amounts
 
 To construct the deterministic outputs in the funding token and also
-in the commitment outputs, we start with the target amount we
-wish to reach and the set
-of amounts that are available in the keyset of the `active_keyset_id`.
+in the commitment outputs, we use this algorithm to decide the amounts of
+the individual proofs.
+We start with the target amount we wish to reach and the set
+of amounts that are available in the keyset of the `keyset_id`.
 We ignore any amounts greater than `params.maximum_amount_for_one_output`,
 they are not considered as available to this amount-selection algorithm.
 If `params.maximum_amount_for_one_output` is zero, then no filtering is
@@ -329,12 +358,12 @@ without forcing them to skip any of these special values.
 # Creating the funding token
 
 Where `capacity` is one of the channel parameters and specifies the maximum
-possible balance for Charlie, Alice must create the funding token with this
-value:
+possible balance for Charlie, the minimum value of `funding_token_amount`
+is:
 
 ```
-total_funding_token_amount
-   = inverse_deterministic_value(
+funding_token_amount
+   >= inverse_deterministic_value(
         inverse_deterministic_value(capacity)
      )
 ```
@@ -342,10 +371,13 @@ total_funding_token_amount
 There are two applications of `inverse_deterministic_value` there because Charlie will
 perform two swaps during his exit.
 
-The fees in the first stage will always be `total_funding_token_amount - deterministic_value_after_fees(total_funding_token_amount)`.
-The fees in the second stage can vary, as they depend on the distribution between the two parties.
+This `funding_token_amount` and the `capacity` are channel parameters.
 
-To make a payment which brings Charlie's balance to `balance`, the following describes how Alice computes the values of the various parts.
+The fees in the first stage will always be `funding_token_amount - deterministic_value_after_fees(funding_token_amount)`.
+The fees in the second stage can vary, as they depend on the distribution between the two parties, and also due
+to the _Keyset Malleability_ issue discussed above.
+
+To make a payment which brings Charlie's balance to `balance`, the following describes how Alice computes the values of the various parts:
 
  - `balance`, we start our computation with this, the balance that we wish Charlie to have in this transaction.
  - `c` = `inverse_deterministic_value(balance)`, the nominal value of Charlie's commitment outputs.
@@ -363,20 +395,17 @@ total_funding_token_amount
    + stage1fees  # the fees taken by the mint in this swap
 ```
 
-where `c = balance + stage2fees_for_charlie`
-and   `a = alices_final_balance + stage2fees_for_alice`
+where `c = balance + stage2fees_when_charlie_completes_his_exit`
+and   `a = alices_final_balance + stage2fees_when_alice_completes_her_exit`
 take account of the fees that are paid by each party in the second stage.
-
-_... TODO: maybe we should recommend that the first payment be for zero sats, to allow the channel to be instantly closed by Charlie if he is unable to provide service now. Typically, therefore, Alice will provide two payments immediately the at the start, one with zero sats and another with the first 'real' payment ..._
 
 # Deterministic outputs: secrets, nonces, and blinding factors
 
 When Alice is creating the funding token, and when either party is creating
-the outputs to be signed in the swap, they must create them using the algorithm
-descibed in 'Deterministic selection of amounts' described above.
+the outputs to be signed in the swap, they must use the algorithm
+described above in 'Deterministic selection of amounts' to decide the amounts.
 In doing so, they will have the _amount_ and _index_ for each output.
-Everything about these outputs is deterministic, including the `Secret.nonce`,
-and also the _blinding factor_.
+Everything about these outputs is deterministic, including the `Secret.nonce` and also the _blinding factor_.
 
 The deterministic outputs are created in one of three `context` values:
  - `context = "funding"` for creating the funding token, where each secret is 2-of-2 P2PK with blinded pubkeys
@@ -388,7 +417,7 @@ The deterministic process is a function of five things:
  - the `channel_id`, the hex representation of the channel_id.
  - the `context` as a string
  - the `amount` in decimal representation, e.g. "32" for 32 satoshis
- - the `index` in decimal representation. (As this is rarely be greater than, an probably never greater than 255, then maybe this should just be represented as one byte?)
+ - the `index` in decimal representation.
  - the `channel_secret` mentioned earlier. Using this ensures that the mint cannot compute the outputs even if they know the channel_id.
 
 As these are all deterministic and based on information known to both parties,
@@ -399,14 +428,29 @@ The secret's _nonce_ is computed as follows:
 ```
 deterministic_nonce(...)
  =
-   SHA256(channel_secret || channel_id || output_context || amount || "nonce" || index)
+   SHA256(channel_secret || "{channel_id}|{output_context}|{amount}|nonce|{index}")
 ```
 
 ## Funding Token Secret (2-of-2 with Blinded Pubkeys)
 
-The keys are blinded following NUT-?28?, where an ephemeral public key (called `p2pk_e` in that NUT)
-is generated deterministically and that key is then used to derive a
-tweak that can be applied to each pubkey.
+The keys are blinded. Later, we discuss how the 1-of-1 keys for the commitment outputs
+are blinded using a NUT-28-style shared-secret scheme. But a simpler deterministic
+scalar-tweak scheme is used for the 2-of-2 keys - and refund key - in the funding token.
+For the funding token, the blinded pubkeys are derived directly from
+context-specific scalars of the form:
+
+```
+r = SHA256("Cashu_Spilman_P2BK_v1" || channel_secret || "{channel_id}|{context}|{retry_counter}")
+```
+
+where `context` is one of:
+- `sender_stage1`
+- `receiver_stage1`
+- `sender_stage1_refund`
+
+The `retry_counter` is incremented until a valid nonzero scalar is found.
+That scalar is then applied directly to the relevant party's pubkey, with
+BIP-340 parity handling, to derive the blinded pubkey.
 While Alice and Charlie know the tweaks that are applied, the mint (Bob) does not.
 
 The funding token uses a 2-of-2 P2PK secret with three blinded pubkeys:
@@ -414,10 +458,10 @@ The funding token uses a 2-of-2 P2PK secret with three blinded pubkeys:
 - `pubkeys` tag: Charlie's blinded pubkey
 - `refund` tag: Alice's refund blinded pubkey
 
-_(Needs more clarity: ...)_ For the 2-of-2 P2PK secret in the funding token, an ephemeral _private_ key is computed as `SHA256("ChannelFundingP2BK" || channel_secret || channel_id)`. That gives us the corresponding
-ephemeral public key `p2pk_e`. Following that NUT, there is a process which takes that p2pk_e and the recipient's key (params.sender_pubkey or params.receiver_pubkey), and the position of that key in the secret, and tweaks it.
-
-While Alice is the intended recipient of both the `data` and `refund` key, NUT-28 blinds them differently due to their position in the P2PK Secret, and therefore the mint cannot see that `data == refund`.
+While Alice is the intended recipient of both the `data` and `refund` key,
+they are blinded differently because they use different derivation contexts
+(`sender_stage1` and `sender_stage1_refund`), and therefore the mint cannot
+see that `data` and `refund` correspond to the same underlying party.
 
 As the swap that spends this funding token use SIG_ALL, the same blinding is used for every output
 in the funding token.
@@ -452,10 +496,34 @@ Where:
 
 Each commitment output is locked to a **unique** blinded pubkey derived from the specific `(amount, index)` of that output.
 
-_(Needs more clarity: ...)_ For the 1-of-1 P2PK secret in the commitment outputs, an ephemeral _private_ key is computed as `SHA256("ChannelClosingP2BK" || <"receiver" or "sender"> || channel_secret || channel_id || amount || index)`.
-That gives us the corresponding
-ephemeral public key `p2pk_e` for this particular output.
-Following that NUT, there is a process which takes that p2pk_e and the recipient's key (params.sender_pubkey or params.receiver_pubkey), and the position of that key in the secret, and tweaks it.
+For the 1-of-1 P2PK secret in the commitment outputs, a per-output
+ephemeral private key is computed as:
+
+```
+ephemeral_secret = SHA256(
+    "Cashu_Spilman_P2BK_ephemeral_v1" ||
+    channel_secret ||
+    "{channel_id}|{stage2_context}|{amount}|{index}|{retry_counter}"
+)
+```
+
+where `stage2_context` is `receiver_stage2` or `sender_stage2`.
+The `retry_counter` is incremented until a valid secret key is found.
+
+Then an ECDH shared secret is computed between that ephemeral private key and
+the recipient's public key, and the NUT-28 tweak scalar is derived as:
+
+```
+stage2_tweak_scalar = SHA256("Cashu_P2BK_v1" || shared_secret_x || 0x00)
+```
+
+If that does not yield a valid nonzero scalar, the current implementation
+retries with an extra trailing `0xff` byte, matching the NUT-28-style fallback
+used in the code.
+
+That scalar is then applied to the recipient's pubkey using the
+NUT-28 / BIP-340 parity rules to derive the blinded pubkey for that
+specific `(amount, index)` output.
 
 Example commitment output secret for Charlie (JSON):
 
@@ -465,9 +533,7 @@ Example commitment output secret for Charlie (JSON):
   {
     "nonce": "b2c3d4e5f6a1234567890abcdef01234...",
     "data": "02charlie_blinded_pubkey_for_this_output...",
-    "tags": [
-      ["sigflag", "SIG_INPUTS"]
-    ]
+    "tags": null
   }
 ]
 ```
@@ -482,21 +548,20 @@ Example commitment output secret for Alice (JSON):
   {
     "nonce": "c3d4e5f6a1b234567890abcdef012345...",
     "data": "02alice_blinded_pubkey_for_this_output...",
-    "tags": [
-      ["sigflag", "SIG_INPUTS"]
-    ]
+    "tags": null
   }
 ]
 ```
 
 The `"data"` field contains Alice's blinded pubkey derived as described above.
+No explicit `sigflag` tag is required here; a missing or `null` tag set is interpreted as the default `SIG_INPUTS` behavior.
 
 ## Blinding Factor for Blind Signatures
 
 The blinding factor (for the Cashu blind signature scheme) is computed separately from the P2BK blinding:
 
 ```
-blinding_factor = SHA256(channel_secret || channel_id || context || amount || "blinding" || index)
+blinding_factor = SHA256(channel_secret || "{channel_id}|{context}|{amount}|blinding|{index}")
 ```
 
 where `context` is one of "funding", "sender" or "receiver".
@@ -578,7 +643,7 @@ via NUT-07 (token state check). NUT-17, if supported by the mint, helps here too
 
 Charlie should return Alice's blind signatures to her, but if he doesn't then Alice
 can use NUT-09 to restore the signatures.
-If Charlie chooses a different keyset (not `params.active_keyset_id`), Alice can
+If Charlie chooses a different keyset (not `params.keyset_id`), Alice can
 use NUT-09 to learn the keyset that he selected.
 
 While we assume that Charlie will usually take the most recent commitment, as it's

--- a/XX.md
+++ b/XX.md
@@ -4,8 +4,6 @@
 
 `depends on: NUT-11 (P2PK), NUT-12 (DLEQ), NUT-09 (restore signatures), NUT-07 (token state check), NUT-?28? P2BK, (NUT-17 is beneficial, but not required)`
 
-_TODO: This is a bit badly-structured and repetitive now. I need to tidy it up._
-
 ---
 
 This describes how Alice can set up a one-way payment channel from herself to Charlie.
@@ -37,6 +35,11 @@ The mint doesn't know that there is a channel, due to various techniques - inclu
 pay-to-blinded-pubkey (... NUT-28? ...) - which make it difficult for
 the mint to correlate the swaps and tokens.
 
+This document doesn't discuss transport of the payments.
+This doesn't discuss how prices will be negotiated.
+This document is purely cryptographic, specifying the outputs (`BlindedMessage`) to use, and
+what is needed to construct and sign and verify the transactions.
+
 # Overview and terminology
 
 Before defining everything in detail, we summarize the overall flow in order
@@ -45,7 +48,7 @@ to introduce and clarify terminology.
 Alice, the sender, takes Charlie's public information - such as his public key and the mints
 and units and keysets that he trusts - and defines the _channel parameters_.
 There is a corresponding _channel id_, which is defined deterministically from those parameters
-and also from a _shared secret_ derived via Diffie Hellman.
+and also from a _channel secret_ derived via Diffie Hellman.
 
 Alice computes the _funding outputs_ , i.e. BlindedMessages, and then pays
 the mint (Bob) via a _swap_ or _mint_ to sign those outputs.
@@ -71,6 +74,9 @@ Charlie's balance.
 
 Alice makes the payment by sending three pieces of data to Charlie:
 the channel id, the new balance for charlie, and her signature.
+For every payment except the final payment for a given channel, Charlie
+will simply verify and store the payment and will not contact the mint.
+For each channel, Charlie needs to store only one balance and signature.
 
 When Charlie wishes to close the channel, he adds his signature to the
 most recent _commitment transaction_ which was signed by Alice.
@@ -86,12 +92,12 @@ and construct her 1-of-1 P2PK proofs.
 If Charlie never exits, Alice can wait until the channel's _expiry_ time
 and then she can spend all of the _funding token_ with just her signature.
 
-There are three kinds of P2PK outputs, the _funding outputs_ and the
+There are three kinds of blinded P2PK outputs, the _funding outputs_ and the
 _commitment outputs_ for each of the two parties.
 All of these outputs are _deterministic_; the output's _secret_ (including the _nonce_)
 and the _blinding factor_ can be computed by both Alice and Bob
 based on the data available to both of them:
-the channel parameters, the shared secret, and the amount of the current _balance_.
+the channel parameters, the channel secret, and the amount of the current _balance_.
 This determinism minimizes the communication that is needed between Alice and Bob.
 
 At the end of this NUT, we define all the steps that Charlie should take
@@ -107,12 +113,13 @@ until he decides to close the channel.
 > creating the `BlindedMessage` (aka _output_) which is then signed by the mint.
 > This blinding factor is computed deterministically as described below.
 > Also, we blind the public keys that are used as the pubkeys to which the tokens
-> are locked, in accordance with NUT-?28?, as described below.
+> are locked, in accordance with NUT-28, as described below.
 
 # Fees
 
 Closing the channel ('exiting') involves two _stages_, a first stage where
-Charlie executes the _commitment transaction_, and a second stage
+Charlie executes the _commitment transaction_ which spends the _funding token_
+that Alice had opened the channel with, and a second stage
 where each party swap their 1-of-1 P2PK outputs into their wallets.
 In each stage, there are fees to be paid.
 Alice is responsible for the fees, and therefore there is some
@@ -159,7 +166,8 @@ complexity to ensure that the payments cover fees for both stages.
 ```
 
 > [!NOTE]
-> _Keyset malleability:_ The keyset for the _funding outputs_ is defined in the _channel parameters_.
+> _Keyset malleability:_ The keyset for the _funding outputs_ is defined in the _channel parameters_ and all
+> the proofs in the funding token must be in that keyset.
 > When Charlie executes the commitment transaction, he can choose which keyset to use as the commitment outputs. He should choose the same keyset, but he is not required to do so.
 > In fact, if that keyset is no longer _active_, he will be required by the mint to choose a different keyset.
 > He has this freedom because Alice's SIG_ALL signature commits to the _amounts_, but not the _keysets_, of the outputs.
@@ -168,7 +176,7 @@ complexity to ensure that the payments cover fees for both stages.
 > If the assumption is wrong, and Charlie uses a different keyset, then this simply means that the final
 amounts that each party gets after completing the second stage of the exit will be slightly different than they expected.
 
-# Channel parameters, `channel_id` and the shared secret.
+# Channel parameters, `channel_id` and the channel secret.
 
 Knowing Charlie's public key, and the set of mints and _units_ and keysets that are trusted by Charlie,
 and a minimum channel lifetime that Charlie requires, Alice defines the channel parameters as follows:
@@ -187,12 +195,17 @@ and a minimum channel lifetime that Charlie requires, Alice defines the channel 
  - `expiry_timestamp`  unix timestamp: If Charlie doesn't close before this time, Alice can re-claim all the funds after this has expired
  - `setup_timestamp` unix timestamp: the time when Alice is setting up this channel
 
-There is also a _shared secret_, computed via Diffie Helman using the
-keys of the two parties.
- 
-The `channel_id` is the SHA256 hash of the concatenation of all the parameters, including the _shared secret_.
+There is also a _channel secret_, derived from an ECDH shared secret
+between the two parties, with a domain separator to ensure the raw
+Diffie-Hellman value is never used directly:
 
-The shared secret is to add a little extra privacy here, by making it more difficult
+```
+channel_secret = SHA256("Cashu_Spilman_channel_secret_v1" || ECDH(alice_secret, charlie_pubkey))
+```
+
+The `channel_id` is the SHA256 hash of the concatenation of all the parameters, including the _channel secret_.
+
+The channel secret is to add a little extra privacy here, by making it more difficult
 for a third party, especially the mint, to predict what the `channel_id` might be.
 If a user publicly shares an error message that contains a `channel_id`, we don't
 want any third party, especially the mint, to be able to tie that id to the public keys.
@@ -267,7 +280,10 @@ amount | index
 if the `maximum_amount_for_one_output` was defined as 99 in this channel, then the algorithm
 would select fifty-four 10-sat outputs and three 1-sat outputs.
 
-_TODO: clarify the order of the outputs when Alice is creating the funding transaction. Make sure it fits the code and follows best practices_
+The outputs in the funding token MUST be sorted in ascending order of amount,
+as recommended in NUT-03 for privacy.
+The deterministic algorithm described above selects amounts largest-first,
+but the resulting outputs are ordered by amount (increasing) with index for tie-breaking (increasing)
 
 # Alice pays the fees
 
@@ -295,11 +311,11 @@ Notice the `>=`, not `=`, in that previous paragraph.
 Sometimes, due to fees, there is no value `x` for which equality can be attained.
 
 For example, if `input_fee_ppk=400` and `x=6`, then 
-`x=7` is too small as that would require three outputs (7 = 4 + 2 +1)
+`x=7` is too small as that would require three outputs (7 = 4 + 2 + 1)
 and as there are three outputs, the fees would cost 1200 ppk and leave
 only 5 sats after paying the fees.
 Therefore, we need `x=8`. That requires just a single 8-sat output
-and theref, after fees, it's worth 7 sats.
+and therefore, after fees, it's worth 7 sats.
 If this example is creating Charlie's commitment outputs, then
 he'll ultimately get 7 sats in his wallet even though the intended
 _balance_ was just 6 sats.
@@ -373,7 +389,7 @@ The deterministic process is a function of five things:
  - the `context` as a string
  - the `amount` in decimal representation, e.g. "32" for 32 satoshis
  - the `index` in decimal representation. (As this is rarely be greater than, an probably never greater than 255, then maybe this should just be represented as one byte?)
- - the `shared_secret` mentioned earlier. Using this ensures that the mint cannot compute the outputs even if they know the channel_id.
+ - the `channel_secret` mentioned earlier. Using this ensures that the mint cannot compute the outputs even if they know the channel_id.
 
 As these are all deterministic and based on information known to both parties,
 both parties can construct all these outputs and secrets and blinding factors.
@@ -383,7 +399,7 @@ The secret's _nonce_ is computed as follows:
 ```
 deterministic_nonce(...)
  =
-   SHA256(shared_secret || channel_id || output_context || amount || "nonce" || index)
+   SHA256(channel_secret || channel_id || output_context || amount || "nonce" || index)
 ```
 
 ## Funding Token Secret (2-of-2 with Blinded Pubkeys)
@@ -398,7 +414,7 @@ The funding token uses a 2-of-2 P2PK secret with three blinded pubkeys:
 - `pubkeys` tag: Charlie's blinded pubkey
 - `refund` tag: Alice's refund blinded pubkey
 
-_(Needs more clarity: ...)_ For the 2-of-2 P2PK secret in the funding token, an ephemeral _private_ key is computed as `SHA256("ChannelFundingP2BK" || shared_secret || channel_id)`. That gives us the corresponding
+_(Needs more clarity: ...)_ For the 2-of-2 P2PK secret in the funding token, an ephemeral _private_ key is computed as `SHA256("ChannelFundingP2BK" || channel_secret || channel_id)`. That gives us the corresponding
 ephemeral public key `p2pk_e`. Following that NUT, there is a process which takes that p2pk_e and the recipient's key (params.sender_pubkey or params.receiver_pubkey), and the position of that key in the secret, and tweaks it.
 
 While Alice is the intended recipient of both the `data` and `refund` key, NUT-28 blinds them differently due to their position in the P2PK Secret, and therefore the mint cannot see that `data == refund`.
@@ -436,7 +452,7 @@ Where:
 
 Each commitment output is locked to a **unique** blinded pubkey derived from the specific `(amount, index)` of that output.
 
-_(Needs more clarity: ...)_ For the 1-of-1 P2PK secret in the commitment outputs, an ephemeral _private_ key is computed as `SHA256("ChannelClosingP2BK" || <"receiver" or "sender"> || shared_secret || channel_id || amount || index)`.
+_(Needs more clarity: ...)_ For the 1-of-1 P2PK secret in the commitment outputs, an ephemeral _private_ key is computed as `SHA256("ChannelClosingP2BK" || <"receiver" or "sender"> || channel_secret || channel_id || amount || index)`.
 That gives us the corresponding
 ephemeral public key `p2pk_e` for this particular output.
 Following that NUT, there is a process which takes that p2pk_e and the recipient's key (params.sender_pubkey or params.receiver_pubkey), and the position of that key in the secret, and tweaks it.
@@ -480,7 +496,7 @@ The `"data"` field contains Alice's blinded pubkey derived as described above.
 The blinding factor (for the Cashu blind signature scheme) is computed separately from the P2BK blinding:
 
 ```
-blinding_factor = SHA256(shared_secret || channel_id || context || amount || "blinding" || index)
+blinding_factor = SHA256(channel_secret || channel_id || context || amount || "blinding" || index)
 ```
 
 where `context` is one of "funding", "sender" or "receiver".

--- a/XX.md
+++ b/XX.md
@@ -2,7 +2,7 @@
 
 `optional`
 
-`depends on: NUT-11 (P2PK), NUT-12 (DLEQ), NUT-09 (restore signatures), NUT-07 (token state check), NUT-28 (P2BK), (NUT-17 is beneficial, but not required)`
+`depends on: NUT-11 (P2PK), NUT-12 (DLEQ for V1/V2 keysets), NUT-09 (restore signatures), NUT-07 (token state check), NUT-28 (P2BK), (NUT-17 is beneficial, but not required)`
 
 ---
 
@@ -39,6 +39,16 @@ This document doesn't discuss transport of the payments.
 This doesn't discuss how prices will be negotiated.
 This document is purely cryptographic, specifying the outputs (`BlindedMessage`) to use, and
 what is needed to construct and sign and verify the transactions.
+
+# Keyset versions
+
+This draft supports NUT-02 V1 and V2 keysets. V1 keysets remain accepted but
+are discouraged; all published test vectors use V2 keysets.
+
+This draft will be extended to support V3 keysets. Unlike V1 and V2, V3 proof
+validation does not require DLEQ, and its spending conditions use a
+substantially different encoding from the NUT-10/NUT-11 P2PK structure used
+here.
 
 # Overview and terminology and determinism
 

--- a/XX.md
+++ b/XX.md
@@ -192,8 +192,9 @@ amounts that each party gets after completing the second stage of the exit will 
 Knowing Charlie's public key, and the set of mints and _units_ and keysets that are trusted by Charlie,
 and a minimum channel lifetime that Charlie requires, Alice defines the channel parameters as follows:
 
- - `sender_pubkey`: Alice's key. Could be an ephemeral pubkey just for this channel
- - `receiver_pubkey`: Charlie's key.
+ - `sender_pubkey`: Alice's 33-byte compressed SEC1 public key. It may be
+   an ephemeral public key used only for this channel.
+ - `receiver_pubkey`: Charlie's 33-byte compressed SEC1 public key.
 
  - `mint` string: URL of mint
  - `unit`: typically `sat` or `msat`
@@ -230,8 +231,10 @@ setup_timestamp | sender_pubkey | receiver_pubkey |
 expiry_timestamp | hex(channel_secret)
 ```
 
-The public keys are represented in hex, and `channel_secret` is hex-encoded before
-being inserted into that string.
+The public keys are represented as lowercase hexadecimal encodings of their
+33-byte compressed SEC1 forms. This exact encoding MUST be used when constructing
+the `channel_id`. The `channel_secret` is also lowercase hex-encoded before being
+inserted into that string.
 
 The channel secret is to add a little extra privacy here, by making it more difficult
 for a third party, especially the mint, to predict what the `channel_id` might be.

--- a/XX.md
+++ b/XX.md
@@ -732,6 +732,19 @@ context    | amount | index
 Alice then signs this (`SIG_ALL`).
 Alice can then send three pieces of data to Charlie: the `channel_id`, the balance for Charlie, and her signature.
 
+The `SIG_ALL` message is the NUT-11 swap aggregation in this exact transaction
+order:
+
+```
+secret_0 || C_0 || ... || secret_n || C_n ||
+amount_0 || B_0 || ... || amount_m || B_m
+```
+
+where each `secret` is its exact canonical NUT-XX serialization, each `C` and
+`B_` is its lowercase compressed SEC1 hex encoding, and each `amount` is its
+base-10 ASCII encoding. Alice and Charlie MUST reconstruct the identical
+message before signing or verifying a balance update.
+
 As already mentioned, Alice must send the full set of channel parameters to Charlie in the first payment - if she hasn't already sent them beforehand -
 but after this it is sufficient for her to send those three pieces of data.
 

--- a/XX.md
+++ b/XX.md
@@ -535,11 +535,31 @@ specified by NUT-28. The `p2pk_e` field is Proof metadata and is not part
 of the P2PK secret. Because `e` is derived deterministically above, `E`
 and `p2pk_e` are deterministic for each `(stage2_context, amount, index)`.
 
-`stage2_tweak_scalar = SHA256("Cashu_P2BK_v1" || Zx || 0x00)`
-      
+Unlike the NUT-28 sender workflow, `e` is derived deterministically above
+rather than generated randomly. Once `e` has been selected, the tweak is
+derived according to NUT-28. Because each commitment-output secret contains
+only the `data` key, its P2BK slot index is `0`, encoded as the single byte
+`0x00`:
 
-If that does not yield a valid scalar, the current implementation
-retries with an extra trailing `0xff` byte.
+```
+stage2_tweak_scalar =
+    SHA256(b"Cashu_P2BK_v1" || Zx || 0x00)
+```
+
+The digest is interpreted as an unsigned 256-bit integer and MUST NOT be
+reduced modulo the secp256k1 group order `n`. It is valid only when
+`1 <= stage2_tweak_scalar < n`.
+
+If it is invalid, retry once as specified by NUT-28:
+
+```
+stage2_tweak_scalar =
+    SHA256(b"Cashu_P2BK_v1" || Zx || 0x00 || 0xff)
+```
+
+If the second value is also invalid, discard the ephemeral keypair `e`/`E`,
+increment `retry_counter`, and restart from the deterministic derivation of
+`ephemeral_secret`.
 
 That scalar is then applied to the recipient's pubkey, where the recipient
 can then use the NUT-28 / BIP-340 parity rules to derive the corresponding private key

--- a/XX.md
+++ b/XX.md
@@ -445,28 +445,57 @@ The deterministic outputs are created in one of three `context` values:
 
 The deterministic process is a function of five things:
 
- - the `channel_id`, the hex representation of the channel_id.
- - the `context` as a string
- - the `amount` in decimal representation, e.g. "32" for 32 satoshis
- - the `index` in decimal representation.
+ - the `channel_id`, represented as 64 lowercase hexadecimal characters.
+ - the `context` as a string.
+ - the `amount` in base-10 ASCII without leading zeros, e.g. `32` for 32 satoshis.
+ - the `index` in base-10 ASCII without leading zeros.
  - the `channel_secret` mentioned earlier. Using this ensures that the mint cannot compute the outputs even if they know the channel_id.
 
 As these are all deterministic and based on information known to both parties,
 both parties can construct all these outputs and secrets and blinding factors.
 
-The secret's _nonce_ and the blind-signature _blinding factor_ are computed as follows:
+The secret's _nonce_ is computed as follows, where all string components are
+UTF-8 encoded and each `|` is the single byte `0x7c`:
 
 ```
-deterministic_nonce(...)
- =
-   HMAC-SHA256(key = channel_secret, message = "{channel_id}|{output_context}|{amount}|nonce|{index}")
+nonce_message =
+    UTF8(channel_id) || b"|" ||
+    UTF8(output_context) || b"|" ||
+    UTF8(decimal(amount)) || b"|nonce|" ||
+    UTF8(decimal(index))
 
-blinding_factor(...)
- =
-   HMAC-SHA256(key = channel_secret, message = "{channel_id}|{output_context}|{amount}|blinding|{index}")
+nonce_bytes = HMAC-SHA256(key = channel_secret, message = nonce_message)
+Secret.nonce = lowercase_hex(nonce_bytes)
 ```
 
-where `output_context` is one of `funding`, `sender` or `receiver`.
+All 32-byte `nonce_bytes` values are valid; the nonce is not a secp256k1
+scalar.
+
+The blind-signature _blinding factor_ is a secp256k1 scalar. For each
+`retry_counter`, construct:
+
+```
+blinding_message =
+    UTF8(channel_id) || b"|" ||
+    UTF8(output_context) || b"|" ||
+    UTF8(decimal(amount)) || b"|blinding|" ||
+    UTF8(decimal(index)) || b"|" ||
+    UTF8(decimal(retry_counter))
+
+blinding_candidate = HMAC-SHA256(
+    key = channel_secret,
+    message = blinding_message
+)
+```
+
+`retry_counter` starts at `0` and increments through `255`; its decimal
+representation uses base-10 ASCII without leading zeros. Interpret
+`blinding_candidate` as an unsigned big-endian integer. It is valid only
+when `1 <= blinding_candidate < n`, where `n` is the secp256k1 group order;
+it MUST NOT be reduced modulo `n`. The first valid candidate is the blinding
+factor. If all 256 candidates are invalid, output construction fails.
+
+`output_context` is exactly one of `funding`, `sender`, or `receiver`.
 The `blinding_factor` here is the per-proof factor used in the Cashu blind-signature
 scheme; it is separate from the pubkey-tweak derivations described below.
 

--- a/XX.md
+++ b/XX.md
@@ -857,4 +857,4 @@ This delay is to make it more difficult for the mint to correlate the three 'exi
 
 # proof-of-concept
 
-_As of 2026-03-20, the implementation includes P2BK (Pay-to-Blinded-Key) with per-proof blinding for stage 2 outputs. The funding and commitment outputs are deterministic with blinded pubkeys. Fees are taken into account fully. The token-state-check and token-restore endpoints are used. The implementation is [here](https://github.com/SatsAndSports/demo_of_spillman_cashu_channel/tree/spilman.channel/crates/cdk/src/spilman), with many integration tests._
+_As of 2026-03-20, the implementation includes P2BK (Pay-to-Blinded-Key) with per-proof blinding for stage 2 outputs. The funding and commitment outputs are deterministic with blinded pubkeys. Fees are taken into account fully. The token-state-check and token-restore endpoints are used. The implementation is [here](https://github.com/SatsAndSports/cashu_spilman_channels), with many integration tests._

--- a/XX.md
+++ b/XX.md
@@ -594,19 +594,31 @@ Where:
 Each commitment output is locked to a **unique** blinded pubkey derived from the specific `(amount, index)` of that output.
 
 For the 1-of-1 P2PK secret in the commitment outputs, a per-output
-ephemeral private key is computed as:
+ephemeral private key is derived as follows. For each `retry_counter`,
+construct:
 
 ```
-ephemeral_secret = SHA256(
-    "Cashu_Spilman_P2BK_ephemeral_v1" ||
+ephemeral_message =
+    b"Cashu_Spilman_P2BK_ephemeral_v1" ||
     channel_secret ||
-    "{channel_id}|{stage2_context}|{amount}|{index}|{retry_counter}"
-)
+    UTF8(channel_id) || b"|" ||
+    UTF8(stage2_context) || b"|" ||
+    UTF8(decimal(amount)) || b"|" ||
+    UTF8(decimal(index)) || b"|" ||
+    UTF8(decimal(retry_counter))
+
+ephemeral_candidate = SHA256(ephemeral_message)
 ```
 
-where `stage2_context` is `receiver_stage2` or `sender_stage2`, for Charlie's balance and Alice's remainder respectively.
-The `retry_counter` is incremented until the hash yields such a valid scalar
-for use as the ephemeral secret key.
+`stage2_context` is exactly `receiver_stage2` or `sender_stage2`, for
+Charlie's balance and Alice's remainder respectively. `retry_counter` starts
+at `0` and increments through `255`; its decimal representation uses base-10
+ASCII without leading zeros. Interpret `ephemeral_candidate` as an unsigned
+big-endian integer. It is valid only when
+`1 <= ephemeral_candidate < n`, where `n` is the secp256k1 group order; it
+MUST NOT be reduced modulo `n`. The first valid candidate is
+`ephemeral_secret`. If all 256 candidates are invalid, output construction
+fails.
 
  Then an ECDH shared secret is computed as defined by NUT-28 P2BK. Let `Zx` denote the 32-byte x-coordinate shared secret from NUT-28:
  

--- a/XX.md
+++ b/XX.md
@@ -450,10 +450,19 @@ construction, and funding proofs do not carry `p2pk_e` metadata. NUT-28
 applies only to the 1-of-1 commitment outputs described below.
 
 For the funding token, the blinded pubkeys are derived directly from
-context-specific scalars of the form:
+context-specific scalars. For each `retry_counter`, construct:
 
 ```
-r = SHA256("Cashu_Spilman_P2BK_v1" || channel_secret || "{channel_id}|{context}|{retry_counter}")
+message =
+    b"Cashu_Spilman_stage1_key_tweak_v1" ||
+    UTF8(channel_id) || b"|" ||
+    UTF8(context) || b"|" ||
+    UTF8(decimal(retry_counter))
+
+r_candidate = HMAC-SHA256(
+    key = channel_secret,
+    message = message
+)
 ```
 
 where `context` is one of:
@@ -461,9 +470,15 @@ where `context` is one of:
 - `receiver_stage1`
 - `sender_stage1_refund`
 
-The `retry_counter` is incremented until a valid scalar is found,
-i.e. one in the range `1 <= s < n` where `n` is the secp256k1 group order.
-That scalar is then applied directly to the relevant party's pubkey, with
+The `channel_secret` is the raw 32-byte HMAC key. `retry_counter` starts at
+`0` and increments through `255`; its decimal representation uses base-10
+ASCII without leading zeros. Interpret `r_candidate` as an unsigned
+big-endian integer. It is valid only when `1 <= r_candidate < n`, where `n`
+is the secp256k1 group order; it MUST NOT be reduced modulo `n`. The first
+valid candidate is used. If all 256 candidates are invalid, channel
+construction fails.
+
+The selected scalar is then applied directly to the relevant party's pubkey, with
 BIP-340 parity handling, to derive the blinded pubkey.
 While Alice and Charlie know the tweaks that are applied, the mint (Bob) does not.
 

--- a/XX.md
+++ b/XX.md
@@ -428,11 +428,11 @@ The secret's _nonce_ and the blind-signature _blinding factor_ are computed as f
 ```
 deterministic_nonce(...)
  =
-   SHA256(channel_secret || "{channel_id}|{output_context}|{amount}|nonce|{index}")
+   HMAC-SHA256(key = channel_secret, message = "{channel_id}|{output_context}|{amount}|nonce|{index}")
 
 blinding_factor(...)
  =
-   SHA256(channel_secret || "{channel_id}|{output_context}|{amount}|blinding|{index}")
+   HMAC-SHA256(key = channel_secret, message = "{channel_id}|{output_context}|{amount}|blinding|{index}")
 ```
 
 where `output_context` is one of `funding`, `sender` or `receiver`.
@@ -522,12 +522,15 @@ where `stage2_context` is `receiver_stage2` or `sender_stage2`, for Charlie's ba
 The `retry_counter` is incremented until the hash yields such a valid scalar
 for use as the ephemeral secret key.
 
-Then an ECDH shared secret is computed between that ephemeral private key and
-the recipient's public key, and the NUT-28 tweak scalar is derived as:
+ Then an ECDH shared secret is computed as defined by NUT-28 P2BK. Let `Zx` denote the 32-byte x-coordinate shared secret from NUT-28:
+ 
+   - sender side: `Zx = x(eP)` 
+   - receiver side: `Zx = x(pE)`
 
-```
-stage2_tweak_scalar = SHA256("Cashu_P2BK_v1" || shared_secret_x || 0x00)
-```
+where `e` is the sender ephemeral private key, `E = eG` is the sender ephemeral public key, `p` is the recipient private key, and `P = pG` is the recipient public key.
+
+`stage2_tweak_scalar = SHA256("Cashu_P2BK_v1" || Zx || 0x00)`
+      
 
 If that does not yield a valid scalar, the current implementation
 retries with an extra trailing `0xff` byte.

--- a/XX.md
+++ b/XX.md
@@ -858,3 +858,5 @@ This delay is to make it more difficult for the mint to correlate the three 'exi
 # proof-of-concept
 
 _As of 2026-03-20, the implementation includes P2BK (Pay-to-Blinded-Key) with per-proof blinding for stage 2 outputs. The funding and commitment outputs are deterministic with blinded pubkeys. Fees are taken into account fully. The token-state-check and token-restore endpoints are used. The implementation is [here](https://github.com/SatsAndSports/cashu_spilman_channels), with many integration tests._
+
+Test vectors are in [tests/XX-tests.md](tests/XX-tests.md).

--- a/XX.md
+++ b/XX.md
@@ -215,12 +215,32 @@ and a minimum channel lifetime that Charlie requires, Alice defines the channel 
  - `setup_timestamp` unix timestamp: the time when Alice is setting up this channel
 
 There is also a _channel secret_, derived from an ECDH shared secret
-between the two parties, with a domain separator to ensure the raw
-Diffie-Hellman value is never used directly:
+between the two parties. Let `P = alice_secret * charlie_pubkey`.
+`P` MUST be serialized as a 33-byte compressed SEC1 public key, using
+prefix `0x02` when its Y coordinate is even and `0x03` when it is odd.
+Define:
 
 ```
-channel_secret = SHA256("Cashu_Spilman_channel_secret_v1" || ECDH(alice_secret, charlie_pubkey))
+dh = SHA256(compressed_SEC1(P))
 ```
+
+This is the default ECDH output of libsecp256k1. Charlie obtains the
+same `dh` with `P = charlie_secret * alice_pubkey`.
+
+`channel_secret` is the 32-byte output of:
+
+```
+HKDF-SHA256(
+    salt = empty byte string,
+    ikm = dh,
+    info = b"Cashu_Spilman_channel_secret_v1",
+    length = 32
+)
+```
+
+The HKDF invocation is as specified by RFC 5869. This derives a
+protocol-specific secret without using the raw Diffie-Hellman value
+directly.
 
 The `channel_id` is the SHA256 hash of the following pipe-delimited string:
 

--- a/XX.md
+++ b/XX.md
@@ -516,16 +516,14 @@ nonce_candidate = HMAC-SHA256(
 If that candidate is also not in the range `1 <= nonce_candidate < n`, output
 construction fails.
 
-The blind-signature _blinding factor_ is a secp256k1 scalar. For each
-`retry_counter`, construct:
+The blind-signature _blinding factor_ is a secp256k1 scalar. Construct:
 
 ```
 blinding_message =
     UTF8(channel_id) || b"|" ||
     UTF8(output_context) || b"|" ||
     UTF8(decimal(amount)) || b"|blinding|" ||
-    UTF8(decimal(index)) || b"|" ||
-    UTF8(decimal(retry_counter))
+    UTF8(decimal(index))
 
 blinding_candidate = HMAC-SHA256(
     key = channel_secret,
@@ -533,12 +531,22 @@ blinding_candidate = HMAC-SHA256(
 )
 ```
 
-`retry_counter` starts at `0` and increments through `255`; its decimal
-representation uses base-10 ASCII without leading zeros. Interpret
-`blinding_candidate` as an unsigned big-endian integer. It is valid only
-when `1 <= blinding_candidate < n`, where `n` is the secp256k1 group order;
-it MUST NOT be reduced modulo `n`. The first valid candidate is the blinding
-factor. If all 256 candidates are invalid, output construction fails.
+Interpret `blinding_candidate` as an unsigned big-endian integer. If
+`1 <= blinding_candidate < n`, where `n` is the secp256k1 group order, it is
+the blinding factor. The candidate MUST NOT be reduced modulo `n`.
+
+Otherwise, retry once with the single raw byte `0xff` appended to the original
+`blinding_message`:
+
+```
+blinding_candidate = HMAC-SHA256(
+    key = channel_secret,
+    message = blinding_message || 0xff
+)
+```
+
+If that candidate is also not in the range `1 <= blinding_candidate < n`,
+output construction fails.
 
 `output_context` is exactly one of `funding`, `sender`, or `receiver`.
 The `blinding_factor` here is the per-proof factor used in the Cashu blind-signature

--- a/XX.md
+++ b/XX.md
@@ -242,19 +242,27 @@ The HKDF invocation is as specified by RFC 5869. This derives a
 protocol-specific secret without using the raw Diffie-Hellman value
 directly.
 
-The `channel_id` is the SHA256 hash of the following pipe-delimited string:
+The `channel_id` is the SHA256 hash of the UTF-8 encoding of the following
+pipe-delimited string. Each `|` below is the single byte `0x7c`; the
+preimage contains no spaces, line breaks, or trailing separator:
 
 ```
-mint | unit | capacity | funding_token_amount |
-keyset_id | input_fee_ppk | maximum_amount_for_one_output |
-setup_timestamp | sender_pubkey | receiver_pubkey |
-expiry_timestamp | hex(channel_secret)
+mint|unit|capacity|funding_token_amount|
+keyset_id|input_fee_ppk|maximum_amount_for_one_output|
+setup_timestamp|sender_pubkey|receiver_pubkey|
+expiry_timestamp|hex(channel_secret)
 ```
 
-The public keys are represented as lowercase hexadecimal encodings of their
-33-byte compressed SEC1 forms. This exact encoding MUST be used when constructing
-the `channel_id`. The `channel_secret` is also lowercase hex-encoded before being
-inserted into that string.
+Text fields use their UTF-8 bytes. The `mint` URL MUST have trailing `/`
+characters removed, as specified by NUT-00. The `mint` and `unit` fields
+MUST NOT contain `|`. `capacity`, `funding_token_amount`, `input_fee_ppk`,
+`maximum_amount_for_one_output`, `setup_timestamp`, and `expiry_timestamp`
+are unsigned integers encoded as base-10 ASCII without a sign or leading
+zeros, except that zero is encoded as `0`. `keyset_id`, `sender_pubkey`,
+`receiver_pubkey`, and `channel_secret` are lowercase hexadecimal encodings.
+The public keys are their 33-byte compressed SEC1 forms, and
+`channel_secret` is its raw 32-byte value. The resulting 32-byte
+`channel_id` is represented externally as lowercase hexadecimal.
 
 The channel secret is to add a little extra privacy here, by making it more difficult
 for a third party, especially the mint, to predict what the `channel_id` might be.

--- a/XX.md
+++ b/XX.md
@@ -473,9 +473,19 @@ they are blinded differently because they use different derivation contexts
 (`sender_stage1` and `sender_stage1_refund`), and therefore the mint cannot
 see that `data` and `refund` correspond to the same underlying party.
 
-As the swap that spends this funding token uses SIG_ALL, the same stage-1 pubkey blinding applies
-to every funding output. The deterministic nonce and blind-signature blinding factor are still
-derived separately for each output.
+When the funding proofs are spent together as `SIG_ALL` inputs, every
+funding proof MUST have the same P2PK `Secret.data` and `Secret.tags`, as
+required by NUT-11. Therefore, all funding proofs use the same blinded
+stage-1 sender, receiver, and refund pubkeys. The `Secret.nonce` and Cashu
+blind-signature blinding factor are still derived separately for each
+funding output.
+
+This does not prevent per-proof P2BK blinding of the commitment outputs.
+`SIG_ALL` applies to the funding proofs used as inputs and commits to the
+`amount` and `B_` of every commitment output. It does not require those
+outputs to have identical P2PK spending conditions. Once issued as Proofs,
+the commitment outputs use the default `SIG_INPUTS` behavior, so each can
+have its own deterministic `e`, `E`, `p2pk_e`, and blinded recipient key.
 
 Example funding token secret (JSON):
 

--- a/XX.md
+++ b/XX.md
@@ -529,6 +529,12 @@ for use as the ephemeral secret key.
 
 where `e` is the sender ephemeral private key, `E = eG` is the sender ephemeral public key, `p` is the recipient private key, and `P = pG` is the recipient public key.
 
+For each commitment output, `E` MUST be encoded as a 33-byte compressed
+SEC1 public key and included in the resulting Proof's `p2pk_e` field, as
+specified by NUT-28. The `p2pk_e` field is Proof metadata and is not part
+of the P2PK secret. Because `e` is derived deterministically above, `E`
+and `p2pk_e` are deterministic for each `(stage2_context, amount, index)`.
+
 `stage2_tweak_scalar = SHA256("Cashu_P2BK_v1" || Zx || 0x00)`
       
 

--- a/XX.md
+++ b/XX.md
@@ -560,14 +560,13 @@ construction, and funding proofs do not carry `p2pk_e` metadata. NUT-28
 applies only to the 1-of-1 commitment outputs described below.
 
 For the funding token, the blinded pubkeys are derived directly from
-context-specific scalars. For each `retry_counter`, construct:
+context-specific scalars. Construct:
 
 ```
 message =
     b"Cashu_Spilman_stage1_key_tweak_v1" ||
     UTF8(channel_id) || b"|" ||
-    UTF8(context) || b"|" ||
-    UTF8(decimal(retry_counter))
+    UTF8(context)
 
 r_candidate = HMAC-SHA256(
     key = channel_secret,
@@ -580,13 +579,11 @@ where `context` is one of:
 - `receiver_stage1`
 - `sender_stage1_refund`
 
-The `channel_secret` is the raw 32-byte HMAC key. `retry_counter` starts at
-`0` and increments through `255`; its decimal representation uses base-10
-ASCII without leading zeros. Interpret `r_candidate` as an unsigned
-big-endian integer. It is valid only when `1 <= r_candidate < n`, where `n`
-is the secp256k1 group order; it MUST NOT be reduced modulo `n`. The first
-valid candidate is used. If all 256 candidates are invalid, channel
-construction fails.
+The `channel_secret` is the raw 32-byte HMAC key. Interpret `r_candidate` as
+an unsigned big-endian integer. If `1 <= r_candidate < n`, where `n` is the
+secp256k1 group order, it is used directly; it MUST NOT be reduced modulo `n`.
+Otherwise, retry once with raw byte `0xff` appended to the original `message`.
+If that candidate is also invalid, channel construction fails.
 
 The selected scalar is then applied directly to the relevant party's pubkey, with
 BIP-340 parity handling, to derive the blinded pubkey.
@@ -638,31 +635,29 @@ then `sigflag`.
 Each commitment output is locked to a **unique** blinded pubkey derived from the specific `(amount, index)` of that output.
 
 For the 1-of-1 P2PK secret in the commitment outputs, a per-output
-ephemeral private key is derived as follows. For each `retry_counter`,
-construct:
+ephemeral private key is derived as follows:
 
 ```
 ephemeral_message =
     b"Cashu_Spilman_P2BK_ephemeral_v1" ||
-    channel_secret ||
     UTF8(channel_id) || b"|" ||
     UTF8(stage2_context) || b"|" ||
     UTF8(decimal(amount)) || b"|" ||
-    UTF8(decimal(index)) || b"|" ||
-    UTF8(decimal(retry_counter))
+    UTF8(decimal(index))
 
-ephemeral_candidate = SHA256(ephemeral_message)
+ephemeral_candidate = HMAC-SHA256(
+    key = channel_secret,
+    message = ephemeral_message
+)
 ```
 
 `stage2_context` is exactly `receiver_stage2` or `sender_stage2`, for
-Charlie's balance and Alice's remainder respectively. `retry_counter` starts
-at `0` and increments through `255`; its decimal representation uses base-10
-ASCII without leading zeros. Interpret `ephemeral_candidate` as an unsigned
-big-endian integer. It is valid only when
-`1 <= ephemeral_candidate < n`, where `n` is the secp256k1 group order; it
-MUST NOT be reduced modulo `n`. The first valid candidate is
-`ephemeral_secret`. If all 256 candidates are invalid, output construction
-fails.
+Charlie's balance and Alice's remainder respectively. Interpret
+`ephemeral_candidate` as an unsigned big-endian integer. If
+`1 <= ephemeral_candidate < n`, where `n` is the secp256k1 group order, it is
+`ephemeral_secret`; it MUST NOT be reduced modulo `n`. Otherwise, retry once
+with raw byte `0xff` appended to the original `ephemeral_message`. If that
+candidate is also invalid, output construction fails.
 
  Then an ECDH shared secret is computed as defined by NUT-28 P2BK. Let `Zx` denote the 32-byte x-coordinate shared secret from NUT-28:
  

--- a/XX.md
+++ b/XX.md
@@ -464,6 +464,23 @@ The deterministic process is a function of five things:
 As these are all deterministic and based on information known to both parties,
 both parties can construct all these outputs and secrets and blinding factors.
 
+## Deterministic Secret Serialization
+
+The exact UTF-8 bytes of a `Secret` are blinded to construct each Cashu
+`BlindedMessage`. For the deterministic outputs defined by this NUT, Alice and
+Charlie MUST therefore use the following compact JSON serialization, rather
+than merely a semantically equivalent JSON value:
+
+- No whitespace is permitted.
+- The P2PK object fields MUST appear in the order `data`, `nonce`, `tags`.
+- The `tags` member MUST always be present and MUST be a JSON array.
+- Tags MUST appear in the order defined for the output type below, and all tag
+  values defined by this NUT are JSON strings.
+- A tagless commitment output MUST encode `tags` as `[]`.
+
+This serialization requirement applies only to deterministic NUT-XX outputs;
+it does not define general canonical JSON for NUT-10 or NUT-11.
+
 The secret's _nonce_ is computed as follows, where all string components are
 UTF-8 encoded and each `|` is the single byte `0x7c`:
 
@@ -576,20 +593,7 @@ have its own deterministic `e`, `E`, `p2pk_e`, and blinded recipient key.
 Example funding token secret (JSON):
 
 ```json
-[
-  "P2PK",
-  {
-    "nonce": "a1b2c3d4e5f678901234567890abcdef...",
-    "data": "02abc123def456789...",
-    "tags": [
-      ["pubkeys", "03def456abc789012..."],
-      ["refund", "02789abcdef012345..."],
-      ["n_sigs", "2"],
-      ["locktime", "1737500000"],
-      ["sigflag", "SIG_ALL"]
-    ]
-  }
-]
+["P2PK",{"data":"02abc123def456789...","nonce":"a1b2c3d4e5f678901234567890abcdef...","tags":[["pubkeys","03def456abc789012..."],["locktime","1737500000"],["n_sigs","2"],["refund","02789abcdef012345..."],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
 ```
 
 Where:
@@ -598,6 +602,10 @@ Where:
 - The `"refund"` tag contains Alice's blinded _refund_ pubkey.
 - `"n_sigs": "2"` requires both Alice and Charlie's signatures before the NUT-11 `locktime` tag, which is the channel's `expiry_timestamp`
 - After that `locktime`, Alice can spend alone using her refund blinded secret key
+
+Funding secrets MUST use the exact template shown above. In particular, the
+tags are ordered `pubkeys`, `locktime`, `n_sigs`, `refund`, `n_sigs_refund`,
+then `sigflag`.
 
 ## Commitment Output Secrets (1-of-1 with Per-Proof Blinded Pubkeys)
 
@@ -676,14 +684,7 @@ for that specific `(amount, index)` output.
 Example commitment output secret for Charlie (JSON):
 
 ```json
-[
-  "P2PK",
-  {
-    "nonce": "b2c3d4e5f6a1234567890abcdef01234...",
-    "data": "02charlie_blinded_pubkey_for_this_output...",
-    "tags": null
-  }
-]
+["P2PK",{"data":"02charlie_blinded_pubkey_for_this_output...","nonce":"b2c3d4e5f6a1234567890abcdef01234...","tags":[]}]
 ```
 
 The `"data"` field contains Charlie's blinded pubkey derived as described above.
@@ -691,18 +692,12 @@ The `"data"` field contains Charlie's blinded pubkey derived as described above.
 Example commitment output secret for Alice (JSON):
 
 ```json
-[
-  "P2PK",
-  {
-    "nonce": "c3d4e5f6a1b234567890abcdef012345...",
-    "data": "02alice_blinded_pubkey_for_this_output...",
-    "tags": null
-  }
-]
+["P2PK",{"data":"02alice_blinded_pubkey_for_this_output...","nonce":"c3d4e5f6a1b234567890abcdef012345...","tags":[]}]
 ```
 
 The `"data"` field contains Alice's blinded pubkey derived as described above.
-No explicit `sigflag` tag is required here; a missing or `null` tag set is interpreted as the default `SIG_INPUTS` behavior.
+No explicit `sigflag` tag is required here; the empty tag set uses the default
+`SIG_INPUTS` behavior.
 
 # Order of outputs in the commitment transaction
 

--- a/XX.md
+++ b/XX.md
@@ -481,8 +481,9 @@ than merely a semantically equivalent JSON value:
 This serialization requirement applies only to deterministic NUT-XX outputs;
 it does not define general canonical JSON for NUT-10 or NUT-11.
 
-The secret's _nonce_ is computed as follows, where all string components are
-UTF-8 encoded and each `|` is the single byte `0x7c`:
+The secret's _nonce_ is an output-discriminator scalar. For V1/V2 P2PK
+output nonces, all string components of `nonce_message` are UTF-8 encoded and
+each `|` is the single byte `0x7c`:
 
 ```
 nonce_message =
@@ -491,12 +492,29 @@ nonce_message =
     UTF8(decimal(amount)) || b"|nonce|" ||
     UTF8(decimal(index))
 
-nonce_bytes = HMAC-SHA256(key = channel_secret, message = nonce_message)
-Secret.nonce = lowercase_hex(nonce_bytes)
+nonce_candidate = HMAC-SHA256(
+    key = channel_secret,
+    message = nonce_message
+)
 ```
 
-All 32-byte `nonce_bytes` values are valid; the nonce is not a secp256k1
-scalar.
+Interpret `nonce_candidate` as an unsigned big-endian integer. If
+`1 <= nonce_candidate < n`, where `n` is the secp256k1 group order,
+`Secret.nonce` is its exactly 64-character lowercase hexadecimal encoding.
+The candidate MUST NOT be reduced modulo `n`.
+
+Otherwise, retry once with the single raw byte `0xff` appended to the original
+`nonce_message`:
+
+```
+nonce_candidate = HMAC-SHA256(
+    key = channel_secret,
+    message = nonce_message || 0xff
+)
+```
+
+If that candidate is also not in the range `1 <= nonce_candidate < n`, output
+construction fails.
 
 The blind-signature _blinding factor_ is a secp256k1 scalar. For each
 `retry_counter`, construct:

--- a/XX.md
+++ b/XX.md
@@ -141,7 +141,7 @@ complexity to ensure that the payments cover fees for both stages.
 │                         FUNDING TOKEN                                   │
 │                  (total_funding_token_amount)                           │
 │                                                                         │
-│  Created by Alice with P2BK proofs requiring both signatures (SIG_ALL)  │
+│  Created by Alice with blinded P2PK proofs (SIG_ALL)                    │
 │  After the expiry time, Alice's signature alone is sufficient           │
 └─────────────────────────────────────────────────────────────────────────┘
                                   │
@@ -442,12 +442,13 @@ where `output_context` is one of `funding`, `sender` or `receiver`.
 The `blinding_factor` here is the per-proof factor used in the Cashu blind-signature
 scheme; it is separate from the pubkey-tweak derivations described below.
 
-## Funding Token Secret (2-of-2 with Blinded Pubkeys)
+## Funding Token Secret (2-of-2 with XX-Specific Blinded Pubkeys)
 
-The keys are blinded. Later, we discuss how the 1-of-1 keys for the commitment outputs
-are blinded using a NUT-28-style shared-secret scheme.
-But (for now, we should change to NUT-28 for this too), a simpler deterministic
-scalar-tweak scheme is used for the 2-of-2 keys - and refund key - in the funding token.
+The funding token uses an XX-specific deterministic scalar-tweak construction
+for its 2-of-2 keys and refund key. It does not use the NUT-28 ECDH/tweak
+construction, and funding proofs do not carry `p2pk_e` metadata. NUT-28
+applies only to the 1-of-1 commitment outputs described below.
+
 For the funding token, the blinded pubkeys are derived directly from
 context-specific scalars of the form:
 

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -180,3 +180,176 @@ blinding_factor = HMAC-SHA256(channel_secret, blinding_message) =
 
 The `blinding_factor` is a valid secp256k1 scalar. It is the first valid
 candidate, so no retry is needed for this vector.
+
+## spilman-test-vector-amount-selection-keysetv2
+
+This vector selects funding-output denominations from the Shared Deterministic
+V2 Mint Fixture.
+
+```text
+target = 100
+maximum_amount_for_one_output = 64
+selected_amounts_largest_first = 64, 32, 4
+```
+
+## spilman-test-vector-amount-selection-keysetv2-max32
+
+This is the same V2-keyset target with a lower per-output maximum.
+
+```text
+target = 100
+maximum_amount_for_one_output = 32
+selected_amounts_largest_first = 32, 32, 32, 4
+```
+
+## spilman-test-vector-stage1-key-tweaks-keysetv2
+
+This vector derives the three shared P2PK keys used by every funding proof.
+Each `message` is the exact HMAC-SHA256 input. All retry counters are `0`.
+
+```text
+channel_id = 7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e
+channel_secret = acfc96a584e645524b017b75cfe0770c3b8dc2ba4f9cef6d99f2cb7bcee691cf
+prefix = Cashu_Spilman_stage1_key_tweak_v1
+
+sender_stage1:
+  original_pubkey = 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+  message = Cashu_Spilman_stage1_key_tweak_v17af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|sender_stage1|0
+  scalar = 2c30d26a35b0d093bab0d1d58f6c70572c0c7cd82cb0ecc34d7e26a54a0eae49
+  blinded_pubkey = 03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d
+
+receiver_stage1:
+  original_pubkey = 02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5
+  message = Cashu_Spilman_stage1_key_tweak_v17af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|receiver_stage1|0
+  scalar = ea4bf4110a5c73c232ea288adf577be653d334521a82f71a767fdbe66fb49614
+  blinded_pubkey = 03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455
+
+sender_stage1_refund:
+  original_pubkey = 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+  message = Cashu_Spilman_stage1_key_tweak_v17af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|sender_stage1_refund|0
+  scalar = 45ad552923c0cd0e988c5a929766c7da81e1b6eced096ff745a3f95b30abbc2b
+  blinded_pubkey = 02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760
+```
+
+## spilman-test-vector-funding-outputs-keysetv2
+
+This vector combines the 100-sat amount-selection and stage-1 vectors. Outputs
+are in Cashu smallest-first order. Each secret is the NUT-10 P2PK JSON with
+the shared `data`, `pubkeys`, `locktime`, `n_sigs`, `refund`,
+`n_sigs_refund`, and `sigflag = SIG_ALL` fields defined above; only `nonce`
+varies by output.
+
+```text
+keyset_id = 01fd5a9250eb619ce33b33bf6e752634a5a8ca4bb629c6b48a99db9c94d09d310d
+
+amount = 4
+index = 0
+secret = ["P2PK",{"data":"03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d","nonce":"e9aad80a4e747e570bb68cff4f8a33f8c2d904f424e695f9e2febf92bbd4fb30","tags":[["pubkeys","03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455"],["locktime","1800000000"],["n_sigs","2"],["refund","02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
+nonce = e9aad80a4e747e570bb68cff4f8a33f8c2d904f424e695f9e2febf92bbd4fb30
+blinding_factor = 89d7fc20c07229e615c9365c83b70938566037c55fe61c102afee78ff44fab66
+blinded_message = 027e3b02f160f2d75b276bd411821a2fc66bd3ba4aed5fc23b9a88e472dd641134
+
+amount = 32
+index = 0
+secret = ["P2PK",{"data":"03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d","nonce":"879abe0662d57e86ec39d715103c1c95814780b29752c01aadb0888b92d3c081","tags":[["pubkeys","03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455"],["locktime","1800000000"],["n_sigs","2"],["refund","02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
+nonce = 879abe0662d57e86ec39d715103c1c95814780b29752c01aadb0888b92d3c081
+blinding_factor = 932933b55f73dfc76c8fd04e671360e46fc2be33878e83ebde17a5c48651744c
+blinded_message = 034e10f284aceb8d8a316105f2533583c7f4e5ea6b2102f276403d061f1ee9460f
+
+amount = 64
+index = 0
+secret = ["P2PK",{"data":"03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d","nonce":"f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a","tags":[["pubkeys","03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455"],["locktime","1800000000"],["n_sigs","2"],["refund","02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
+nonce = f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a
+blinding_factor = 74285411dc702b0e295f143d026b95bd75cf730647a694e5c5b8147f619d1b35
+blinded_message = 03fb84f24c1bb271786a89aaeaff334c36db02bde6e1f9607d69f94db907b48bbf
+```
+
+## spilman-test-vector-stage2-p2bk-keysetv2
+
+This vector fixes the NUT-28 derivation for the commitment-output `(amount,
+index) = (32, 0)` slot. Both entries use the channel ID and channel secret from
+`spilman-test-vector-channel-id-keysetv2`; both scalar retry counters are zero.
+
+```text
+amount = 32
+index = 0
+
+context = receiver_stage2
+recipient_pubkey = 02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5
+ephemeral_secret = dc2029be89e39a26f5a49653a7de750807002f9549f4774ed8c6376d1cf4bc7b
+p2pk_e = 02224366f001c35581b8316a62160d4e5733f102757a1a824d8e41a9ad795d5a90
+shared_secret_x = e5198d9a589490993b1edd9c5bf76e31bf9610bdca088654fb2d654b62a0085d
+p2bk_scalar = 51db52022fe771a7e084346852a2115fbefd204efe4fb6c5e94cd3844c718e75
+blinded_pubkey = 0397dfedc39293131c2d4c5f76169001e2b11057284dc9345e8178f3ce035660df
+
+context = sender_stage2
+recipient_pubkey = 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+ephemeral_secret = b0a12b2dc14d71c23a27c02d35ebde1eccdc50984fac5b4597099cc653a6d69b
+p2pk_e = 02a1be7b930f67d26fd168214a18f5c208cb21cda5f6f08bbf61930cae109d5a39
+shared_secret_x = a1be7b930f67d26fd168214a18f5c208cb21cda5f6f08bbf61930cae109d5a39
+p2bk_scalar = 891005d4ef10bee9b46144fec3d81f051e8d5db42c6078f60a0fd1ad0c4798db
+blinded_pubkey = 023725a2912497df0d49de8269b778e664b917e6c919e122fd099e2e99be03f1af
+```
+
+## spilman-test-vector-commitment-outputs-keysetv2
+
+This vector uses the zero-fee 100-sat channel and a 50-sat receiver balance.
+Receiver and sender each receive deterministic amounts `2 + 16 + 32`. Each
+`secret` is the exact canonical UTF-8 JSON string defined by NUT-XX; every
+tagless secret uses `"tags":[]`.
+
+```text
+keyset_id = 01fd5a9250eb619ce33b33bf6e752634a5a8ca4bb629c6b48a99db9c94d09d310d
+receiver_balance = 50
+
+context = receiver
+amount = 2
+index = 0
+secret = ["P2PK",{"data":"03aae5610f300463773890d489bc8638324b7d9966c6aec461b9afe2859cf2be9f","nonce":"008b267f22e9da9672d141c6ca72f069c464e1863909d82e4ccdd0fbca0fe658","tags":[]}]
+p2pk_e = 0254f06f28d614849f7e90c53171b194c358a625864cdf26fec99c78553c6781c5
+blinding_factor = 9c9107c949e3bb007439519cad428379702bfac828b33fcad7a5b885ba2a95bf
+blinded_message = 033a81f9199fda2d0b6955a4114cd2ddffc52b2ddf89197b5a04bd806c8843399e
+
+context = receiver
+amount = 16
+index = 0
+secret = ["P2PK",{"data":"03f8d7134afdf587bf8d40d79ae4aab8905e3a2bb378493a46de13daadff24a2b4","nonce":"fe4ac5c03c0dca0ef9af528fddb8975558d03ae7a7f73a93e3718d6f52f4c2f0","tags":[]}]
+p2pk_e = 029927a0192b8c65ad0e4ddbfcb476b4f9f6c4deb8746a4810eb767cfa81d62195
+blinding_factor = 3bc38b19a49bc506cee66eca9a779dcb4fc132aea294713150532fae82152e39
+blinded_message = 03dc893fd2f3a9509d2f0ed30459aff829cede98826aea0a6ee7a80948c2d74e32
+
+context = receiver
+amount = 32
+index = 0
+secret = ["P2PK",{"data":"0397dfedc39293131c2d4c5f76169001e2b11057284dc9345e8178f3ce035660df","nonce":"0c640e9c0e7b5c13d519e6a5dbae6d84fc8b71a2da736689fd950606aa3abd07","tags":[]}]
+p2pk_e = 02224366f001c35581b8316a62160d4e5733f102757a1a824d8e41a9ad795d5a90
+blinding_factor = de8dedd0c3484e02422ee298d7fa97cca44b80d82d7c6b7ab33743aa32d78e3d
+blinded_message = 024e661853c27f2e83300b1ad45c85290861a6eb2d8567ae6595eb6e582770ddf1
+
+context = sender
+amount = 2
+index = 0
+secret = ["P2PK",{"data":"02ff4d525e601d93409a27b86704fd4fef883bba75729cf88eb2e8d59de3a55c58","nonce":"a5a204390c60cca38988fcedc3f77bef1f32272cef922082f3a8cb8de6fbc73d","tags":[]}]
+p2pk_e = 028db3f60a69b312696ca1e54e49a0ea3b9b1aaaf3c1405b412333ac07771707de
+blinding_factor = 2c0d9ab01f983f1610a9f8a9b1a3773923bda5e8938b5a15b89c13f02ea0ccd9
+blinded_message = 02cf1e71062b1e7ff01986cd0160174c7b039b4b94cd0ef5e1518fe776a1b3154d
+
+context = sender
+amount = 16
+index = 0
+secret = ["P2PK",{"data":"039da1bb99af72c4e3359961d06a27fcba0b09c6e9ced64682c5c58f8166df06b5","nonce":"fa5eac4d875dbb343a5840d62a9b6fd0b90d1ee08f1a0b627ba7767c0c622881","tags":[]}]
+p2pk_e = 02f7895660f690f1d498e2f215a7e6de772407b954d09b75e579ed4a284c3a28f7
+blinding_factor = 603d1b5b9c66de9a5144c19bbac91e943feccb8d5d408c7a1ce4092bc5bd4b8f
+blinded_message = 02a2f5005d6b714b9c35e9806a9c9f45fd6d7055a112e4f22551c555ccb945d550
+
+context = sender
+amount = 32
+index = 0
+secret = ["P2PK",{"data":"023725a2912497df0d49de8269b778e664b917e6c919e122fd099e2e99be03f1af","nonce":"d19c3e67ae5c9aa3d737ccd349cb83c8f384ec5940d166238da8eef54fcd0cfe","tags":[]}]
+p2pk_e = 02a1be7b930f67d26fd168214a18f5c208cb21cda5f6f08bbf61930cae109d5a39
+blinding_factor = df1c0c9bb910d9dcbace8fa188e38c72ec9e90474b9c574d789aa45b1c31b530
+blinded_message = 035ff45bffcec127d65c52aad3fd866591cfd6cdb24cfc95761c1faed0647e1fb5
+
+stable_swap_output_order =
+  receiver:2, sender:2, receiver:16, sender:16, receiver:32, sender:32
+```

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -148,3 +148,34 @@ normalized_mint = https://vector-mint.example
 
 The exact UTF-8 SHA-256 preimage and the expected channel ID are therefore the
 same as `spilman-test-vector-channel-id`.
+
+## spilman-test-vector-output-nonce-and-blinding
+
+This vector covers one 64-sat output in the 100-sat funding token from
+`spilman-test-vector-channel-id`. With zero fees and a maximum output amount
+of 64, that funding token has outputs of 64, 32, and 4 sats. This vector does
+not define the funding output's stage-1 P2PK keys; it only defines its
+per-proof NUT-10 nonce and Cashu blind-signature blinding factor.
+
+```text
+channel_id = 7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e
+channel_secret = acfc96a584e645524b017b75cfe0770c3b8dc2ba4f9cef6d99f2cb7bcee691cf
+output_context = funding
+amount = 64
+index = 0
+
+nonce_message =
+  7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|funding|64|nonce|0
+nonce_bytes = HMAC-SHA256(channel_secret, nonce_message) =
+  f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a
+Secret.nonce = f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a
+
+retry_counter = 0
+blinding_message =
+  7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|funding|64|blinding|0|0
+blinding_factor = HMAC-SHA256(channel_secret, blinding_message) =
+  74285411dc702b0e295f143d026b95bd75cf730647a694e5c5b8147f619d1b35
+```
+
+The `blinding_factor` is a valid secp256k1 scalar. It is the first valid
+candidate, so no retry is needed for this vector.

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -353,3 +353,38 @@ blinded_message = 035ff45bffcec127d65c52aad3fd866591cfd6cdb24cfc95761c1faed0647e
 stable_swap_output_order =
   receiver:2, sender:2, receiver:16, sender:16, receiver:32, sender:32
 ```
+
+## spilman-test-vector-sig-all-keysetv2
+
+This vector fixes the NUT-11 `SIG_ALL` message for the 50-sat receiver-balance
+commitment swap above. The three funding inputs are ordered `4, 32, 64`; use
+their complete `secret` strings from
+`spilman-test-vector-funding-outputs-keysetv2` in that order.
+
+The funding-proof `C` values are valid unblinded signatures from the shared
+deterministic V2 test mint. DLEQ proofs are not part of this Spilman vector;
+their generation and verification are defined by NUT-12.
+
+```text
+funding_input_0_amount = 4
+funding_input_0_C = 028d2b7d1215b72c2b23d51563fb0d61e3652b87a77ceb3b237df1b9f46b0d044f
+funding_input_1_amount = 32
+funding_input_1_C = 02de5cb101e677403e4658d615e1a665db787558cccd09ff93a65983fa48fcecfd
+funding_input_2_amount = 64
+funding_input_2_C = 03bb199086ab2d33ce69cc80a007b48350fb13ce669af96be24f44613e9d0013b7
+
+commitment_outputs_in_order =
+  2|033a81f9199fda2d0b6955a4114cd2ddffc52b2ddf89197b5a04bd806c8843399e,
+  2|02cf1e71062b1e7ff01986cd0160174c7b039b4b94cd0ef5e1518fe776a1b3154d,
+  16|03dc893fd2f3a9509d2f0ed30459aff829cede98826aea0a6ee7a80948c2d74e32,
+  16|02a2f5005d6b714b9c35e9806a9c9f45fd6d7055a112e4f22551c555ccb945d550,
+  32|024e661853c27f2e83300b1ad45c85290861a6eb2d8567ae6595eb6e582770ddf1,
+  32|035ff45bffcec127d65c52aad3fd866591cfd6cdb24cfc95761c1faed0647e1fb5
+
+sig_all_message_sha256 = e070783478edcc7917e26ee2c2b9befc67f5ffc389304519f532d980bc4b5532
+```
+
+The concatenated message is signed by Alice's stage-1 blinded key for each
+balance update. Charlie signs the identical message with his stage-1 blinded
+key when submitting the close swap. Schnorr signature bytes are not fixed by
+this vector because NUT-11 signatures are nondeterministic.

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -14,7 +14,7 @@ layers in
 
 The test names use the exact vector names from this file.
 
-## spilman-test-vector-channel-secret-hkdf-v1-001
+## spilman-test-vector-channel-secret-hkdf
 
 This vector defines the channel-secret derivation in the [Offline Spilman
 channel draft](../XX.md). The private keys below are fixed public test inputs
@@ -51,3 +51,100 @@ channel_secret =
 
 Charlie obtains the same `shared_point`, `dh`, and `channel_secret` from
 `charlie_secret_key * alice_public_key`.
+
+## Shared Deterministic Mint Fixture
+
+The vectors below use this real SAT keyset. It is generated directly with CDK
+from the public test-only mnemonic below and MUST NOT be used for funds. This
+fixture documents test data only; it does not specify Offline Spilman behavior.
+
+```text
+mint_seed_mnemonic = nut nut nut nut nut nut nut nut nut nut nut crunch
+unit = sat
+input_fee_ppk = 0
+denominations = 1, 2, 4, ..., 2147483648
+keyset_id = 01fd5a9250eb619ce33b33bf6e752634a5a8ca4bb629c6b48a99db9c94d09d310d
+```
+
+The complete public SAT keyset is:
+
+```text
+1=025940fded404beb21b53e2bdf8126c988b98389c7356e0b18102231999580a36c
+2=02fd58fdb8a8939ab38e9ba3352167cdee914c71a3e20bdaa7df127ded477703ff
+4=02a9bb3e42b765ce432a1e02bd3e5189b069416a4dd17b92a60b42335854269f60
+8=02c5135a0793aebc1dde718788916fd2f763e8fa95ead4d211eacb965baeca6ae3
+16=0356f90096d7bc3b34a002e5b057ddb7a44be6d6a21b1863aeb152ed248b6a03c4
+32=02cfd62a904934c12c9418c0a1c729b57552ced0f2d3402064e1b3ecd60f76d912
+64=03500bfa755ca5b8e97b88719de7bdd5cea3bb0fd25ce0f50e9dc7b47e19a297c6
+128=0324a535f92e82a5a04b014d742e95a16b85fcf4318e5f792a6a01a87d29c7b048
+256=02fd6baf9d791d5683c6801d5a9898dbed87c87f13520f5296a2e32a511f905296
+512=039a25cccd5849f121ea38abd4252a78175223f91985399c7979a9c1169cf0c403
+1024=03a35bd4f4bb07a470230a981960f9fb33acaa5523b6d28217d3d7cf4a14250cc8
+2048=03ed874ebb9708b6d35d1f06864f19ce319efaf45543e1e8a7ab1cc27e4abab0c5
+4096=032775aa538bb6252ec759b2ca6916ce400bc1f0bc2d24728cdcb7ca90fc08b946
+8192=03a493c8d8c653c7bb12e0e7812b463086581537c52901b4eeb4b140470da1b323
+16384=02b1aa5a46658beead8c75ffaad088f6f6b4f01525ad08eaa88d64091e3ef3878a
+32768=023dc4f1fb0c22e85c10c53dbed19e8487b66b30d1b1abdf055df918f958afb096
+65536=032ae7371305dcc9ad5b8749874ab8417d5d1685d91cf2f3dd38fe08f88ee34bd1
+131072=030344a937f02e50dbd41a460ed65e44aa3ea94749f82d7217e26c124470749792
+262144=02e902875fb29e9cef027c5f27de895b86a967684f5ad84d321fb6ad68df6087ae
+524288=02adc12a3ab59b4dd077a1e7c2ddabb2c157315bd992d7bbc8d17eabdf5e351c52
+1048576=035305b99c4861dc967f084d728b32c28418a52d2b731a96e958ae6079f09b5083
+2097152=029d4ce4c99ca0c40f8e3086343b08df07b58f301b4695b5ab8cea7e16de36be94
+4194304=03271e1cf5b9aa0d246ecc402bab0017e8bf55bd6e99045b85c0ed684bec119c3b
+8388608=02d1567e5866e88bf846aee7cfb7f0219f201dd30656ed89b484d956eaa280e4e9
+16777216=03edbbcea0f37e3c11113fcb1d1da120c1bc771fa1e98b8477639f5d7baad8daee
+33554432=031bc3a038bb294887340ba8c7dbf520069ac1a7fc60fd67e32d248634f9b477ed
+67108864=0209b736cd34ccb545bc2a9a7cb79e47fe575e2409ee9f8571dc2e776411893c70
+134217728=024cd0e494ee09931b6fb860571b8dedf456c2c6928bd91b88fbd0d02105efea32
+268435456=03a636f035481eb006825fed06c597d23a63db42e9068ad809d793f7ed2ab3ad8c
+536870912=03e69698e1242cb31e26e447a56c19a0abfcaabc96e8e31138099d0e754cb06108
+1073741824=021f8dbe172cc14b48654ce9a3b26c8945ce78e3071a3e472111267de7a674cf46
+2147483648=022d410dc2dd4a4e14e4deda462afd1dd7a61a0a2a9f2d3b92b8c7b091bfd45598
+```
+
+## spilman-test-vector-channel-id
+
+This vector defines the canonical channel-ID encoding in the [Offline Spilman
+channel draft](../XX.md). Its `keyset_id` and `input_fee_ppk` are from the
+Shared Deterministic Mint Fixture.
+
+```text
+mint = https://vector-mint.example
+unit = sat
+capacity = 100
+funding_token_amount = 100
+keyset_id = 01fd5a9250eb619ce33b33bf6e752634a5a8ca4bb629c6b48a99db9c94d09d310d
+input_fee_ppk = 0
+maximum_amount = 64
+setup_timestamp = 1700000000
+sender_pubkey = 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+receiver_pubkey = 02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5
+expiry_timestamp = 1800000000
+channel_secret = acfc96a584e645524b017b75cfe0770c3b8dc2ba4f9cef6d99f2cb7bcee691cf
+```
+
+The exact UTF-8 SHA-256 preimage is:
+
+```text
+https://vector-mint.example|sat|100|100|01fd5a9250eb619ce33b33bf6e752634a5a8ca4bb629c6b48a99db9c94d09d310d|0|64|1700000000|0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798|02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5|1800000000|acfc96a584e645524b017b75cfe0770c3b8dc2ba4f9cef6d99f2cb7bcee691cf
+```
+
+```text
+channel_id = SHA256(preimage) =
+  7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e
+```
+
+## spilman-test-vector-channel-id-mint-trailing-slash
+
+This vector verifies that a trailing slash in the mint URL does not affect the
+channel ID. All inputs and the expected output are the same as
+`spilman-test-vector-channel-id`, except:
+
+```text
+mint_input = https://vector-mint.example/
+normalized_mint = https://vector-mint.example
+```
+
+The exact UTF-8 SHA-256 preimage and the expected channel ID are therefore the
+same as `spilman-test-vector-channel-id`.

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -169,6 +169,7 @@ nonce_message =
   7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|funding|64|nonce|0
 nonce_bytes = HMAC-SHA256(channel_secret, nonce_message) =
   f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a
+nonce_bytes is a valid nonzero secp256k1 scalar, so no retry is used.
 Secret.nonce = f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a
 
 retry_counter = 0

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -205,7 +205,7 @@ selected_amounts_largest_first = 32, 32, 32, 4
 ## spilman-test-vector-stage1-key-tweaks-keysetv2
 
 This vector derives the three shared P2PK keys used by every funding proof.
-Each `message` is the exact HMAC-SHA256 input. All retry counters are `0`.
+Each `message` is the exact HMAC-SHA256 input.
 
 ```text
 channel_id = 7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e
@@ -214,21 +214,21 @@ prefix = Cashu_Spilman_stage1_key_tweak_v1
 
 sender_stage1:
   original_pubkey = 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
-  message = Cashu_Spilman_stage1_key_tweak_v17af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|sender_stage1|0
-  scalar = 2c30d26a35b0d093bab0d1d58f6c70572c0c7cd82cb0ecc34d7e26a54a0eae49
-  blinded_pubkey = 03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d
+  message = Cashu_Spilman_stage1_key_tweak_v17af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|sender_stage1
+  scalar = 08bcce7d4847ab4ed33c737431cfe6f6aeba419edd418cae80e12178221296e9
+  blinded_pubkey = 02516479c6dee216722f477dcc5ecddb6a793fa7aaf7d8d2b887f45dc6ff96faee
 
 receiver_stage1:
   original_pubkey = 02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5
-  message = Cashu_Spilman_stage1_key_tweak_v17af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|receiver_stage1|0
-  scalar = ea4bf4110a5c73c232ea288adf577be653d334521a82f71a767fdbe66fb49614
-  blinded_pubkey = 03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455
+  message = Cashu_Spilman_stage1_key_tweak_v17af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|receiver_stage1
+  scalar = 0f1bf68bab1e80af962b49eec1f2dc479c3bff3d093e8d2ad9c4c475713cada9
+  blinded_pubkey = 02b37243d00583b225e1f5dc23a48a7568b09eec889bfa45c20fc865de7309b2a9
 
 sender_stage1_refund:
   original_pubkey = 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
-  message = Cashu_Spilman_stage1_key_tweak_v17af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|sender_stage1_refund|0
-  scalar = 45ad552923c0cd0e988c5a929766c7da81e1b6eced096ff745a3f95b30abbc2b
-  blinded_pubkey = 02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760
+  message = Cashu_Spilman_stage1_key_tweak_v17af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|sender_stage1_refund
+  scalar = 956ac1d4ed35bf4abf97b2177053c50ca66e9e1d614dd3934b2374fa1bda5f2e
+  blinded_pubkey = 022055ae1c0cba2f9cb756b4779276c8e061fe9ccd286c43a91b4164d265fcfbe8
 ```
 
 ## spilman-test-vector-funding-outputs-keysetv2
@@ -244,31 +244,31 @@ keyset_id = 01fd5a9250eb619ce33b33bf6e752634a5a8ca4bb629c6b48a99db9c94d09d310d
 
 amount = 4
 index = 0
-secret = ["P2PK",{"data":"03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d","nonce":"e9aad80a4e747e570bb68cff4f8a33f8c2d904f424e695f9e2febf92bbd4fb30","tags":[["pubkeys","03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455"],["locktime","1800000000"],["n_sigs","2"],["refund","02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
+secret = ["P2PK",{"data":"02516479c6dee216722f477dcc5ecddb6a793fa7aaf7d8d2b887f45dc6ff96faee","nonce":"e9aad80a4e747e570bb68cff4f8a33f8c2d904f424e695f9e2febf92bbd4fb30","tags":[["pubkeys","02b37243d00583b225e1f5dc23a48a7568b09eec889bfa45c20fc865de7309b2a9"],["locktime","1800000000"],["n_sigs","2"],["refund","022055ae1c0cba2f9cb756b4779276c8e061fe9ccd286c43a91b4164d265fcfbe8"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
 nonce = e9aad80a4e747e570bb68cff4f8a33f8c2d904f424e695f9e2febf92bbd4fb30
 blinding_factor = d8d6d77cfe64154981bc10bfbb96987c27353f1854e3b977543e5c92ff91ffef
-blinded_message = 03c1d74cd3ce918288b83438fb63850c4b316a82135afc6543e564c0915facadef
+blinded_message = 036a453cdf46b2abdb52d72c591152199bd386f79dd00c322f2e2d776b0c9ec16a
 
 amount = 32
 index = 0
-secret = ["P2PK",{"data":"03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d","nonce":"879abe0662d57e86ec39d715103c1c95814780b29752c01aadb0888b92d3c081","tags":[["pubkeys","03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455"],["locktime","1800000000"],["n_sigs","2"],["refund","02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
+secret = ["P2PK",{"data":"02516479c6dee216722f477dcc5ecddb6a793fa7aaf7d8d2b887f45dc6ff96faee","nonce":"879abe0662d57e86ec39d715103c1c95814780b29752c01aadb0888b92d3c081","tags":[["pubkeys","02b37243d00583b225e1f5dc23a48a7568b09eec889bfa45c20fc865de7309b2a9"],["locktime","1800000000"],["n_sigs","2"],["refund","022055ae1c0cba2f9cb756b4779276c8e061fe9ccd286c43a91b4164d265fcfbe8"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
 nonce = 879abe0662d57e86ec39d715103c1c95814780b29752c01aadb0888b92d3c081
 blinding_factor = 8952cedabe7d95af9d8388373e1bc2d8cb8897a4e59a5b3c0d3c7e93d2059b0f
-blinded_message = 02f4fa3357831a0eed7aa2ebd0164a75c804a463650c890f37815f5c70f3683265
+blinded_message = 02be9df107c01a2e33640bc229b673b71dccdee427c4e417c83c39f585abfb5dc6
 
 amount = 64
 index = 0
-secret = ["P2PK",{"data":"03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d","nonce":"f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a","tags":[["pubkeys","03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455"],["locktime","1800000000"],["n_sigs","2"],["refund","02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
+secret = ["P2PK",{"data":"02516479c6dee216722f477dcc5ecddb6a793fa7aaf7d8d2b887f45dc6ff96faee","nonce":"f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a","tags":[["pubkeys","02b37243d00583b225e1f5dc23a48a7568b09eec889bfa45c20fc865de7309b2a9"],["locktime","1800000000"],["n_sigs","2"],["refund","022055ae1c0cba2f9cb756b4779276c8e061fe9ccd286c43a91b4164d265fcfbe8"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
 nonce = f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a
 blinding_factor = 95066df465e8e73f5d56df3bcf010ed7c8cc473b0e68ada8bb51589f31009618
-blinded_message = 0365caa01fd1599a8f3c1321022c56680bf010351c2af4c45936fde4bfd8469442
+blinded_message = 02529111ff074c0e7503ab7f299c6221702a77c40354ad5f3e38c7cb61a9dc2c83
 ```
 
 ## spilman-test-vector-stage2-p2bk-keysetv2
 
 This vector fixes the NUT-28 derivation for the commitment-output `(amount,
 index) = (32, 0)` slot. Both entries use the channel ID and channel secret from
-`spilman-test-vector-channel-id-keysetv2`; both scalar retry counters are zero.
+`spilman-test-vector-channel-id-keysetv2`.
 
 ```text
 amount = 32
@@ -276,19 +276,19 @@ index = 0
 
 context = receiver_stage2
 recipient_pubkey = 02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5
-ephemeral_secret = dc2029be89e39a26f5a49653a7de750807002f9549f4774ed8c6376d1cf4bc7b
-p2pk_e = 02224366f001c35581b8316a62160d4e5733f102757a1a824d8e41a9ad795d5a90
-shared_secret_x = e5198d9a589490993b1edd9c5bf76e31bf9610bdca088654fb2d654b62a0085d
-p2bk_scalar = 51db52022fe771a7e084346852a2115fbefd204efe4fb6c5e94cd3844c718e75
-blinded_pubkey = 0397dfedc39293131c2d4c5f76169001e2b11057284dc9345e8178f3ce035660df
+ephemeral_secret = 6736788d5e1325a6ad0aec521c673c80db323ae9cb6e756252d190f658a49da4
+p2pk_e = 03b95460565471b30d35b7b96cb632391c680806dad65379a3bf93e5a66dcc936f
+shared_secret_x = 0b205af6f661eb73197e71666e46f8d7acb03dbe79734d5eb6056b3efa9c5c95
+p2bk_scalar = 40f12c7792828472b303dec3ffd759c374b7646fa73182f737eb4c45a3c9cd61
+blinded_pubkey = 02270ea899810d2f4064d4df8bfc356b5706ba8e236c93c1963f620c14794ad601
 
 context = sender_stage2
 recipient_pubkey = 0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
-ephemeral_secret = b0a12b2dc14d71c23a27c02d35ebde1eccdc50984fac5b4597099cc653a6d69b
-p2pk_e = 02a1be7b930f67d26fd168214a18f5c208cb21cda5f6f08bbf61930cae109d5a39
-shared_secret_x = a1be7b930f67d26fd168214a18f5c208cb21cda5f6f08bbf61930cae109d5a39
-p2bk_scalar = 891005d4ef10bee9b46144fec3d81f051e8d5db42c6078f60a0fd1ad0c4798db
-blinded_pubkey = 023725a2912497df0d49de8269b778e664b917e6c919e122fd099e2e99be03f1af
+ephemeral_secret = 17809cf637c793619c16f1a26a641ec05cc35237205da5c2c705fe0942e51df5
+p2pk_e = 03600d205df80cea1ea916c7a3ea98009a001483aa4a35cfb96ca20ce707f58a74
+shared_secret_x = 600d205df80cea1ea916c7a3ea98009a001483aa4a35cfb96ca20ce707f58a74
+p2bk_scalar = b0706b1fa1e4c0865243c94e7a114ff6b0f5a16664240d90308b1d04023c9704
+blinded_pubkey = 03b5b9b73e75d63ff6a43093ed2604fb056aa932620a80940e25a1d1de4455264f
 ```
 
 ## spilman-test-vector-commitment-outputs-keysetv2
@@ -305,50 +305,50 @@ receiver_balance = 50
 context = receiver
 amount = 2
 index = 0
-secret = ["P2PK",{"data":"03aae5610f300463773890d489bc8638324b7d9966c6aec461b9afe2859cf2be9f","nonce":"008b267f22e9da9672d141c6ca72f069c464e1863909d82e4ccdd0fbca0fe658","tags":[]}]
-p2pk_e = 0254f06f28d614849f7e90c53171b194c358a625864cdf26fec99c78553c6781c5
+secret = ["P2PK",{"data":"03976217324d65dd310860c16ed0ab60b9bb2a7e6bf9354d1d204899f17d6b1e12","nonce":"008b267f22e9da9672d141c6ca72f069c464e1863909d82e4ccdd0fbca0fe658","tags":[]}]
+p2pk_e = 035ccec34674ef9771472cdb1140a30d288a76040b9a402be53638866d3369ab2b
 blinding_factor = 42a8442f1f234b0fd8727e653fc69ff73e66ea3c84b7689a76339d9ab3ff07bf
-blinded_message = 02d177be1fe757258b4a1b520911be0308e58ca235197d31856e4d84f963382dea
+blinded_message = 0225d53d34dfeec3151295621c0094165dd3d94bf4d0f7cf9f4bcd946a94eaaab5
 
 context = receiver
 amount = 16
 index = 0
-secret = ["P2PK",{"data":"03f8d7134afdf587bf8d40d79ae4aab8905e3a2bb378493a46de13daadff24a2b4","nonce":"fe4ac5c03c0dca0ef9af528fddb8975558d03ae7a7f73a93e3718d6f52f4c2f0","tags":[]}]
-p2pk_e = 029927a0192b8c65ad0e4ddbfcb476b4f9f6c4deb8746a4810eb767cfa81d62195
+secret = ["P2PK",{"data":"0355c22359dc1ab7f5c2f3bc90149f949aaffea848f38d3bba967a48d3776ad537","nonce":"fe4ac5c03c0dca0ef9af528fddb8975558d03ae7a7f73a93e3718d6f52f4c2f0","tags":[]}]
+p2pk_e = 02010f9d212bcdece828a68524d97ebe6c4506df314efb7ce0070d04f5084dc2bf
 blinding_factor = 3a793efb2d8332e71a04a4f126ebdf7622546583a25f555dbd028a871858c55e
-blinded_message = 0337c112530d05a669c8be0548d0c9d08583e2b247324686a65cc18a890a5d8826
+blinded_message = 02686997630f52fd739d62b94cd14358f1d4ba5daf3a6d6c3b10ee4479938ccdea
 
 context = receiver
 amount = 32
 index = 0
-secret = ["P2PK",{"data":"0397dfedc39293131c2d4c5f76169001e2b11057284dc9345e8178f3ce035660df","nonce":"0c640e9c0e7b5c13d519e6a5dbae6d84fc8b71a2da736689fd950606aa3abd07","tags":[]}]
-p2pk_e = 02224366f001c35581b8316a62160d4e5733f102757a1a824d8e41a9ad795d5a90
+secret = ["P2PK",{"data":"02270ea899810d2f4064d4df8bfc356b5706ba8e236c93c1963f620c14794ad601","nonce":"0c640e9c0e7b5c13d519e6a5dbae6d84fc8b71a2da736689fd950606aa3abd07","tags":[]}]
+p2pk_e = 03b95460565471b30d35b7b96cb632391c680806dad65379a3bf93e5a66dcc936f
 blinding_factor = acdd0fcfceef385b839d58b70d27dae12d708729e4efefe31f63420c101fae3f
-blinded_message = 03e05451988fcc86fb57b074cdcbd0b6de48e1cf6962ccc494ca15aa56d64d406e
+blinded_message = 02160974d3b2928f741ce5833309d8c572faf4ce64aeb620e7163f34fcd82dff55
 
 context = sender
 amount = 2
 index = 0
-secret = ["P2PK",{"data":"02ff4d525e601d93409a27b86704fd4fef883bba75729cf88eb2e8d59de3a55c58","nonce":"a5a204390c60cca38988fcedc3f77bef1f32272cef922082f3a8cb8de6fbc73d","tags":[]}]
-p2pk_e = 028db3f60a69b312696ca1e54e49a0ea3b9b1aaaf3c1405b412333ac07771707de
+secret = ["P2PK",{"data":"02493df89ad25a74a098b302fdd225344189cb2865c6d1edc2fcd730384888d246","nonce":"a5a204390c60cca38988fcedc3f77bef1f32272cef922082f3a8cb8de6fbc73d","tags":[]}]
+p2pk_e = 0378728c7baf110d9336a9ed523cf49c94473c30f0909cf5d8edfb5ab42a823add
 blinding_factor = 8c525518a63808137e793b3fdd1491b745e737b0cabb42047337825c717cd40a
-blinded_message = 0336186b8e54341d63c7424ce259d4743b3804ac24025d2d9f4911d645f53ce46c
+blinded_message = 032bf5de6d21526305149bc2e08424ed024f74a644409f637902154b28dd2b7278
 
 context = sender
 amount = 16
 index = 0
-secret = ["P2PK",{"data":"039da1bb99af72c4e3359961d06a27fcba0b09c6e9ced64682c5c58f8166df06b5","nonce":"fa5eac4d875dbb343a5840d62a9b6fd0b90d1ee08f1a0b627ba7767c0c622881","tags":[]}]
-p2pk_e = 02f7895660f690f1d498e2f215a7e6de772407b954d09b75e579ed4a284c3a28f7
+secret = ["P2PK",{"data":"02b49021bc36f31cc22f4ee2b70dab41e5900b8d7681e6d415fdf0db2231c55ada","nonce":"fa5eac4d875dbb343a5840d62a9b6fd0b90d1ee08f1a0b627ba7767c0c622881","tags":[]}]
+p2pk_e = 030642bc7f978e74851befc286198a5121b909baf11f90c7b2db0b318062b0e5a9
 blinding_factor = 5c8fbc6e15ed4b6ecf8ba42485db5cf8b4cd44840c60a12c2de289041163536f
-blinded_message = 03431fe8b75f709a9bc7784d34ebc9612dc6b7d3a6ab10ccb5a0e6654fdd9dcae6
+blinded_message = 02a30cde253b234c36193de2b5b91254255ef42250b51628ca856bcebba76f4ecb
 
 context = sender
 amount = 32
 index = 0
-secret = ["P2PK",{"data":"023725a2912497df0d49de8269b778e664b917e6c919e122fd099e2e99be03f1af","nonce":"d19c3e67ae5c9aa3d737ccd349cb83c8f384ec5940d166238da8eef54fcd0cfe","tags":[]}]
-p2pk_e = 02a1be7b930f67d26fd168214a18f5c208cb21cda5f6f08bbf61930cae109d5a39
+secret = ["P2PK",{"data":"03b5b9b73e75d63ff6a43093ed2604fb056aa932620a80940e25a1d1de4455264f","nonce":"d19c3e67ae5c9aa3d737ccd349cb83c8f384ec5940d166238da8eef54fcd0cfe","tags":[]}]
+p2pk_e = 03600d205df80cea1ea916c7a3ea98009a001483aa4a35cfb96ca20ce707f58a74
 blinding_factor = 51a394d16ba49c82f05813628ec414ab082198c9c7136b352df13b828244f00c
-blinded_message = 039143524cc1929a645b93ca820dee2921cdb04633b894537436786c6a0653bdf9
+blinded_message = 03c652d5f40b395d33be28c1547761101cf9f0c65c995b2f701644cb43966d42e0
 
 stable_swap_output_order =
   receiver:2, sender:2, receiver:16, sender:16, receiver:32, sender:32
@@ -367,21 +367,21 @@ their generation and verification are defined by NUT-12.
 
 ```text
 funding_input_0_amount = 4
-funding_input_0_C = 028d2b7d1215b72c2b23d51563fb0d61e3652b87a77ceb3b237df1b9f46b0d044f
+funding_input_0_C = 03324f2f0c4961e71397999bb072623d53e05276faf6e377aff1e04c8fc89757f0
 funding_input_1_amount = 32
-funding_input_1_C = 02de5cb101e677403e4658d615e1a665db787558cccd09ff93a65983fa48fcecfd
+funding_input_1_C = 0396b23d7ddc18f2f2f0a47c464d0316bd65011d1e96605c2d653272cd5955f04b
 funding_input_2_amount = 64
-funding_input_2_C = 03bb199086ab2d33ce69cc80a007b48350fb13ce669af96be24f44613e9d0013b7
+funding_input_2_C = 03ce7ca88ba5cdc6999008b6395feaf372a628587203a974ca1a284f3d019e6484
 
 commitment_outputs_in_order =
-  2|02d177be1fe757258b4a1b520911be0308e58ca235197d31856e4d84f963382dea,
-  2|0336186b8e54341d63c7424ce259d4743b3804ac24025d2d9f4911d645f53ce46c,
-  16|0337c112530d05a669c8be0548d0c9d08583e2b247324686a65cc18a890a5d8826,
-  16|03431fe8b75f709a9bc7784d34ebc9612dc6b7d3a6ab10ccb5a0e6654fdd9dcae6,
-  32|03e05451988fcc86fb57b074cdcbd0b6de48e1cf6962ccc494ca15aa56d64d406e,
-  32|039143524cc1929a645b93ca820dee2921cdb04633b894537436786c6a0653bdf9
+  2|0225d53d34dfeec3151295621c0094165dd3d94bf4d0f7cf9f4bcd946a94eaaab5,
+  2|032bf5de6d21526305149bc2e08424ed024f74a644409f637902154b28dd2b7278,
+  16|02686997630f52fd739d62b94cd14358f1d4ba5daf3a6d6c3b10ee4479938ccdea,
+  16|02a30cde253b234c36193de2b5b91254255ef42250b51628ca856bcebba76f4ecb,
+  32|02160974d3b2928f741ce5833309d8c572faf4ce64aeb620e7163f34fcd82dff55,
+  32|03c652d5f40b395d33be28c1547761101cf9f0c65c995b2f701644cb43966d42e0
 
-sig_all_message_sha256 = 93dde72850cf5dea639d675dc19f829bf85369bebdb8513422982a1a0793415f
+sig_all_message_sha256 = 917319d409c84dccb0d21fe31a6129bbd34c5db72c9757d3a2522eadca030189
 ```
 
 The concatenated message is signed by Alice's stage-1 blinded key for each

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -1,5 +1,19 @@
 # Offline Spilman Channel Test Vectors
 
+## Reference Implementations
+
+Each named test vector in this file is exercised by two independent test
+layers in
+[`cashu_spilman_channels`](https://github.com/SatsAndSports/cashu_spilman_channels):
+
+- [`spilman-test-vectors`](https://github.com/SatsAndSports/cashu_spilman_channels/tree/main/crates/spilman-test-vectors)
+  contains a clean-room reference derivation used to generate and verify the
+  fixed vector values.
+- [`cdk-spilman` compatibility tests](https://github.com/SatsAndSports/cashu_spilman_channels/blob/main/crates/cdk-spilman/tests/spilman_test_vectors.rs)
+  verify that production code derives the same values.
+
+The test names use the exact vector names from this file.
+
 ## spilman-test-vector-channel-secret-hkdf-v1-001
 
 This vector defines the channel-secret derivation in the [Offline Spilman

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -1,0 +1,39 @@
+# Offline Spilman Channel Test Vectors
+
+## spilman-test-vector-channel-secret-hkdf-v1-001
+
+This vector defines the channel-secret derivation in the [Offline Spilman
+channel draft](../XX.md). The private keys below are fixed public test inputs
+only and MUST NOT be used for funds.
+
+```text
+alice_secret_key_hex =
+  0000000000000000000000000000000000000000000000000000000000000001
+
+charlie_secret_key_hex =
+  0000000000000000000000000000000000000000000000000000000000000002
+
+alice_public_key_compressed_sec1_hex =
+  0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+
+charlie_public_key_compressed_sec1_hex =
+  02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5
+
+shared_point_compressed_sec1_hex =
+  02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5
+
+dh = SHA256(compressed_SEC1(alice_secret_key * charlie_public_key)) =
+  b1c9938f01121e159887ac2c8d393a22e4476ff8212de13fe1939de2a236f0a7
+
+hkdf_hash = SHA-256
+hkdf_salt = empty byte string
+hkdf_ikm = dh
+hkdf_info_utf8 = Cashu_Spilman_channel_secret_v1
+hkdf_length = 32
+
+channel_secret =
+  acfc96a584e645524b017b75cfe0770c3b8dc2ba4f9cef6d99f2cb7bcee691cf
+```
+
+Charlie obtains the same `shared_point`, `dh`, and `channel_secret` from
+`charlie_secret_key * alice_public_key`.

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -52,7 +52,7 @@ channel_secret =
 Charlie obtains the same `shared_point`, `dh`, and `channel_secret` from
 `charlie_secret_key * alice_public_key`.
 
-## Shared Deterministic Mint Fixture
+## Shared Deterministic V2 Mint Fixture
 
 The vectors below use this real SAT keyset. It is generated directly with CDK
 from the public test-only mnemonic below and MUST NOT be used for funds. This
@@ -60,6 +60,7 @@ fixture documents test data only; it does not specify Offline Spilman behavior.
 
 ```text
 mint_seed_mnemonic = nut nut nut nut nut nut nut nut nut nut nut crunch
+keyset_version = v2
 unit = sat
 input_fee_ppk = 0
 denominations = 1, 2, 4, ..., 2147483648
@@ -103,11 +104,11 @@ The complete public SAT keyset is:
 2147483648=022d410dc2dd4a4e14e4deda462afd1dd7a61a0a2a9f2d3b92b8c7b091bfd45598
 ```
 
-## spilman-test-vector-channel-id
+## spilman-test-vector-channel-id-keysetv2
 
 This vector defines the canonical channel-ID encoding in the [Offline Spilman
 channel draft](../XX.md). Its `keyset_id` and `input_fee_ppk` are from the
-Shared Deterministic Mint Fixture.
+Shared Deterministic V2 Mint Fixture.
 
 ```text
 mint = https://vector-mint.example
@@ -135,11 +136,11 @@ channel_id = SHA256(preimage) =
   7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e
 ```
 
-## spilman-test-vector-channel-id-mint-trailing-slash
+## spilman-test-vector-channel-id-keysetv2-mint-trailing-slash
 
 This vector verifies that a trailing slash in the mint URL does not affect the
 channel ID. All inputs and the expected output are the same as
-`spilman-test-vector-channel-id`, except:
+`spilman-test-vector-channel-id-keysetv2`, except:
 
 ```text
 mint_input = https://vector-mint.example/
@@ -147,12 +148,12 @@ normalized_mint = https://vector-mint.example
 ```
 
 The exact UTF-8 SHA-256 preimage and the expected channel ID are therefore the
-same as `spilman-test-vector-channel-id`.
+same as `spilman-test-vector-channel-id-keysetv2`.
 
-## spilman-test-vector-output-nonce-and-blinding
+## spilman-test-vector-output-nonce-and-blinding-keysetv2
 
 This vector covers one 64-sat output in the 100-sat funding token from
-`spilman-test-vector-channel-id`. With zero fees and a maximum output amount
+`spilman-test-vector-channel-id-keysetv2`. With zero fees and a maximum output amount
 of 64, that funding token has outputs of 64, 32, and 4 sats. This vector does
 not define the funding output's stage-1 P2PK keys; it only defines its
 per-proof NUT-10 nonce and Cashu blind-signature blinding factor.

--- a/tests/XX-tests.md
+++ b/tests/XX-tests.md
@@ -172,15 +172,14 @@ nonce_bytes = HMAC-SHA256(channel_secret, nonce_message) =
 nonce_bytes is a valid nonzero secp256k1 scalar, so no retry is used.
 Secret.nonce = f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a
 
-retry_counter = 0
 blinding_message =
-  7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|funding|64|blinding|0|0
+  7af675f4f1b9843200d23060ebeb5bf5abea67fa511af79aefa4ba6a19b88c2e|funding|64|blinding|0
 blinding_factor = HMAC-SHA256(channel_secret, blinding_message) =
-  74285411dc702b0e295f143d026b95bd75cf730647a694e5c5b8147f619d1b35
+  95066df465e8e73f5d56df3bcf010ed7c8cc473b0e68ada8bb51589f31009618
 ```
 
-The `blinding_factor` is a valid secp256k1 scalar. It is the first valid
-candidate, so no retry is needed for this vector.
+The `blinding_factor` is a valid secp256k1 scalar, so no retry is needed for
+this vector.
 
 ## spilman-test-vector-amount-selection-keysetv2
 
@@ -247,22 +246,22 @@ amount = 4
 index = 0
 secret = ["P2PK",{"data":"03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d","nonce":"e9aad80a4e747e570bb68cff4f8a33f8c2d904f424e695f9e2febf92bbd4fb30","tags":[["pubkeys","03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455"],["locktime","1800000000"],["n_sigs","2"],["refund","02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
 nonce = e9aad80a4e747e570bb68cff4f8a33f8c2d904f424e695f9e2febf92bbd4fb30
-blinding_factor = 89d7fc20c07229e615c9365c83b70938566037c55fe61c102afee78ff44fab66
-blinded_message = 027e3b02f160f2d75b276bd411821a2fc66bd3ba4aed5fc23b9a88e472dd641134
+blinding_factor = d8d6d77cfe64154981bc10bfbb96987c27353f1854e3b977543e5c92ff91ffef
+blinded_message = 03c1d74cd3ce918288b83438fb63850c4b316a82135afc6543e564c0915facadef
 
 amount = 32
 index = 0
 secret = ["P2PK",{"data":"03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d","nonce":"879abe0662d57e86ec39d715103c1c95814780b29752c01aadb0888b92d3c081","tags":[["pubkeys","03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455"],["locktime","1800000000"],["n_sigs","2"],["refund","02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
 nonce = 879abe0662d57e86ec39d715103c1c95814780b29752c01aadb0888b92d3c081
-blinding_factor = 932933b55f73dfc76c8fd04e671360e46fc2be33878e83ebde17a5c48651744c
-blinded_message = 034e10f284aceb8d8a316105f2533583c7f4e5ea6b2102f276403d061f1ee9460f
+blinding_factor = 8952cedabe7d95af9d8388373e1bc2d8cb8897a4e59a5b3c0d3c7e93d2059b0f
+blinded_message = 02f4fa3357831a0eed7aa2ebd0164a75c804a463650c890f37815f5c70f3683265
 
 amount = 64
 index = 0
 secret = ["P2PK",{"data":"03da88bac82ac2731d6f4463e2d981824ea2d0e4862215bf8a422b1afe4eea6a8d","nonce":"f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a","tags":[["pubkeys","03c988d50c11fa634afdd519e2a9ce751adf29f0b17ad6251b7c199fdf9c1f7455"],["locktime","1800000000"],["n_sigs","2"],["refund","02d9194f39e5689e97a4f20614b09e5ec751edc41f63d0bde6fc39d7dfeba74760"],["n_sigs_refund","1"],["sigflag","SIG_ALL"]]}]
 nonce = f934dd4311715f9e9af3d338c2b7235581a779f748839ffbfe584b0c1e21e37a
-blinding_factor = 74285411dc702b0e295f143d026b95bd75cf730647a694e5c5b8147f619d1b35
-blinded_message = 03fb84f24c1bb271786a89aaeaff334c36db02bde6e1f9607d69f94db907b48bbf
+blinding_factor = 95066df465e8e73f5d56df3bcf010ed7c8cc473b0e68ada8bb51589f31009618
+blinded_message = 0365caa01fd1599a8f3c1321022c56680bf010351c2af4c45936fde4bfd8469442
 ```
 
 ## spilman-test-vector-stage2-p2bk-keysetv2
@@ -308,48 +307,48 @@ amount = 2
 index = 0
 secret = ["P2PK",{"data":"03aae5610f300463773890d489bc8638324b7d9966c6aec461b9afe2859cf2be9f","nonce":"008b267f22e9da9672d141c6ca72f069c464e1863909d82e4ccdd0fbca0fe658","tags":[]}]
 p2pk_e = 0254f06f28d614849f7e90c53171b194c358a625864cdf26fec99c78553c6781c5
-blinding_factor = 9c9107c949e3bb007439519cad428379702bfac828b33fcad7a5b885ba2a95bf
-blinded_message = 033a81f9199fda2d0b6955a4114cd2ddffc52b2ddf89197b5a04bd806c8843399e
+blinding_factor = 42a8442f1f234b0fd8727e653fc69ff73e66ea3c84b7689a76339d9ab3ff07bf
+blinded_message = 02d177be1fe757258b4a1b520911be0308e58ca235197d31856e4d84f963382dea
 
 context = receiver
 amount = 16
 index = 0
 secret = ["P2PK",{"data":"03f8d7134afdf587bf8d40d79ae4aab8905e3a2bb378493a46de13daadff24a2b4","nonce":"fe4ac5c03c0dca0ef9af528fddb8975558d03ae7a7f73a93e3718d6f52f4c2f0","tags":[]}]
 p2pk_e = 029927a0192b8c65ad0e4ddbfcb476b4f9f6c4deb8746a4810eb767cfa81d62195
-blinding_factor = 3bc38b19a49bc506cee66eca9a779dcb4fc132aea294713150532fae82152e39
-blinded_message = 03dc893fd2f3a9509d2f0ed30459aff829cede98826aea0a6ee7a80948c2d74e32
+blinding_factor = 3a793efb2d8332e71a04a4f126ebdf7622546583a25f555dbd028a871858c55e
+blinded_message = 0337c112530d05a669c8be0548d0c9d08583e2b247324686a65cc18a890a5d8826
 
 context = receiver
 amount = 32
 index = 0
 secret = ["P2PK",{"data":"0397dfedc39293131c2d4c5f76169001e2b11057284dc9345e8178f3ce035660df","nonce":"0c640e9c0e7b5c13d519e6a5dbae6d84fc8b71a2da736689fd950606aa3abd07","tags":[]}]
 p2pk_e = 02224366f001c35581b8316a62160d4e5733f102757a1a824d8e41a9ad795d5a90
-blinding_factor = de8dedd0c3484e02422ee298d7fa97cca44b80d82d7c6b7ab33743aa32d78e3d
-blinded_message = 024e661853c27f2e83300b1ad45c85290861a6eb2d8567ae6595eb6e582770ddf1
+blinding_factor = acdd0fcfceef385b839d58b70d27dae12d708729e4efefe31f63420c101fae3f
+blinded_message = 03e05451988fcc86fb57b074cdcbd0b6de48e1cf6962ccc494ca15aa56d64d406e
 
 context = sender
 amount = 2
 index = 0
 secret = ["P2PK",{"data":"02ff4d525e601d93409a27b86704fd4fef883bba75729cf88eb2e8d59de3a55c58","nonce":"a5a204390c60cca38988fcedc3f77bef1f32272cef922082f3a8cb8de6fbc73d","tags":[]}]
 p2pk_e = 028db3f60a69b312696ca1e54e49a0ea3b9b1aaaf3c1405b412333ac07771707de
-blinding_factor = 2c0d9ab01f983f1610a9f8a9b1a3773923bda5e8938b5a15b89c13f02ea0ccd9
-blinded_message = 02cf1e71062b1e7ff01986cd0160174c7b039b4b94cd0ef5e1518fe776a1b3154d
+blinding_factor = 8c525518a63808137e793b3fdd1491b745e737b0cabb42047337825c717cd40a
+blinded_message = 0336186b8e54341d63c7424ce259d4743b3804ac24025d2d9f4911d645f53ce46c
 
 context = sender
 amount = 16
 index = 0
 secret = ["P2PK",{"data":"039da1bb99af72c4e3359961d06a27fcba0b09c6e9ced64682c5c58f8166df06b5","nonce":"fa5eac4d875dbb343a5840d62a9b6fd0b90d1ee08f1a0b627ba7767c0c622881","tags":[]}]
 p2pk_e = 02f7895660f690f1d498e2f215a7e6de772407b954d09b75e579ed4a284c3a28f7
-blinding_factor = 603d1b5b9c66de9a5144c19bbac91e943feccb8d5d408c7a1ce4092bc5bd4b8f
-blinded_message = 02a2f5005d6b714b9c35e9806a9c9f45fd6d7055a112e4f22551c555ccb945d550
+blinding_factor = 5c8fbc6e15ed4b6ecf8ba42485db5cf8b4cd44840c60a12c2de289041163536f
+blinded_message = 03431fe8b75f709a9bc7784d34ebc9612dc6b7d3a6ab10ccb5a0e6654fdd9dcae6
 
 context = sender
 amount = 32
 index = 0
 secret = ["P2PK",{"data":"023725a2912497df0d49de8269b778e664b917e6c919e122fd099e2e99be03f1af","nonce":"d19c3e67ae5c9aa3d737ccd349cb83c8f384ec5940d166238da8eef54fcd0cfe","tags":[]}]
 p2pk_e = 02a1be7b930f67d26fd168214a18f5c208cb21cda5f6f08bbf61930cae109d5a39
-blinding_factor = df1c0c9bb910d9dcbace8fa188e38c72ec9e90474b9c574d789aa45b1c31b530
-blinded_message = 035ff45bffcec127d65c52aad3fd866591cfd6cdb24cfc95761c1faed0647e1fb5
+blinding_factor = 51a394d16ba49c82f05813628ec414ab082198c9c7136b352df13b828244f00c
+blinded_message = 039143524cc1929a645b93ca820dee2921cdb04633b894537436786c6a0653bdf9
 
 stable_swap_output_order =
   receiver:2, sender:2, receiver:16, sender:16, receiver:32, sender:32
@@ -375,14 +374,14 @@ funding_input_2_amount = 64
 funding_input_2_C = 03bb199086ab2d33ce69cc80a007b48350fb13ce669af96be24f44613e9d0013b7
 
 commitment_outputs_in_order =
-  2|033a81f9199fda2d0b6955a4114cd2ddffc52b2ddf89197b5a04bd806c8843399e,
-  2|02cf1e71062b1e7ff01986cd0160174c7b039b4b94cd0ef5e1518fe776a1b3154d,
-  16|03dc893fd2f3a9509d2f0ed30459aff829cede98826aea0a6ee7a80948c2d74e32,
-  16|02a2f5005d6b714b9c35e9806a9c9f45fd6d7055a112e4f22551c555ccb945d550,
-  32|024e661853c27f2e83300b1ad45c85290861a6eb2d8567ae6595eb6e582770ddf1,
-  32|035ff45bffcec127d65c52aad3fd866591cfd6cdb24cfc95761c1faed0647e1fb5
+  2|02d177be1fe757258b4a1b520911be0308e58ca235197d31856e4d84f963382dea,
+  2|0336186b8e54341d63c7424ce259d4743b3804ac24025d2d9f4911d645f53ce46c,
+  16|0337c112530d05a669c8be0548d0c9d08583e2b247324686a65cc18a890a5d8826,
+  16|03431fe8b75f709a9bc7784d34ebc9612dc6b7d3a6ab10ccb5a0e6654fdd9dcae6,
+  32|03e05451988fcc86fb57b074cdcbd0b6de48e1cf6962ccc494ca15aa56d64d406e,
+  32|039143524cc1929a645b93ca820dee2921cdb04633b894537436786c6a0653bdf9
 
-sig_all_message_sha256 = e070783478edcc7917e26ee2c2b9befc67f5ffc389304519f532d980bc4b5532
+sig_all_message_sha256 = 93dde72850cf5dea639d675dc19f829bf85369bebdb8513422982a1a0793415f
 ```
 
 The concatenated message is signed by Alice's stage-1 blinded key for each


### PR DESCRIPTION
With this NUT, Alice and Bob can - using any mint supporting P2PK (NUT-11) - set up a channel where, once this 'cashu channel' is opened, Alice can decrease her own balance and increase Bob's balance. After each update, Bob can verify the new balance without needing to contact the mint for every update of the balance.

This allows a very large number (billions) of balance updates, where each update may be very small (millisat), but with only using a small number (dozens) of proofs prepared in advance.

Some features:
 - blinding the pubkey, for extra privacy, using P2BK (NUT-28)
 - deterministic outputs, as a function of the channel parameters, to minimize the bandwidth
 - the receiver can verify the opening of a channel and the payments without needing to contact the mint. The server contacts the mint only when they decide to close the channel