### PR TITLE
NUT-21 and NUT-22 matching rules

### DIFF
--- a/21.md
+++ b/21.md
@@ -53,9 +53,14 @@ The mint lists each protected endpoint that requires a clear authentication toke
 
 The `*` wildcard, if present, MUST be the final character only.
 
-For example, `/v1/auth/*` matches any path that starts with `/v1/auth/`.
+For example:
 
-In the example above, the `/v1/auth/blind/mint` path is the exact match [NUT-22][22] endpoint for obtaining blind authentication tokens (BATs).
+- `/v1/*` matches any path starting `/v1/` (all endpoints)
+- `/v1/auth/*` matches any path that starts with `/v1/auth/` (all auth endpoints)
+- `/v1/mint/*` matches any path that starts with `/v1/mint/` (all minting endpoints)
+- `/v1/mint/bolt*` matches any path starting `/v1/mint/bolt` (bolt11/12 minting endpoints)
+
+In the example above, the `/v1/auth/blind/mint` path is the **exact match** [NUT-22][22] endpoint for obtaining blind authentication tokens (BATs).
 
 > [!CAUTION]
 > Wallets **MUST** treat mint provided `path` values as untrusted input and use exact or prefix matching only. Never use regex matching on untrusted input.

--- a/22.md
+++ b/22.md
@@ -229,7 +229,11 @@ The mint lists each protected endpoint that requires a blind authentication toke
 
 The `*` wildcard, if present, MUST be the final character only.
 
-For example, `/v1/mint/*` matches any path that starts with `/v1/mint/`.
+For example:
+
+- `/v1/*` matches any path starting `/v1/` (all endpoints)
+- `/v1/mint/*` matches any path that starts with `/v1/mint/` (all minting endpoints)
+- `/v1/mint/bolt*` matches any path starting `/v1/mint/bolt` (bolt11/12 minting endpoints)
 
 > [!CAUTION]
 > Wallets **MUST** treat mint provided `path` values as untrusted input and use exact or prefix matching only. Never use regex matching on untrusted input.


### PR DESCRIPTION
Clarifies `protected_endpoints` matching rules for NUT-21 and NUT-22

- [x] CDK: https://github.com/cashubtc/cdk/pull/1586
- [x] Cashu-TS: https://github.com/cashubtc/cashu-ts/pull/483
- [x] Nutshell: https://github.com/cashubtc/nutshell/pull/885