### PR TITLE
NUT-11: Optional P2PKWitness.digest for multi-party SIG_ALL

### DIFF
--- a/11.md
+++ b/11.md
@@ -75,6 +75,8 @@ In cases where `SIG_ALL` signers require detailed information about the inputs a
 
 If both `digest` and `mts` are included, a wallet SHOULD use the `mts` and IGNORE the `digest`, or MUST validate the `digest` matches the `SHA256(mts)` before using it.
 
+Wallets SHOULD remove the `digest` and `mts` before sending to proofs to the mint.
+
 ## Tags
 
 More complex spending conditions can be defined in the tags in `Secret.tags`. All tags are optional. Tags are arrays with two or more strings being `["key", "value1", "value2", ...]`. We denote a specific tag in a proof by its `key`.

--- a/11.md
+++ b/11.md
@@ -63,12 +63,17 @@ Signatures are stored in `P2PKWitness` objects and are provided in either each `
 {
   "signatures": <Array[<hex_str>]>,
   "digest": <str> // Optional.
+  "mts": <str>, // Optional.
 }
 ```
 
 The `signatures` are an array of signatures in hex and correspond to the signatures by one or more signing public keys.
 
 To facilitate the signing of multi-party `SIG_ALL` transactions, the SHA256 digest of the message to be signed can be stored in the optional `P2PKWitness.digest` of the `Proof` to be signed. Wallets SHOULD sign a `SIG_ALL` proof over this digest, if present, and ignore it entirely for `SIG_INPUTS` proofs.
+
+In cases where `SIG_ALL` signers require detailed information about the inputs and outputs (eg: where there are multiple receivers), the plain text _message to sign_ can be stored in the `P2PKWitness.mts` of the `Proof` to be signed. Wallets **MUST** sign a `SIG_ALL` proof over the SHA256 of this message. if present, and ignore it entirely for `SIG_INPUTS` proofs.
+
+If both `digest` and `mts` are included, a wallet SHOULD use the `mts` and IGNORE the `digest`, or MUST validate the `digest` matches the `SHA256(mts)` before using it.
 
 ## Tags
 

--- a/11.md
+++ b/11.md
@@ -62,8 +62,8 @@ Signatures are stored in `P2PKWitness` objects and are provided in either each `
 ```json
 {
   "signatures": <Array[<hex_str>]>,
-  "digest": <str> // Optional.
-  "mts": <str>, // Optional.
+  "digest": <str>, // Optional.
+  "mts": <str> // Optional.
 }
 ```
 

--- a/11.md
+++ b/11.md
@@ -71,7 +71,7 @@ The `signatures` are an array of signatures in hex and correspond to the signatu
 
 To facilitate the signing of multi-party `SIG_ALL` transactions, the SHA256 digest of the message to be signed can be stored in the optional `P2PKWitness.digest` of the `Proof` to be signed. Wallets SHOULD sign a `SIG_ALL` proof over this digest, if present, and ignore it entirely for `SIG_INPUTS` proofs.
 
-In cases where `SIG_ALL` signers require detailed information about the inputs and outputs (eg: where there are multiple receivers), the plain text _message to sign_ can be stored in the `P2PKWitness.mts` of the `Proof` to be signed. Wallets **MUST** sign a `SIG_ALL` proof over the SHA256 of this message. if present, and ignore it entirely for `SIG_INPUTS` proofs.
+In cases where `SIG_ALL` signers require detailed information about the inputs and outputs (eg: where there are multiple receivers), the plain text _message to sign_ can be stored in the `P2PKWitness.mts` of the `Proof` to be signed. Wallets **MUST** sign a `SIG_ALL` proof over the SHA256 of this message, if present, and ignore it entirely for `SIG_INPUTS` proofs.
 
 If both `digest` and `mts` are included, a wallet SHOULD use the `mts` and IGNORE the `digest`, or MUST validate the `digest` matches the `SHA256(mts)` before using it.
 

--- a/11.md
+++ b/11.md
@@ -75,7 +75,7 @@ In cases where `SIG_ALL` signers require detailed information about the inputs a
 
 If both `digest` and `mts` are included, a wallet SHOULD use the `mts` and IGNORE the `digest`, or MUST validate the `digest` matches the `SHA256(mts)` before using it.
 
-Wallets SHOULD remove the `digest` and `mts` before sending to proofs to the mint.
+Wallets SHOULD remove the `digest` and `mts` before sending the proofs to the mint.
 
 ## Tags
 

--- a/11.md
+++ b/11.md
@@ -61,11 +61,14 @@ Signatures are stored in `P2PKWitness` objects and are provided in either each `
 
 ```json
 {
-  "signatures": <Array[<hex_str>]>
+  "signatures": <Array[<hex_str>]>,
+  "digest": <str> // Optional.
 }
 ```
 
 The `signatures` are an array of signatures in hex and correspond to the signatures by one or more signing public keys.
+
+To facilitate the signing of multi-party `SIG_ALL` transactions, the SHA256 digest of the message to be signed can be stored in the optional `P2PKWitness.digest` of the `Proof` to be signed. Wallets SHOULD sign a `SIG_ALL` proof over this digest, if present, and ignore it entirely for `SIG_INPUTS` proofs.
 
 ## Tags
 


### PR DESCRIPTION
Closes #319

This PR proposes an optional `digest` and `mts` ("message to sign") keys be added to the `P2PKWitness` object. This allows the receiver/co-ordinator to pass around a token containing the Proof(s) to sign to other parties. 

The `P2PKWitness.digest` tells the other party the message to sign for that Proof. 

The `P2PKWitness.mts` is the raw message for use in cases where signers require the detail of the inputs and outputs.