### PR TITLE
fix: use new signing scheme for SIG_ALL

### DIFF
--- a/tests/11-test.md
+++ b/tests/11-test.md
@@ -220,7 +220,7 @@ The following is an invalid `SwapRequest` with pubkeys and refund mixed.
 
 The following is a `SwapRequest` with locktime passed and refund keys signatures are valid
 
-```json
+````json
 {
   "inputs": [
     {
@@ -261,9 +261,8 @@ The following is a valid `SwapRequest` with an HTLC also locked to a public key
     }
   ]
 }
-```
+````
 
-TODO
 The following is an invalid `SwapRequest` with an HTLC also locked to a public key, locktime and refund key. locktime is
 not expired but proof is signed with refund key.
 
@@ -341,7 +340,6 @@ Example `MeltRequest`:
 ```
 
 The following is the valid `msg_to_sign` on the above `MeltRequest`.
-
 
 ```
 ["P2PK",{"nonce":"bbf9edf441d17097e39f5095a3313ba24d3055ab8a32f758ff41c10d45c4f3de","data":"029116d32e7da635c8feeb9f1f4559eb3d9b42d400f9d22a64834d89cde0eb6835","tags":[["sigflag","SIG_ALL"]]}]02a9d461ff36448469dccf828fa143833ae71c689886ac51b62c8d61ddaa10028b0038ec853d65ae1b79b5cdbc2774150b2cb288d6d26e12958a16fb33c32d9a86c39cF8911fzT88aEi1d-6boZZkq5lYxbUSVs-HbJxK0


### PR DESCRIPTION
Modify the current SIG_ALL test vectors to use the new signing scheme. 

This Test vectors where generated using CDK as a WALLET and Nutmix as a MINT