### PR TITLE
Add new error codes 10001, 10003 for pending objects + rename tokens to proofs

### DIFF
--- a/error_codes.md
+++ b/error_codes.md
@@ -2,13 +2,12 @@
 
 | Code  | Description                                     | Relevant nuts                            |
 | ----- | ----------------------------------------------- | ---------------------------------------- |
-| 10001 | Outputs are pending                             | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
-| 10002 | Outputs already signed                          | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
-| 10003 | Proofs could not be verified                    | [NUT-03][03], [NUT-05][05]               |
-| 10003 | Proofs are pending                              | [NUT-03][03], [NUT-05][05]               |
+| 10001 | Proof verification failed                       | [NUT-03][03], [NUT-05][05]               |
 | 11001 | Proofs already spent                            | [NUT-03][03], [NUT-05][05]               |
-| 11002 | Transaction is not balanced (inputs != outputs) | [NUT-02][02], [NUT-03][03], [NUT-05][05] |
-| 11005 | Unit in request is not supported                | [NUT-04][04], [NUT-05][05]               |
+| 11002 | Proofs are pending                              | [NUT-03][03], [NUT-05][05]               |
+| 11003 | Outputs already signed                          | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
+| 11004 | Outputs are pending                             | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
+| 11005 | Transaction is not balanced (inputs != outputs) | [NUT-02][02], [NUT-03][03], [NUT-05][05] |
 | 11006 | Amount outside of limit range                   | [NUT-04][04], [NUT-05][05]               |
 | 11007 | Duplicate inputs provided                       | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
 | 11008 | Duplicate outputs provided                      | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
@@ -16,6 +15,7 @@
 | 11010 | Inputs and outputs not of same unit             | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
 | 11011 | Amountless invoice is not supported             | [NUT-05][05]                             |
 | 11012 | Amount in request does not equal invoice        | [NUT-05][05]                             |
+| 11013 | Unit in request is not supported                | [NUT-04][04], [NUT-05][05]               |
 | 12001 | Keyset is not known                             | [NUT-02][02], [NUT-04][04]               |
 | 12002 | Keyset is inactive, cannot sign messages        | [NUT-02][02], [NUT-03][03], [NUT-04][04] |
 | 20001 | Quote request is not paid                       | [NUT-04][04]                             |


### PR DESCRIPTION
We introduce two new error codes for the "pending" state of both input proofs and output blinded messages. These objects are "pending" in the mint, if they are currently in a transaction. This is distinct from "already spent" and "already signed" which means they have already been successfully processed in a transaction.

We also changed the nomenclature in the error messages from "Tokens" to "Proofs".

## Summary

**5 New Error Codes:**
1. New error: **10001** - Proof verification failed
2. New error: **11002** - Proofs are pending
3. New error: **11003** - Outputs already signed
4. New error: **11004** - Outputs are pending
5. New error: **11013** - Unit in request is not supported

**4 Changed Error Codes:**
1. Changed error **10002 → 11003** (Outputs already signed)
2. Changed error **10003 → 10001** (Proof verification failed)
3. Changed error **11005 → 11013** (Unit not supported - moved)
4. Changed error **11002 → 11005** (Transaction not balanced - moved)

**1 Updated Description:**
- Error **20002** - Description clarified from "Tokens have already been issued for quote" to "Quote has already been issued"

Tracking mints:

- [ ] nutshell https://github.com/cashubtc/nutshell/pull/852
- [ ] cdk https://github.com/cashubtc/cdk/pull/1396
- [ ] nutmix

Wallets:
- [ ] cashu.me
- [ ] 