### PR TITLE
Add error codes for max inputs and outputs for a operation

### DIFF
--- a/error_codes.md
+++ b/error_codes.md
@@ -16,6 +16,8 @@
 | 11011 | Amountless invoice is not supported             | [NUT-05][05]                             |
 | 11012 | Amount in request does not equal invoice        | [NUT-05][05]                             |
 | 11013 | Unit in request is not supported                | [NUT-04][04], [NUT-05][05]               |
+| 11014 | Max inputs exceeded                             | [NUT-03][03], [NUT-05][05]               |
+| 11015 | Max outputs exceeded                            | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
 | 12001 | Keyset is not known                             | [NUT-02][02], [NUT-04][04]               |
 | 12002 | Keyset is inactive, cannot sign messages        | [NUT-02][02], [NUT-03][03], [NUT-04][04] |
 | 20001 | Quote request is not paid                       | [NUT-04][04]                             |


### PR DESCRIPTION
Currently I think nutshell just responds with a 422 for this. I think it could be worth adding to the spec'd error codes.

- [x] cdk: https://github.com/cashubtc/cdk/pull/1619
 - [ ] nutshell: 
 - [x] cashu-ts: 