### PR TITLE
NUT-12 DLEQ: 'r' refers to the mint's random nonce, and also to Alice's blinding factor. Rename one of them to avoid confusion

### DIFF
--- a/12.md
+++ b/12.md
@@ -18,11 +18,11 @@ The complete DLEQ proof reads
 (These steps occur when Bob returns C')
 
 Bob:
-m = a random nonce, selected by Bob the mint and not shared
-R1 = m*G
-R2 = m*B'
+k = a random nonce, selected by Bob the mint and not shared
+R1 = k*G
+R2 = k*B'
 e = hash(R1,R2,A,C')
-s = m + e*a
+s = k + e*a
 return e, s
 
 Alice:


### PR DESCRIPTION
_Update: 2025-11-25: instead of the note, this PR now just renames one of the variables, so that we no longer have two different variables with the same name_

In NUT-00, `r` refers to the _blinding factor_ which Alice's uses to blind and unblind. This is also used in this NUT-12 when Alice sends her blinding factor to Carol. This is _not_ shared with the mint.

But the DLEQ proof here in NUT-12 also reuses `r` to refer to the random nonce selected by Bob the mint, and Bob doesn't share this with Alice or Carol.

Two different variables with the same name (`r`) is confusing

This PR rename's Bob's (the mint) `r` to `m` to ensure that this isn't confused with Alice's `r`