### PR TITLE
Nut00 conventions

### DIFF
--- a/13.md
+++ b/13.md
@@ -92,8 +92,6 @@ Using the `secret` string and the private key `r`, the wallet generates a `Blind
 
 The user's wallet can now request the corresponding `BlindSignatures` for theses `BlindedMessages` from the mint using the [NUT-09][09] restore endpoint or by downloading the entire mint's database.
 
-> [!NOTE]
-
 #### Generate `Proofs`
 
 Using the restored `BlindSignatures` and the `r` generated in the previous step, the wallet can [unblind][00] the signature to `C`. The triple `(secret, C, amount)` is a restored `Proof`.


### PR DESCRIPTION
# Closes: #321

This PR adds some clarifying default conventions for the NUTS, and clarifies the BIP32 handling for invalid derivations in NUT-13