### PR TITLE
NUT-21: Fixes leftover XX -> 21

### DIFF
--- a/suppl/21.md
+++ b/suppl/21.md
@@ -1,6 +1,6 @@
-# NUT-XX-SUPPL: Clear Authentication
+# NUT-21-SUPPL: Clear Authentication
 
-`for: NUT-XX`
+`for: NUT-21`
 
 ---
 


### PR DESCRIPTION
The suppl/21.md had a couple of leftover `XX` references. Now fixed to `21`