### PR TITLE
docs: add NUT-28 Proof of Liabilities specification

### DIFF
--- a/28.md
+++ b/28.md
@@ -1,0 +1,233 @@
+# NUT-28: Proof of Liabilities
+
+`optional`
+
+---
+
+Proof of Liabilities (PoL) enables wallets to verify a mint has not inflated its token supply using Merkle Sum Trees with Bitcoin-anchored timestamps.
+
+## Types
+
+### `MerkleSumNode`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hash` | hex64 | SHA256 digest (lowercase) |
+| `amount` | uint | Sum of subtree amounts |
+
+### `MerkleSumProof`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `leaf_value` | string | Leaf identifier (`B_` or `Y`) |
+| `leaf_amount` | uint | Amount at leaf |
+| `siblings` | `[[hex64, uint, "L"|"R"], ...]` | Sibling nodes |
+| `root_hash` | hex64 | Expected root |
+| `root_amount` | uint | Expected total |
+
+### `EpochReport`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `keyset_id` | hex | Keyset identifier |
+| `epoch_date` | string | `YYYY-MM-DD` (UTC) |
+| `epoch_start` | uint | Unix timestamp 00:00:00 UTC |
+| `epoch_end` | uint | Unix timestamp 23:59:59 UTC |
+| `previous_epoch_hash` | hex64 \| null | Chain link |
+| `cumulative_minted` | uint | Total minted since genesis |
+| `cumulative_burned` | uint | Total burned since genesis |
+| `total_minted` | uint | Minted this epoch |
+| `total_burned` | uint | Burned this epoch |
+| `outstanding_balance` | uint | `cumulative_minted - cumulative_burned` |
+| `mint_root_hash` | hex64 | Mint tree root |
+| `mint_root_amount` | uint | Mint tree sum |
+| `burn_root_hash` | hex64 | Burn tree root |
+| `burn_root_amount` | uint | Burn tree sum |
+| `report_timestamp` | uint | Generation time |
+| `report_hash` | hex64 | Canonical hash |
+| `ots_proof` | base64 \| null | OpenTimestamps proof |
+| `ots_confirmed` | bool | Blockchain anchored |
+
+### `PoLRootsResponse`
+
+Same as `EpochReport` plus:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_closed` | bool | Epoch finalized |
+
+### `PoLHistoryResponse`
+
+| Field | Type |
+|-------|------|
+| `keyset_id` | hex |
+| `epochs` | `[EpochReport]` |
+| `chain_valid` | bool |
+
+### `PoLVerifyResponse`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `keyset_id` | hex | |
+| `B_` or `Y` | hex | |
+| `status` | string | `INCLUDED`, `NOT_FOUND`, or `PENDING_EPOCH` |
+| `proof` | `MerkleSumProof` \| null | Only for closed epochs |
+
+### `MintCommitment` (optional)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `keyset_id` | hex | |
+| `B_` | hex | Blinded message |
+| `amount` | uint | Token amount |
+| `epoch_date` | string | Target epoch |
+| `timestamp` | uint | Commitment time |
+| `signature` | hex | Mint signature over fields |
+
+### `PoLCommitmentResponse`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `keyset_id` | hex | |
+| `B_` | hex | |
+| `status` | string | `PENDING_EPOCH` or `ALREADY_CLOSED` |
+| `commitment` | `MintCommitment` \| null | Only for pending tokens |
+
+## Epochs
+
+- **Open epoch**: Current UTC day. Proofs return `PENDING_EPOCH` status (not queryable).
+- **Closed epoch**: Past days. Finalized with fixed-size tree and OTS proof.
+
+Closed epochs use **fixed padding** ($2^{24}$ leaves) to hide user count.
+
+## Canonical Hashing
+
+### Node Preimages
+
+All preimages are UTF-8 strings with `:` (0x3A) separator.
+
+| Node Type | Preimage Format |
+|-----------|-----------------|
+| Leaf | `<value>:<amount>` |
+| Internal | `<left_hash>:<right_hash>:<sum>` |
+| Empty | `EMPTY:0` → `df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119` |
+
+Where `<amount>` and `<sum>` are decimal strings (no leading zeros except `0`).
+
+### Report Hash
+
+1. Build JSON with keys in **alphabetical order**: `burn_root_amount`, `burn_root_hash`, `cumulative_burned`, `cumulative_minted`, `epoch_date`, `epoch_end`, `epoch_start`, `keyset_id`, `mint_root_amount`, `mint_root_hash`, `outstanding_balance`, `previous_epoch_hash`, `total_burned`, `total_minted`
+2. Serialize compact (no whitespace)
+3. `report_hash = SHA256(utf8_bytes)`
+
+Rules: strings double-quoted, integers unquoted, `null` literal.
+
+> **Note**: Implementers SHOULD construct the JSON string manually or use a canonical JSON library (e.g., JCS per [RFC 8785](https://datatracker.ietf.org/doc/html/rfc8785)) to ensure deterministic output.
+
+## Merkle Sum Tree
+
+### Construction
+
+```
+1. Sort leaves by value (lexicographic)
+2. Pad to 2^n with empty nodes (append to right)
+3. Build bottom-up: parent = combine(left, right)
+```
+
+### Proof Verification
+
+```
+verify(leaf_value, leaf_amount, siblings, root_hash, root_amount):
+    h = SHA256(leaf_value + ":" + leaf_amount)
+    a = leaf_amount
+    for (sh, sa, pos) in siblings:
+        a = a + sa
+        h = SHA256(sh + ":" + h + ":" + a) if pos=="L" else SHA256(h + ":" + sh + ":" + a)
+    return h == root_hash AND a == root_amount
+```
+
+### Privacy
+
+Mints **MUST** pad closed epochs to fixed size ($2^{24}$ leaves) for k-anonymity. Tree size remains constant across all epochs to prevent user-count inference.
+
+## Epoch Chaining
+
+```
+Genesis: previous_epoch_hash = null
+Epoch[n]: previous_epoch_hash = Epoch[n-1].report_hash
+          cumulative_minted = Epoch[n-1].cumulative_minted + total_minted
+          cumulative_burned = Epoch[n-1].cumulative_burned + total_burned
+```
+
+## OpenTimestamps
+
+On epoch close, `report_hash` is submitted to OTS calendars. Wallets download `.ots` and verify independently.
+
+## Endpoints
+
+| Method | Path | Query | Response |
+|--------|------|-------|----------|
+| GET | `/v1/pol/roots/{keyset_id}` | `epoch_date?` | `PoLRootsResponse` |
+| GET | `/v1/pol/history/{keyset_id}` | `limit?` (default 30) | `PoLHistoryResponse` |
+| GET | `/v1/pol/verify/mint/{keyset_id}/{B_}` | `epoch_date?` | `PoLVerifyResponse` |
+| GET | `/v1/pol/verify/burn/{keyset_id}/{Y}` | `epoch_date?` | `PoLVerifyResponse` |
+| GET | `/v1/pol/commitment/{keyset_id}/{B_}` | `amount` | `PoLCommitmentResponse` |
+| GET | `/v1/pol/ots/{keyset_id}/{epoch_date}` | — | Binary `.ots` file |
+
+### OTS Download Headers
+
+- `Content-Type: application/octet-stream`
+- `X-Report-Hash`: timestamped hash
+- `X-OTS-Confirmed`: `"true"` \| `"false"`
+
+## Verification
+
+### Token State
+
+```
+1. GET /v1/pol/verify/mint/{keyset_id}/{B_} → status?
+   - NOT_FOUND: invalid token
+   - PENDING_EPOCH: minted today, wait for epoch close
+   - INCLUDED: continue
+2. Y = hash_to_curve(secret)  [NUT-00]
+3. GET /v1/pol/verify/burn/{keyset_id}/{Y} → status?
+   - NOT_FOUND or PENDING_EPOCH: token is UNSPENT
+   - INCLUDED: token is SPENT
+```
+
+### Mint Commitment (optional)
+
+For tokens minted in the open epoch, the mint MAY return a signed commitment:
+
+```
+commitment = sign(keyset_id || B_ || amount || epoch_date || timestamp)
+```
+
+If the token is missing from tomorrow's closed tree, the wallet can present the commitment as proof of mint misbehavior.
+
+### Chain Integrity
+
+```
+for i in 1..len(epochs):
+    assert epochs[i].previous_epoch_hash == epochs[i-1].report_hash
+    assert epochs[i].cumulative_minted == epochs[i-1].cumulative_minted + epochs[i].total_minted
+    assert epochs[i].cumulative_burned == epochs[i-1].cumulative_burned + epochs[i].total_burned
+```
+
+## Mint Info
+
+```json
+{ "28": { "supported": true, "tree_size": 16777216 } }
+```
+
+`tree_size` (optional): fixed padding size, default $2^{24}$.
+
+## Security
+
+1. **Privacy**: Proof queries reveal token ownership to mint
+2. **Trust**: PoL reduces but doesn't eliminate trust; OTS mitigates backdating
+3. **OTS**: Calendar reliance; final verification against Bitcoin blockchain
+
+[00]: 00.md
+[06]: 06.md
+[tests]: tests/28-tests.md

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 | [25][25] | Payment Method: BOLT12            | [cdk], [cashu-ts][ts]                                                          | [cdk-mintd]                                      |
 | [26][26] | Payment Request Bech32m Encoding  | [cdk]                                                                          | -                                                |
 | [27][27] | Nostr Mint Backup                 | [Cashu.me][cashume], [cdk]                                                     | -                                                |
+| [28][28] | Proof of Liabilities              | [Nutshell][py]                                                                 | [Nutshell][py]                                   |
 
 #### Wallets:
 
@@ -102,3 +103,4 @@ Wallets and mints `MUST` implement all mandatory specs and `CAN` implement optio
 [25]: 25.md
 [26]: 26.md
 [27]: 27.md
+[28]: 28.md

--- a/tests/28-tests.md
+++ b/tests/28-tests.md
@@ -1,0 +1,364 @@
+# NUT-28 Test Vectors
+
+## Canonical Serialization
+
+All values are serialized as UTF-8 strings. Fields are concatenated with the ASCII colon character (`:`, byte `0x3A`).
+
+### Leaf Node
+
+**Input**:
+- `value` = `"02abc123"`
+- `amount` = `8`
+
+**Preimage** (UTF-8 string):
+```
+02abc123:8
+```
+
+**Preimage** (hex bytes):
+```
+30 32 61 62 63 31 32 33 3a 38
+```
+
+**Hash**:
+```
+SHA256("02abc123:8") = <implementation computes this>
+```
+
+### Empty Node (Constant)
+
+**Preimage**:
+```
+EMPTY:0
+```
+
+**Preimage** (hex bytes):
+```
+45 4d 50 54 59 3a 30
+```
+
+**Hash**:
+```
+SHA256("EMPTY:0") = df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119
+```
+
+### Internal Node
+
+**Input**:
+- `left.hash` = `"abc123..."` (64 hex chars)
+- `left.amount` = `8`
+- `right.hash` = `"def456..."` (64 hex chars)
+- `right.amount` = `4`
+
+**Preimage** (template):
+```
+<left_hash>:<right_hash>:<total_amount>
+```
+
+**Example**:
+```
+abc123...:def456...:12
+```
+
+Where `:` is ASCII 0x3A and `12` is the decimal string of `8 + 4`.
+
+## Merkle Sum Tree
+
+### Tree Construction Example
+
+For privacy, mints SHOULD pad trees to a fixed size (recommended $2^{24}$).
+
+Example with 3 actual leaves padded to size 4:
+
+**Actual leaves:**
+```json
+[
+  ["B_1", 100],
+  ["B_2", 50],
+  ["B_3", 25]
+]
+```
+
+**Padded tree (size 4):**
+```
+                    Root (amount=175)
+                   /                \
+           Node1 (150)            Node2 (25)
+          /        \             /        \
+       B_1(100)  B_2(50)     B_3(25)   EMPTY(0)
+```
+
+The empty node uses:
+- `hash = SHA256("EMPTY:0")` = `df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119`
+- `amount = 0`
+
+**Result:** The root amount (175) correctly reflects the sum of actual tokens, while the tree depth remains constant regardless of the number of tokens.
+
+## Merkle Sum Proof Verification
+
+### Example Tree
+
+Build a tree with 4 leaves:
+
+```json
+[
+  ["B_1", 2],
+  ["B_2", 4],
+  ["B_3", 8],
+  ["B_4", 1]
+]
+```
+
+The tree structure:
+
+```
+                    Root (amount=15)
+                   /                \
+           Node1 (6)              Node2 (9)
+          /        \             /        \
+       B_1(2)    B_2(4)      B_3(8)     B_4(1)
+```
+
+### Valid Inclusion Proof for B_3
+
+```json
+{
+  "leaf_value": "B_3",
+  "leaf_amount": 8,
+  "siblings": [
+    ["<hash_of_B_4>", 1, "R"],
+    ["<hash_of_Node1>", 6, "L"]
+  ],
+  "root_hash": "<root_hash>",
+  "root_amount": 15
+}
+```
+
+Verification steps:
+1. `current = LeafNode("B_3", 8)`
+2. Combine with B_4 (right sibling): `current = combine(current, B_4_node)`
+3. Combine with Node1 (left sibling): `current = combine(Node1, current)`
+4. Check: `current.hash == root_hash AND current.amount == 15`
+
+## Epoch Report Hash
+
+### Canonical JSON Serialization
+
+The `report_hash` uses compact JSON with:
+- Keys in **alphabetical order**
+- No whitespace between tokens
+- Strings: double-quoted
+- Integers: decimal, no quotes
+- Null: literal `null`
+
+### Example
+
+**Epoch Report Data**:
+```json
+{
+  "burn_root_amount": 12500,
+  "burn_root_hash": "789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456",
+  "cumulative_burned": 112500,
+  "cumulative_minted": 150000,
+  "epoch_date": "2024-01-15",
+  "epoch_end": 1705363199,
+  "epoch_start": 1705276800,
+  "keyset_id": "009a1f293253e41e",
+  "mint_root_amount": 50000,
+  "mint_root_hash": "d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5",
+  "outstanding_balance": 37500,
+  "previous_epoch_hash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+  "total_burned": 12500,
+  "total_minted": 50000
+}
+```
+
+**Serialized (no whitespace)**:
+```
+{"burn_root_amount":12500,"burn_root_hash":"789abcdef...","cumulative_burned":112500,...}
+```
+
+**Hash**:
+```
+report_hash = SHA256(serialized_json_utf8_bytes)
+```
+
+### Genesis Epoch (null previous_epoch_hash)
+
+When `previous_epoch_hash` is null:
+```json
+{
+  ...
+  "previous_epoch_hash": null,
+  ...
+}
+```
+
+Serialized as literal `null` (no quotes):
+```
+..."previous_epoch_hash":null,...
+```
+
+## Chain Validation
+
+### Valid Chain
+
+```json
+[
+  {
+    "epoch_date": "2024-01-13",
+    "previous_epoch_hash": null,
+    "cumulative_minted": 75000,
+    "cumulative_burned": 62500,
+    "total_minted": 75000,
+    "total_burned": 62500,
+    "report_hash": "epoch1_hash"
+  },
+  {
+    "epoch_date": "2024-01-14",
+    "previous_epoch_hash": "epoch1_hash",
+    "cumulative_minted": 100000,
+    "cumulative_burned": 100000,
+    "total_minted": 25000,
+    "total_burned": 37500,
+    "report_hash": "epoch2_hash"
+  },
+  {
+    "epoch_date": "2024-01-15",
+    "previous_epoch_hash": "epoch2_hash",
+    "cumulative_minted": 150000,
+    "cumulative_burned": 112500,
+    "total_minted": 50000,
+    "total_burned": 12500,
+    "report_hash": "epoch3_hash"
+  }
+]
+```
+
+Validation:
+1. Epoch 1: `previous_epoch_hash == null` ✓ (genesis)
+2. Epoch 2: `previous_epoch_hash == epoch1_hash` ✓
+3. Epoch 3: `previous_epoch_hash == epoch2_hash` ✓
+4. Cumulative values: 
+   - Epoch 2: `100000 == 75000 + 25000` ✓, `100000 == 62500 + 37500` ✓
+   - Epoch 3: `150000 == 100000 + 50000` ✓, `112500 == 100000 + 12500` ✓
+
+Chain is **valid**.
+
+### Invalid Chain (Hash Mismatch)
+
+```json
+[
+  {
+    "epoch_date": "2024-01-13",
+    "previous_epoch_hash": null,
+    "report_hash": "epoch1_hash"
+  },
+  {
+    "epoch_date": "2024-01-14",
+    "previous_epoch_hash": "wrong_hash",
+    "report_hash": "epoch2_hash"
+  }
+]
+```
+
+Validation fails: `epoch2.previous_epoch_hash != epoch1.report_hash`
+
+### Invalid Chain (Cumulative Mismatch)
+
+```json
+[
+  {
+    "epoch_date": "2024-01-13",
+    "cumulative_minted": 75000,
+    "total_minted": 75000,
+    "report_hash": "epoch1_hash"
+  },
+  {
+    "epoch_date": "2024-01-14",
+    "previous_epoch_hash": "epoch1_hash",
+    "cumulative_minted": 90000,
+    "total_minted": 25000
+  }
+]
+```
+
+Validation fails: `90000 != 75000 + 25000`
+
+## API Response Examples
+
+### GET /v1/pol/roots/{keyset_id}
+
+Current epoch (not closed):
+
+```json
+{
+  "keyset_id": "009a1f293253e41e",
+  "epoch_date": "2024-01-15",
+  "is_closed": false,
+  "previous_epoch_hash": "a1b2c3...",
+  "mint_root_hash": "d4e5f6...",
+  "mint_root_amount": 50000,
+  "burn_root_hash": "789abc...",
+  "burn_root_amount": 12500,
+  "outstanding_balance": 37500,
+  "cumulative_minted": 150000,
+  "cumulative_burned": 112500,
+  "report_timestamp": 1705312800,
+  "report_hash": "def012...",
+  "ots_proof": null,
+  "ots_confirmed": false
+}
+```
+
+### GET /v1/pol/verify/mint/{keyset_id}/{B_}
+
+Token found:
+
+```json
+{
+  "keyset_id": "009a1f293253e41e",
+  "B_": "02abc123def456...",
+  "included": true,
+  "proof": {
+    "leaf_value": "02abc123def456...",
+    "leaf_amount": 8,
+    "siblings": [
+      ["feedface...", 4, "R"],
+      ["deadbeef...", 12, "L"]
+    ],
+    "root_hash": "d4e5f6...",
+    "root_amount": 50000
+  }
+}
+```
+
+Token not found:
+
+```json
+{
+  "keyset_id": "009a1f293253e41e",
+  "B_": "02xyz789...",
+  "included": false,
+  "proof": null
+}
+```
+
+## Token State Verification
+
+### Determine Token Status
+
+Given a token with:
+- `B_` = `"02abc123..."`
+- `secret` = `"mysecret123"`
+- `Y` = `hash_to_curve("mysecret123")` = `"03def456..."`
+
+Query sequence:
+
+1. `GET /v1/pol/verify/mint/{keyset_id}/02abc123...`
+   - Response: `{"included": true, ...}`
+   - Token was minted ✓
+
+2. `GET /v1/pol/verify/burn/{keyset_id}/03def456...`
+   - If `{"included": false}` → Token is **UNSPENT** (valid, can be redeemed)
+   - If `{"included": true}` → Token is **SPENT** (already redeemed)


### PR DESCRIPTION
### PR: NUT-28 Proof of Liabilities

Summary
Implements **NUT-28: Proof of Liabilities**, enabling verifiable mint solvency via **Merkle Sum Trees** and **OpenTimestamps** without compromising user privacy.

Based on the [PoL Scheme PoC](https://gist.github.com/callebtc/ed5228d1d8cbaade0104db5d1cf63939) by @callebtc.

Technical Specs
* **Architecture:** Fixed-Size Dense Merkle Sum Tree (padded to $2^{24}$ leaves for k-anonymity).
* **Integrity:** Daily Epochs chained via hash (`previous_epoch_hash`).
* **Timestamping:** Final epoch hash anchored to Bitcoin via OpenTimestamps.
* **Storage:** Database-agnostic implementation (compatible with current SQL backends).

Changes
- [x] **Core:** `PoLService` for epoch management (mint/burn tracking).
- [x] **API:** Endpoints for fetching Roots (`/roots`), History (`/history`), and Inclusion Proofs (`/verify`).
- [x] **Crypto:** `MerkleSumTree` logic with canonical serialization.
- [x] **Docs:** Added `docs/specs/28.md` (Spec) and `28-tests.md` (Test Vectors).

## 🧪 Verification
Run the included test vectors:
```bash
pytest tests/test_pol_of_liabilities.py