### PR TITLE
Require mints to support the CORS Prefer header

### DIFF
--- a/05.md
+++ b/05.md
@@ -127,6 +127,9 @@ The wallet includes the following common data in its request:
 
 where `quote` is the melt quote ID and `inputs` are the proofs with a total amount sufficient to cover the requested amount plus any fees.
 
+> [!IMPORTANT]
+> The `Prefer: respond-async` header is not on the default CORS safelist, so mints **MUST** include `Prefer` in their CORS `Access-Control-Allow-Headers`, EVEN if the mint does not allow async processing.
+
 #### Synchronous Response
 
 For synchronous processing, the mint responds with a structure that indicates the final payment state and includes any method-specific proof of payment when successful.


### PR DESCRIPTION
NUT-05 allows asynchronous processing to be requested using the `Prefer: respond-async` header.

As this is an allowable option, mints must support this in their CORS `Access-Control-Allow-Headers`, EVEN if the mint does not allow async processing.

The prevents clients, such as web browsers, receiving network errors on CORS preflight if they set the header.

See also : https://github.com/cashubtc/cdk/pull/1607

## Alternative

We might consider replacing this valid but unsafelisted header with an optional field in the POST body. That way, if mints do not support async processing, they need do nothing.