### PR TITLE
Feat(melt): replace Prefer header with prefer_async field in POST data

### DIFF
--- a/05.md
+++ b/05.md
@@ -28,7 +28,7 @@ The melting process follows these steps for all payment methods:
 
 **Synchronous (Default):** The melt request blocks until payment completion. This ensures immediate finality but may result in long request times for slow payment methods.
 
-**Asynchronous (Optional):** When the `Prefer: respond-async` header is included and supported by the mint, the request returns immediately after validation with a `"PENDING"` state. The wallet must then monitor the payment progress through polling or websocket notifications.
+**Asynchronous (Optional):** When the `prefer_async: true` param is included and supported by the mint, the request returns immediately after validation with a `"PENDING"` state. The wallet must then monitor the payment progress through polling or websocket notifications.
 
 ## Common Request and Response Formats
 
@@ -89,21 +89,20 @@ To execute the melting process, the wallet calls the `POST /v1/melt/{method}` en
 POST https://mint.host:3338/v1/melt/{method}
 ```
 
-#### Synchronous Processing (Default)
+The wallet includes the following common data in its request:
 
-> [!IMPORTANT]
-> For methods that involve external payments (like Lightning), this call may block until the payment either succeeds or fails. This can take a long time. Make sure to **use no (or a very long) timeout when making this call**!
-
-#### Asynchronous Processing
-
-The wallet can include the `Prefer: respond-async` header to request asynchronous processing:
-
-```http
-POST https://mint.host:3338/v1/melt/{method}
-Prefer: respond-async
+```json
+{
+  "quote": <str>,
+  "inputs": <Array[Proof]>,
+  "prefer_async": <bool> // optional: false if omitted
+  // Additional method-specific fields may be required
+}
 ```
 
-When the `Prefer: respond-async` header is included:
+where `quote` is the melt quote ID and `inputs` are the proofs with a total amount sufficient to cover the requested amount plus any fees.
+
+When `prefer_async: true` is included in the request data:
 
 - **If the mint supports asynchronous processing:**
   1. The mint will verify the request (including proof validation)
@@ -112,20 +111,11 @@ When the `Prefer: respond-async` header is included:
   4. The wallet can poll the quote state endpoint or subscribe to websocket notifications to monitor payment progress
 
 - **If the mint does not support asynchronous processing:**
-  - The mint ignores the `Prefer` header and processes the request synchronously
+  - The mint ignores the `prefer_async` field and processes the request synchronously
   - The response follows the standard synchronous flow with final payment state
 
-The wallet includes the following common data in its request:
-
-```json
-{
-  "quote": <str>,
-  "inputs": <Array[Proof]>
-  // Additional method-specific fields may be required
-}
-```
-
-where `quote` is the melt quote ID and `inputs` are the proofs with a total amount sufficient to cover the requested amount plus any fees.
+> [!IMPORTANT]
+> For methods that involve external payments (like Lightning), a synchronous call will block until the payment either succeeds or fails. This can take a long time. Make sure to **use no (or a very long) timeout when making this call**!
 
 #### Synchronous Response
 
@@ -133,7 +123,7 @@ For synchronous processing, the mint responds with a structure that indicates th
 
 #### Asynchronous Response
 
-For asynchronous processing with `Prefer: respond-async`, the mint responds with:
+For asynchronous processing when `prefer_async: true` is included in the request data, the mint responds with:
 
 ```http
 HTTP/1.1 200 OK
@@ -162,12 +152,12 @@ The wallet should then either:
 
 ```http
 POST https://mint.host:3338/v1/melt/bolt11
-Prefer: respond-async
 Content-Type: application/json
 
 {
   "quote": "TRmjduhIsPxd...",
-  "inputs": [...]
+  "inputs": [...],
+  "prefer_async": true
 }
 ```
 


### PR DESCRIPTION
This PR replaces the `Prefer: respond-async` header in NUT-05 with a `"prefer_async": <bool>` field in the POST data.

## Implementations

- CDK: https://github.com/cashubtc/cdk/pull/1618
- Cashu-TS: https://github.com/cashubtc/cashu-ts/pull/500
- Nutshell:
    - https://github.com/cashubtc/nutshell/pull/887 (tested against Cashu-TS PR above)
    - https://github.com/cashubtc/nutshell/pull/801 (being updated)

## Detailed Description

This is a non-breaking change, as mints only honor an async preference if they choose to - there is no mint signalling or guarantee.

The reason for the change is simple - `Prefer` is not on the CORS safelist, so browsers require a preflight check before sending a request with this header. If a mint does not add `Prefer` to their CORS `Access-Control-Allow-Headers` response, the preflight will fail with an unspecified network error.

This creates a "fail unsafe" scenario, because a mint that does not support async must still allow the header to avoid an error. This new approach sidesteps CORS issues, by adding a POST data field the mint can ignore if unsupported.