### PR TITLE
NUT-XX: Efficient wallet recovery

### DIFF
--- a/342.md
+++ b/342.md
@@ -1,4 +1,4 @@
-# NUT-XX: Efficient Wallet Recovery
+# NUT-342: Efficient Wallet Recovery
 
 `optional`
 
@@ -202,15 +202,15 @@ This NUT is fully backwards-compatible:
 
 ### Nostr mint backups (NUT-27)
 
-To signal to a restoring wallet that the original wallet maintained the Depth Invariant, wallets that implement this NUT and perform [NUT-27][27] backups **SHOULD** include a `nut_xx: true` field in the unencrypted JSON payload.
+To signal to a restoring wallet that the original wallet maintained the Depth Invariant, wallets that implement this NUT and perform [NUT-27][27] backups **SHOULD** include a `nut_342: true` field in the unencrypted JSON payload.
 
-Example of a [NUT-27][27] backup payload with the `nut_xx` hint:
+Example of a [NUT-27][27] backup payload with the `nut_342` hint:
 
 ```json
 {
   "mints": ["https://mint.example.com", "https://another-mint.org"],
   "timestamp": 1703721600,
-  "nut_xx": true
+  "nut_342": true
 }
 ```
 

--- a/342.md
+++ b/342.md
@@ -6,7 +6,7 @@
 
 ---
 
-This NUT defines an improved recovery algorithm for [NUT-13][13] wallets that reduces the number of `BlindedMessages` revealed to the mint from O(T) to a constant (~182), improving both privacy and efficiency. It combines a binary search to locate the last issued nonce index T with a **Depth Invariant** that confines all unspent tokens to the last `d` nonce indices.
+This NUT defines an improved recovery algorithm for [NUT-13][13] wallets that reduces the number of `BlindedMessages` revealed to the mint from O(T) to a constant (~182 = log₂(2³²) + g + d with default parameters), improving both privacy and efficiency. It combines a binary search to locate the last issued nonce index T with a **Depth Invariant** that confines all unspent tokens to the last `d` nonce indices.
 
 ## Depth Invariant
 

--- a/342.md
+++ b/342.md
@@ -1,4 +1,4 @@
-# NUT-342: Efficient Wallet Recovery
+# NUT-342: Efficient Wallet Recovery with Dynamic Gap Backup
 
 `optional`
 
@@ -6,71 +6,94 @@
 
 ---
 
-This NUT defines an improved recovery algorithm for [NUT-13][13] wallets that reduces the number of `BlindedMessages` revealed to the mint from O(T) to a constant (~182 = log₂(2³²) + g + d with default parameters), improving both privacy and efficiency. It combines a binary search to locate the last issued nonce index T with a **Depth Invariant** that confines all unspent tokens to the last `d` nonce indices.
+This NUT defines an improved recovery algorithm for [NUT-13][13] wallets that reduces the number of `BlindedMessages` revealed to the mint during recovery, improving both privacy and efficiency. It avoids the need for maintaining a strict Depth Invariant (which would require periodic wallet consolidation swaps) by dynamically tracking the "gap" to the oldest unspent proof and backing it up on the mint itself, stored within the `BlindedMessage` objects.
 
-## Depth Invariant
+During recovery, the wallet performs a binary search to find the last issued nonce index `T`, retrieves its `d_gap` from the mint, and restores all unspent proofs in the range `[T - d_gap, T]`.
 
-This NUT introduces a protocol invariant that wallets **MUST** maintain during normal operation:
+## Dynamic Gap Tracking
 
-> **All unspent `Proofs` must have a nonce index greater than `T - d`.**
+Instead of active wallet consolidation, wallets that implement this NUT dynamically compute the "gap" from any newly generated outputs to the oldest unspent proofs in the wallet.
 
-Where:
+### Mechanics
 
-- **T** is the index of the nonce used for the last issued `BlindedMessage`. No issued note has a nonce index greater than T.
-- **d** is a configurable positive integer defining the maximum depth of the unspent token window. Wallets **SHOULD** use d = 100 as the default.
-- **g** is a configurable positive integer defining a gap-tolerance window scanned beyond the candidate T to handle failed operations. Wallets **SHOULD** use g = 50 as the default.
-- **Nonce index** is the `counter_k` value used by [NUT-13][13] to derive the secret and blinding factor for a `Proof`.
+A wallet tracks the secret derivation index (`counter_k`) for each unspent `Proof` in its local database.
 
-Formally, for every unspent `Proof` with nonce index `i`: `i > T - d`
+During any operation that generates new `BlindedMessage` outputs (such as a swap, mint, or melt-change request):
 
+1. **Find first unspent index**: Locate the minimum derivation index among all unspent `Proofs` currently stored in the wallet, let this be `first_unspent`.
+2. **Calculate gap**: For each new output with derivation index `current_index`:
+   - If there are no unspent proofs currently in the wallet (i.e., the wallet is empty), `d_gap = 0`.
+   - Otherwise, `d_gap = current_index - first_unspent`.
+3. **Include `d_gap` in output**: The wallet includes this `d_gap` value in the `BlindedMessage` object sent to the mint.
+
+### Privacy-Preserving Encryption
+
+To prevent the mint from knowing the wallet's activity patterns or the exact number of active coins, the `d_gap` value **SHOULD** be encrypted by the wallet before sending.
+
+#### Encryption Procedure
+
+1. **Derive key**: Let `r` be the 32-byte private blinding factor used to construct the corresponding `BlindedMessage`'s `B_` (`B_ = Y + rG`). Derive a 128-bit key using SHA-256:
+   ```
+   K_aes = SHA256(r)[0:16]
+   ```
+2. **Encrypt**: Convert `d_gap` to a 4-byte big-endian byte array. Encrypt using AES-128-GCM with a random 12-byte nonce:
+   ```
+   ciphertext, tag = AES_128_GCM_Encrypt(key=K_aes, nonce=nonce, plaintext=d_gap_bytes)
+   ```
+3. **Serialize**: Store the hex-encoded concatenation of the nonce, ciphertext, and authentication tag in the `d_gap` field of the `BlindedMessage`:
+   ```
+   d_gap = hex(nonce || ciphertext || tag)
+   ```
+
+## Protocol Modifications
+
+### `BlindedMessage`
+
+The `BlindedMessage` object is extended with an optional `d_gap` field:
+
+```json
+{
+  "amount": int,
+  "id": hex_str,
+  "B_": hex_str,
+  "d_gap": int | str
+}
 ```
-[0] |=============================[T-d]-----[T]>
-     spent or reissued               unspent proofs (-), at most d of them
+
+- `d_gap`: Either an integer (plaintext) or a hex-encoded string containing the encrypted gap data.
+
+### `BlindSignature`
+
+The `BlindSignature` object returned by the mint is also extended with the corresponding `d_gap` field received in the request:
+
+```json
+{
+  "amount": int,
+  "id": hex_str,
+  "C_": hex_str,
+  "d_gap": int | str
+}
 ```
 
-This invariant guarantees that all unspent tokens are confined to the nonce window `(T - d, T]`, whose size is bounded by `d`.
+- `d_gap`: The exact `d_gap` value received by the mint in the requesting `BlindedMessage`.
 
-### Maintaining the invariant
+### Mint Requirements
 
-To maintain the invariant, wallets that implement this NUT **MUST**:
+Mints **MUST** store the `d_gap` field alongside the `BlindedMessage` and `BlindSignature` in their database. When returning a `BlindSignature` (either during the initial response or in response to a [NUT-09][09] restore request), the mint **MUST** return the corresponding stored `d_gap` value.
 
-1. **On receive (mint/swap-in)**: After receiving new tokens, T increases. If any existing unspent `Proof` now has a nonce index `i ≤ T - d`, the wallet **MUST** consolidate those proofs by re-issuing them via a [NUT-03][03] swap. The re-issued proofs receive new nonce indices near T, restoring the invariant.
-
-2. **On send (swap-to-send)**: A send operation involves a [NUT-03][03] swap that creates new outputs (send proofs + change proofs), which increases T. If this increase causes any remaining unspent proofs (those not involved in the swap) to have index `i ≤ T - d`, the wallet **MUST** consolidate them. Note: a pure melt (paying a Lightning invoice without swap) does not increase T and therefore cannot violate the invariant.
-
-3. **Coin selection**: Wallets **MAY** use arbitrary coin selection. After any operation that increases T, the wallet **MUST** check whether any unspent proof now has index `i ≤ T - d` and consolidate if so. This preserves free coin selection while enforcing the invariant.
-
-4. **Compaction**: If the wallet already holds `d` or more unspent proofs, any operation that creates new outputs would violate the invariant regardless of consolidation. In this case, the wallet **MUST** first compact its existing proofs by combining multiple proofs into fewer outputs via a [NUT-03][03] swap, reducing the number of unspent proofs before proceeding.
-
-> [!NOTE]
-> The consolidation swap is a standard [NUT-03][03] swap — it does not reveal any additional information about the wallet's history beyond what is already implicit in the swap operation itself.
-
-### Consolidation strategy
-
-Since recovery can be triggered at any time by data loss, the invariant **MUST** hold at all times — not just "before recovery". Wallets **MUST** consolidate violating proofs immediately before any operation that increases T.
-
-In practice, a simple strategy is:
-
-- After each operation that increases T, check whether any unspent proof has index `i ≤ T - d`.
-- If so, consolidate all such proofs in a single [NUT-03][03] swap before the operation is considered complete.
-
-This ensures the invariant is never violated, even if the wallet crashes or loses data immediately after the operation.
-
-## Recovery algorithm
+## Recovery Algorithm
 
 ### Locating T via binary search
 
-The wallet uses binary search over the nonce space `[0, 2^32 - 1]` to find T with O(log N) queries to the mint's [NUT-09][09] restore endpoint.
+The wallet uses binary search over the nonce space `[0, 2^32 - 1]` to find `T` (the highest index for which the mint has an issued signature) with O(log N) queries to the mint's [NUT-09][09] restore endpoint.
 
 At each step, the wallet queries the mint with a single `BlindedMessage` derived from the midpoint index `m`. If the mint returns a `BlindSignature` for it, `m ≤ T`; otherwise, `m > T`.
-
-Where `query(keyset_id, index)` sends a single `BlindedMessage` (derived from `keyset_id` and `counter = index`) to the [NUT-09][09] endpoint and returns the mint's response.
 
 Python:
 
 ```python
 async def find_t(keyset_id: str) -> int:
-    """Binary search to find T (last issued nonce index)."""
+    """Binary search to find T (last issued/signed nonce index)."""
     lo = 0
     hi = 2**32 - 1
 
@@ -85,56 +108,68 @@ async def find_t(keyset_id: str) -> int:
         else:
             hi = m - 1   # T is to the left of m
 
-    return lo  # lo == hi == T_candidate
+    return lo  # lo == hi == T
 ```
 
-### Gap tolerance
+### Decrypting `d_gap`
 
-Failed wallet operations (e.g., network interruptions after the counter was incremented but before the mint signed) may create gaps in the issued nonce space. A single gap at index `m` would cause the binary search to return a T less than the true value, potentially missing valid tokens.
-
-To mitigate this, after `find_t` returns a candidate `T_candidate`, wallets **MUST** perform a forward linear scan of `[T_candidate + 1, T_candidate + g]` to verify that no issued nonces exist beyond `T_candidate`. If any are found, `T_candidate` is updated to the highest found index, and the scan window shifts forward from the new `T_candidate`.
+Once `T` is found, the wallet retrieves the `BlindSignature` for `T` and decrypts its `d_gap` value to find the unspent window start.
 
 Python:
 
 ```python
-async def scan_gap(keyset_id: str, t_candidate: int, g: int = 50) -> int:
-    """Forward scan to handle gaps in the nonce space."""
-    t = t_candidate
-    i = t + 1
-    limit = t + g
+import hashlib
+import os
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
-    while i <= limit:
-        if await query(keyset_id, i):
-            t = i
-            limit = i + g   # extend window from new T
-        i += 1
+def decrypt_d_gap(encrypted_hex: str, r: bytes) -> int:
+    """Decrypt d_gap using the blinding factor r."""
+    data = bytes.fromhex(encrypted_hex)
+    if len(data) < 12 + 16:  # nonce (12B) + plaintext (4B) + tag (16B)
+        raise ValueError("Invalid encrypted data length")
 
-    return t
+    key = hashlib.sha256(r).digest()[:16]
+    aesgcm = AESGCM(key)
+    nonce = data[:12]
+    ciphertext = data[12:]
+
+    plaintext = aesgcm.decrypt(nonce, ciphertext, None)
+    return int.from_bytes(plaintext, byteorder='big')
 ```
-
-This adds at most `g` queries per gap encountered. For wallets with no gaps (the common case), it adds exactly `g` queries total.
-
-> [!NOTE]
-> The gap scan can be implemented as a single [NUT-09][09] batch request containing `g` `BlindedMessages`, rather than `g` individual requests. If any signatures are returned, the wallet extends the window from the highest found index and sends another batch. This reduces total requests without affecting the number of nonces revealed.
 
 ### Recovering unspent proofs
 
-With T known, all unspent tokens are in the nonce window `(T - d, T]` thanks to the Depth Invariant. The wallet sends a single batch request to the [NUT-09][09] endpoint with `BlindedMessages` for indices `T - d + 1` through `T`, then filters out spent `Proofs` using [NUT-07][07].
+With `T` and `d_gap` known, all unspent tokens are guaranteed to reside in the nonce window `[T - d_gap, T]`. The wallet sends a single batch request to the [NUT-09][09] endpoint with `BlindedMessages` for indices `T - d_gap` through `T`, then filters out spent `Proofs` using [NUT-07][07].
 
 Python:
 
 ```python
-async def recover(keyset_id: str, t: int, d: int = 100) -> list:
-    """Recover unspent proofs from the bounded window."""
-    start = max(0, t - d + 1)
+async def recover(keyset_id: str, t: int) -> list:
+    """Recover unspent proofs from the dynamic window."""
+    # Step 1: Retrieve the signature for T to get d_gap
+    msg_t = blinded_message(keyset_id, t)
+    signatures = await restore([msg_t])
+    if not signatures:
+        return []
+
+    sig_t = signatures[0]
+    d_gap_val = sig_t.get("d_gap")
+
+    # Decrypt d_gap if it is encrypted (represented as string)
+    if isinstance(d_gap_val, str):
+        r_t = get_r(keyset_id, t) # Re-generate private blinding factor
+        d_gap = decrypt_d_gap(d_gap_val, r_t)
+    else:
+        d_gap = d_gap_val if d_gap_val is not None else 0
+
+    # Step 2: Batch restore from T - d_gap to T
+    start = max(0, t - d_gap)
     outputs = [blinded_message(keyset_id, i) for i in range(start, t + 1)]
     signatures = await restore(outputs)          # NUT-09
     proofs = unblind(signatures)
     unspent = await check_states(proofs)         # NUT-07
     return [p for p in unspent if p.state == "UNSPENT"]
 ```
-
-This step requires exactly one [NUT-09][09] request (with at most `d` outputs) plus one [NUT-07][07] state check.
 
 ### Full recovery procedure
 
@@ -143,68 +178,48 @@ Wallets implementing this NUT **SHOULD** use the following procedure instead of 
 Python:
 
 ```python
-async def recover_wallet(mnemonic: str, d: int = 100, g: int = 50):
-    """Full wallet recovery using binary search."""
+async def recover_wallet(mnemonic: str):
+    """Full wallet recovery using binary search and d_gap."""
     init_from_mnemonic(mnemonic)
     for keyset_id in get_keysets():
-        t_candidate = await find_t(keyset_id)
-        if t_candidate == -1:
+        t = await find_t(keyset_id)
+        if t == -1:
             continue
 
-        t = await scan_gap(keyset_id, t_candidate, g)
-        unspent = await recover(keyset_id, t, d)
+        unspent = await recover(keyset_id, t)
         store(unspent)
         set_counter(keyset_id, t + 1)
 ```
 
-## Privacy analysis
+## Privacy and Efficiency Analysis
 
 ### Cost breakdown
 
-With default parameters d = 100, g = 50:
+With dynamic gap backup, recovery requires only a tiny fraction of the requests compared to NUT-13.
 
-| Component | Nonces revealed | Requests (individual) | Requests (batched) |
-|---|---|---|---|
-| Binary search | log₂(N) = 32 | 32 (sequential, cannot be batched) | 32 |
-| Gap scan | g = 50 | 50 | 1–2 (single [NUT-09][09] batch) |
-| Recovery | d = 100 | 1 ([NUT-09][09] batch) | 1 |
-| State check | 0 | 1 ([NUT-07][07]) | 1 |
-| **Total** | **182** | **84** | **~35** |
+| Component     | Nonces revealed | Requests (individual)  | Requests (batched) |
+| ------------- | --------------- | ---------------------- | ------------------ |
+| Binary search | log₂(N) = 32    | 32 (sequential)        | 32                 |
+| Recovery      | d_gap + 1       | 1 ([NUT-09][09] batch) | 1                  |
+| State check   | 0               | 1 ([NUT-07][07])       | 1                  |
+| **Total**     | **33 + d_gap**  | **34**                 | **34**             |
 
-### Comparison with NUT-13
+Compared to the original NUT-342 proposal, this approach completely eliminates the need for:
 
-| Approach | Nonces revealed | Requests |
-|---|---|---|
-| [NUT-13][13] linear scan (batch=25) | T + 50 | T/25 + 2 |
-| This NUT (d=100, g=50, batched) | 182 (constant) | ~35 |
-
-Examples:
-
-| Wallet size (T) | NUT-13 nonces | This NUT nonces | NUT-13 requests | This NUT requests |
-|---|---|---|---|---|
-| 100 | 150 | 182 | 6 | ~35 |
-| 500 | 550 | 182 | 22 | ~35 |
-| 1,000 | 1,050 | 182 | 42 | ~35 |
-| 5,000 | 5,050 | 182 | 202 | ~35 |
-| 100,000 | 100,050 | 182 | 4,002 | ~35 |
-
-### Breakeven note
-
-This NUT reveals **more** nonces than [NUT-13][13] for small wallets (T < ~132), because the fixed cost of binary search (32 probes) plus the recovery window (`d` nonces) exceeds the cost of a linear scan. Since T is only discovered during recovery, wallets cannot decide in advance which strategy is cheaper.
+- Periodic standard wallet consolidation swaps (which save network fees and improve privacy).
+- O(g) gap-scanning during recovery (as the backed-up `d_gap` on the latest signature is guaranteed to span all the way back to the oldest unspent proof, bypassing all intermediate failed/skipped nonce gaps).
 
 ## Backwards compatibility
 
 This NUT is fully backwards-compatible:
 
-- **Mint**: No changes required. The wallet uses the existing [NUT-09][09] restore endpoint with single-element batches during binary search and a standard batch for the final recovery. No new endpoints or response fields are needed.
-- **Wallet**: Implementing this NUT is optional. Wallets that do not implement it continue to use the [NUT-13][13] linear scan.
-- **Interoperability**: Wallets that implement this NUT can recover funds from any [NUT-13][13] wallet. However, if the original wallet did NOT maintain the Depth Invariant, unspent tokens outside the `(T - d, T]` window will not be recovered. In this case, wallets **SHOULD** fall back to the [NUT-13][13] linear scan over `[0, T]` to ensure complete recovery.
+- **Mint**: Implementing this NUT is optional for mints. If supported, the mint saves and returns the optional `d_gap` field. Mints that do not support this NUT will ignore the `d_gap` field.
+- **Wallet**: Wallets that support this NUT can fall back to the [NUT-13][13] linear scan recovery if the mint does not return a `d_gap` in the `BlindSignature` response for `T`.
+- **Interoperability**: If a wallet is restored on a mint that does not support `d_gap` storage, or if recovering an older wallet that did not backup `d_gap`, the restored signature for `T` will not contain `d_gap`. In this case, the wallet **MUST** fall back to the [NUT-13][13] linear scan.
 
 ### Nostr mint backups (NUT-27)
 
-To signal to a restoring wallet that the original wallet maintained the Depth Invariant, wallets that implement this NUT and perform [NUT-27][27] backups **SHOULD** include a `nut_342: true` field in the unencrypted JSON payload.
-
-Example of a [NUT-27][27] backup payload with the `nut_342` hint:
+To signal to a restoring wallet that the original wallet backed up `d_gap` to the mint, wallets that implement this NUT and perform [NUT-27][27] backups **SHOULD** include a `nut_342: true` field in the unencrypted JSON payload.
 
 ```json
 {
@@ -214,32 +229,16 @@ Example of a [NUT-27][27] backup payload with the `nut_342` hint:
 }
 ```
 
-A restoring wallet that finds this flag **MAY** safely assume the depth invariant was maintained and skip the [NUT-13][13] linear scan fallback.
-
-### Migration
-
-Existing wallets that adopt this NUT **SHOULD** perform a one-time consolidation at activation to bring all unspent proofs into the `(T - d, T]` window, establishing the Depth Invariant for future recoveries.
+A restoring wallet that finds this flag **MAY** safely assume the `d_gap` backup was maintained and skip the [NUT-13][13] linear scan fallback.
 
 ## Implementation notes
-
-### Mints
-
-No changes to the mint are required. The existing [NUT-09][09] restore endpoint is used as-is.
 
 ### Wallets
 
 Wallets that implement this NUT **MUST**:
-- Implement the consolidation logic to maintain the Depth Invariant after send and receive operations
-- Store the nonce index (`counter_k`) for each `Proof` in their local database, so that violation checks can be performed efficiently
 
-Wallets **SHOULD**:
-- Use d = 100 as the default depth parameter
-- Use g = 50 as the default gap-tolerance window
-- Expose `d` as a user-configurable setting for advanced users who want to trade off recovery window size against consolidation frequency
-
-## Test vectors
-
-TBD — to be added before this NUT moves to final status.
+- Store the secret derivation index (`counter_k`) for each `Proof` in their local database.
+- Calculate and include `d_gap` (preferably encrypted) in every `BlindedMessage`.
 
 [03]: 03.md
 [07]: 07.md

--- a/342.md
+++ b/342.md
@@ -89,107 +89,17 @@ The wallet uses binary search over the nonce space `[0, 2^32 - 1]` to find `T` (
 
 At each step, the wallet queries the mint with a single `BlindedMessage` derived from the midpoint index `m`. If the mint returns a `BlindSignature` for it, `m ≤ T`; otherwise, `m > T`.
 
-Python:
-
-```python
-async def find_t(keyset_id: str) -> int:
-    """Binary search to find T (last issued/signed nonce index)."""
-    lo = 0
-    hi = 2**32 - 1
-
-    # Edge case: nothing has been issued
-    if not await query(keyset_id, 0):
-        return -1
-
-    while lo < hi:
-        m = (lo + hi + 1) // 2
-        if await query(keyset_id, m):
-            lo = m       # T is at m or to the right
-        else:
-            hi = m - 1   # T is to the left of m
-
-    return lo  # lo == hi == T
-```
-
 ### Decrypting `d_gap`
 
 Once `T` is found, the wallet retrieves the `BlindSignature` for `T` and decrypts its `d_gap` value to find the unspent window start.
-
-Python:
-
-```python
-import hashlib
-import os
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-
-def decrypt_d_gap(encrypted_hex: str, r: bytes) -> int:
-    """Decrypt d_gap using the blinding factor r."""
-    data = bytes.fromhex(encrypted_hex)
-    if len(data) < 12 + 16:  # nonce (12B) + plaintext (4B) + tag (16B)
-        raise ValueError("Invalid encrypted data length")
-
-    key = hashlib.sha256(r).digest()[:16]
-    aesgcm = AESGCM(key)
-    nonce = data[:12]
-    ciphertext = data[12:]
-
-    plaintext = aesgcm.decrypt(nonce, ciphertext, None)
-    return int.from_bytes(plaintext, byteorder='big')
-```
 
 ### Recovering unspent proofs
 
 With `T` and `d_gap` known, all unspent tokens are guaranteed to reside in the nonce window `[T - d_gap, T]`. The wallet sends a single batch request to the [NUT-09][09] endpoint with `BlindedMessages` for indices `T - d_gap` through `T`, then filters out spent `Proofs` using [NUT-07][07].
 
-Python:
-
-```python
-async def recover(keyset_id: str, t: int) -> list:
-    """Recover unspent proofs from the dynamic window."""
-    # Step 1: Retrieve the signature for T to get d_gap
-    msg_t = blinded_message(keyset_id, t)
-    signatures = await restore([msg_t])
-    if not signatures:
-        return []
-
-    sig_t = signatures[0]
-    d_gap_val = sig_t.get("d_gap")
-
-    # Decrypt d_gap if it is encrypted (represented as string)
-    if isinstance(d_gap_val, str):
-        r_t = get_r(keyset_id, t) # Re-generate private blinding factor
-        d_gap = decrypt_d_gap(d_gap_val, r_t)
-    else:
-        d_gap = d_gap_val if d_gap_val is not None else 0
-
-    # Step 2: Batch restore from T - d_gap to T
-    start = max(0, t - d_gap)
-    outputs = [blinded_message(keyset_id, i) for i in range(start, t + 1)]
-    signatures = await restore(outputs)          # NUT-09
-    proofs = unblind(signatures)
-    unspent = await check_states(proofs)         # NUT-07
-    return [p for p in unspent if p.state == "UNSPENT"]
-```
-
 ### Full recovery procedure
 
-Wallets implementing this NUT **SHOULD** use the following procedure instead of the linear scan defined in [NUT-13][13]:
-
-Python:
-
-```python
-async def recover_wallet(mnemonic: str):
-    """Full wallet recovery using binary search and d_gap."""
-    init_from_mnemonic(mnemonic)
-    for keyset_id in get_keysets():
-        t = await find_t(keyset_id)
-        if t == -1:
-            continue
-
-        unspent = await recover(keyset_id, t)
-        store(unspent)
-        set_counter(keyset_id, t + 1)
-```
+Wallets implementing this NUT **SHOULD** use the binary search to locate `T`, fetch the `d_gap` of `T` to determine the start of the unspent token window, and then execute a batch recovery of all nonces in the range `[T - d_gap, T]` instead of the linear scan defined in [NUT-13][13].
 
 ## Privacy and Efficiency Analysis
 
@@ -217,20 +127,6 @@ This NUT is fully backwards-compatible:
 - **Wallet**: Wallets that support this NUT can fall back to the [NUT-13][13] linear scan recovery if the mint does not return a `d_gap` in the `BlindSignature` response for `T`.
 - **Interoperability**: If a wallet is restored on a mint that does not support `d_gap` storage, or if recovering an older wallet that did not backup `d_gap`, the restored signature for `T` will not contain `d_gap`. In this case, the wallet **MUST** fall back to the [NUT-13][13] linear scan.
 
-### Nostr mint backups (NUT-27)
-
-To signal to a restoring wallet that the original wallet backed up `d_gap` to the mint, wallets that implement this NUT and perform [NUT-27][27] backups **SHOULD** include a `nut_342: true` field in the unencrypted JSON payload.
-
-```json
-{
-  "mints": ["https://mint.example.com", "https://another-mint.org"],
-  "timestamp": 1703721600,
-  "nut_342": true
-}
-```
-
-A restoring wallet that finds this flag **MAY** safely assume the `d_gap` backup was maintained and skip the [NUT-13][13] linear scan fallback.
-
 ## Implementation notes
 
 ### Wallets
@@ -244,4 +140,3 @@ Wallets that implement this NUT **MUST**:
 [07]: 07.md
 [09]: 09.md
 [13]: 13.md
-[27]: 27.md

--- a/342.md
+++ b/342.md
@@ -12,17 +12,17 @@ During recovery, the wallet performs a binary search to find the last issued non
 
 ## Dynamic Gap Tracking
 
-Wallets that implement this NUT dynamically compute the "gap" (`d_gap`) from newly generated outputs to the oldest unspent proofs in the wallet.
+Wallets that implement this NUT dynamically compute the "gap" (`d_gap`) from newly generated outputs to the oldest unspent or pending proofs in the wallet.
 
 ### Mechanics
 
-A wallet tracks the secret derivation index (`counter_k`) for each unspent `Proof` in its local database.
+A wallet tracks the secret derivation index (`counter_k`) for each unspent or pending `Proof` in its local database.
 
 During any operation that generates new `BlindedMessage` outputs (such as a swap, mint, or melt-change request):
 
-1. **Find first unspent index**: Locate the minimum derivation index among all unspent `Proofs` currently stored in the wallet, let this be `first_unspent`.
+1. **Find first unspent index**: Locate the minimum derivation index among all unspent or pending `Proofs` currently stored in the wallet, let this be `first_unspent`.
 2. **Calculate gap**: For each new output with derivation index `current_index`:
-   - If there are no unspent proofs currently in the wallet (i.e., the wallet is empty), `d_gap = 0`.
+   - If there are no unspent or pending proofs currently in the wallet (i.e., the wallet is empty), `d_gap = 0`.
    - Otherwise, `d_gap = current_index - first_unspent`.
 3. **Include `d_gap` in output**: The wallet includes this `d_gap` value in the `BlindedMessage` object sent to the mint.
 

--- a/342.md
+++ b/342.md
@@ -81,6 +81,18 @@ The `BlindSignature` object returned by the mint is also extended with the corre
 
 Mints **MUST** store the `d_gap` field alongside the `BlindedMessage` and `BlindSignature` in their database. When returning a `BlindSignature` (either during the initial response or in response to a [NUT-09][09] restore request), the mint **MUST** return the corresponding stored `d_gap` value.
 
+### Mint info setting
+
+The [NUT-06][06] `nuts` settings indicates support for this feature:
+
+```json
+{
+  "342": {
+    "supported": true
+  }
+}
+```
+
 ## Recovery Algorithm
 
 ### Locating T via binary search
@@ -184,6 +196,7 @@ Wallets that implement this NUT **MUST**:
 - Calculate and include `d_gap` (preferably encrypted) in every `BlindedMessage`.
 
 [03]: 03.md
+[06]: 06.md
 [07]: 07.md
 [09]: 09.md
 [13]: 13.md

--- a/342.md
+++ b/342.md
@@ -24,9 +24,9 @@ where `first_unspent` is the minimum derivation index among all unspent or pendi
 
 A wallet using this NUT **MUST** include `d_gap` in every newly generated `BlindedMessage`. This definition guarantees that the hint on the latest issued output covers every older unspent or pending proof known when that output was created.
 
-### Privacy-Preserving Encryption
+### Encryption
 
-To prevent the mint from knowing the wallet's activity patterns or the exact number of active coins, the `d_gap` value **SHOULD** be encrypted by the wallet before sending.
+To prevent the mint from learning the wallet's activity patterns or the exact number of active coins, the wallet **MUST** encrypt `d_gap` before sending it.
 
 #### Encryption Procedure
 
@@ -52,11 +52,11 @@ The `BlindedMessage` object is extended with an optional `d_gap` field:
   "amount": int,
   "id": hex_str,
   "B_": hex_str,
-  "d_gap": int | str
+  "d_gap": hex_str
 }
 ```
 
-- `d_gap`: Either an integer (plaintext) or a hex-encoded string containing the encrypted gap data.
+- `d_gap`: The hex-encoded `nonce || ciphertext || tag` produced by the encryption procedure above.
 
 ### `BlindSignature`
 
@@ -67,7 +67,7 @@ The `BlindSignature` object returned by the mint is also extended with the corre
   "amount": int,
   "id": hex_str,
   "C_": hex_str,
-  "d_gap": int | str
+  "d_gap": hex_str
 }
 ```
 
@@ -145,12 +145,8 @@ With `T` and `d_gap` known, all unspent tokens are guaranteed to reside in the n
 function recover_unspent_proofs(keyset_id, t) {
     signature = restore_signature(keyset_id, t)
 
-    if signature.d_gap is encrypted {
-        r = get_r(keyset_id, t)
-        d_gap = decrypt_d_gap(signature.d_gap, r)
-    } else {
-        d_gap = signature.d_gap
-    }
+    r = get_r(keyset_id, t)
+    d_gap = decrypt_d_gap(signature.d_gap, r)
 
     start = max(0, t - d_gap)
     signatures = restore_signatures_batch(keyset_id, start, t)

--- a/342.md
+++ b/342.md
@@ -6,13 +6,13 @@
 
 ---
 
-This NUT defines an improved recovery algorithm for [NUT-13][13] wallets that reduces the number of `BlindedMessages` revealed to the mint during recovery, improving both privacy and efficiency. It avoids the need for maintaining a strict Depth Invariant (which would require periodic wallet consolidation swaps) by dynamically tracking the "gap" to the oldest unspent proof and backing it up on the mint itself, stored within the `BlindedMessage` objects.
+This NUT defines an improved recovery algorithm for [NUT-13][13] wallets that reduces the number of `BlindedMessages` revealed to the mint during recovery, improving both privacy and efficiency. It does so by dynamically tracking the "gap" (`d_gap`) between the last issued nonce and the oldest unspent proof, storing this value alongside the `BlindedMessage` on the mint itself.
 
 During recovery, the wallet performs a binary search to find the last issued nonce index `T`, retrieves its `d_gap` from the mint, and restores all unspent proofs in the range `[T - d_gap, T]`.
 
 ## Dynamic Gap Tracking
 
-Instead of active wallet consolidation, wallets that implement this NUT dynamically compute the "gap" from any newly generated outputs to the oldest unspent proofs in the wallet.
+Wallets that implement this NUT dynamically compute the "gap" (`d_gap`) from newly generated outputs to the oldest unspent proofs in the wallet.
 
 ### Mechanics
 
@@ -204,10 +204,10 @@ With dynamic gap backup, recovery requires only a tiny fraction of the requests 
 | State check   | 0               | 1 ([NUT-07][07])       | 1                  |
 | **Total**     | **33 + d_gap**  | **34**                 | **34**             |
 
-Compared to the original NUT-342 proposal, this approach completely eliminates the need for:
+This approach has several distinct advantages:
 
-- Periodic standard wallet consolidation swaps (which save network fees and improve privacy).
-- O(g) gap-scanning during recovery (as the backed-up `d_gap` on the latest signature is guaranteed to span all the way back to the oldest unspent proof, bypassing all intermediate failed/skipped nonce gaps).
+- **No consolidation swaps**: Wallets do not need to perform periodic standard token consolidation swaps (which saves network fees and improves privacy).
+- **No forward linear gap-scanning**: Since the backed-up `d_gap` on the latest signature is guaranteed to span all the way back to the oldest unspent proof, there is no need for forward linear gap-scans beyond `T` during recovery, bypassing all intermediate failed/skipped nonce gaps.
 
 ## Backwards compatibility
 

--- a/342.md
+++ b/342.md
@@ -89,13 +89,60 @@ The wallet uses binary search over the nonce space `[0, 2^32 - 1]` to find `T` (
 
 At each step, the wallet queries the mint with a single `BlindedMessage` derived from the midpoint index `m`. If the mint returns a `BlindSignature` for it, `m ≤ T`; otherwise, `m > T`.
 
+```
+function find_t(keyset_id) {
+    lo = 0
+    hi = 2^32 - 1
+
+    if query(keyset_id, 0) is false:
+        return -1
+
+    while lo < hi {
+        m = (lo + hi + 1) / 2
+        if query(keyset_id, m) is true {
+            lo = m
+        } else {
+            hi = m - 1
+        }
+    }
+    return lo
+}
+```
+
 ### Decrypting `d_gap`
 
 Once `T` is found, the wallet retrieves the `BlindSignature` for `T` and decrypts its `d_gap` value to find the unspent window start.
 
+```
+function decrypt_d_gap(encrypted_hex, r) {
+    key = SHA256(r)[0:16]
+    nonce, ciphertext, tag = split(encrypted_hex)
+    return AES_128_GCM_Decrypt(key, nonce, ciphertext, tag)
+}
+```
+
 ### Recovering unspent proofs
 
 With `T` and `d_gap` known, all unspent tokens are guaranteed to reside in the nonce window `[T - d_gap, T]`. The wallet sends a single batch request to the [NUT-09][09] endpoint with `BlindedMessages` for indices `T - d_gap` through `T`, then filters out spent `Proofs` using [NUT-07][07].
+
+```
+function recover_unspent_proofs(keyset_id, t) {
+    signature = restore_signature(keyset_id, t)
+
+    if signature.d_gap is encrypted {
+        r = get_r(keyset_id, t)
+        d_gap = decrypt_d_gap(signature.d_gap, r)
+    } else {
+        d_gap = signature.d_gap
+    }
+
+    start = max(0, t - d_gap)
+    signatures = restore_signatures_batch(keyset_id, start, t)
+    proofs = unblind(signatures)
+
+    return filter_unspent(proofs)
+}
+```
 
 ### Full recovery procedure
 

--- a/342.md
+++ b/342.md
@@ -6,25 +6,23 @@
 
 ---
 
-This NUT defines an improved recovery algorithm for [NUT-13][13] wallets that reduces the number of `BlindedMessages` revealed to the mint during recovery, improving both privacy and efficiency. It does so by dynamically tracking the "gap" (`d_gap`) between the last issued nonce and the oldest unspent proof, storing this value alongside the `BlindedMessage` on the mint itself.
+This NUT extends `BlindedMessage` and `BlindSignature` with `d_gap`, a wallet-provided recovery hint. The hint records the distance between an output's derivation index and the oldest unspent or pending proof known to the wallet. Mints store and return the hint so wallets can reduce the number of `BlindedMessages` revealed during [NUT-13][13] recovery.
 
-During recovery, the wallet performs a binary search to find the last issued nonce index `T`, retrieves its `d_gap` from the mint, and restores all unspent proofs in the range `[T - d_gap, T]`.
+How a wallet locates the latest issued output and uses its hint is an implementation detail. A non-normative strategy is described below.
 
-## Dynamic Gap Tracking
+## Protocol
 
-Wallets that implement this NUT dynamically compute the "gap" (`d_gap`) from newly generated outputs to the oldest unspent or pending proofs in the wallet.
+### `d_gap`
 
-### Mechanics
+For an output at derivation index `current_index`, `d_gap` is defined as:
 
-A wallet tracks the secret derivation index (`counter_k`) for each unspent or pending `Proof` in its local database.
+```
+d_gap = current_index - first_unspent
+```
 
-During any operation that generates new `BlindedMessage` outputs (such as a swap, mint, or melt-change request):
+where `first_unspent` is the minimum derivation index among all unspent or pending proofs known to the wallet when it creates the output. If there are no such proofs, `d_gap` is `0`.
 
-1. **Find first unspent index**: Locate the minimum derivation index among all unspent or pending `Proofs` currently stored in the wallet, let this be `first_unspent`.
-2. **Calculate gap**: For each new output with derivation index `current_index`:
-   - If there are no unspent or pending proofs currently in the wallet (i.e., the wallet is empty), `d_gap = 0`.
-   - Otherwise, `d_gap = current_index - first_unspent`.
-3. **Include `d_gap` in output**: The wallet includes this `d_gap` value in the `BlindedMessage` object sent to the mint.
+A wallet using this NUT **MUST** include `d_gap` in every newly generated `BlindedMessage`. This definition guarantees that the hint on the latest issued output covers every older unspent or pending proof known when that output was created.
 
 ### Privacy-Preserving Encryption
 
@@ -44,8 +42,6 @@ To prevent the mint from knowing the wallet's activity patterns or the exact num
    ```
    d_gap = hex(nonce || ciphertext || tag)
    ```
-
-## Protocol Modifications
 
 ### `BlindedMessage`
 
@@ -93,11 +89,19 @@ The [NUT-06][06] `nuts` settings indicates support for this feature:
 }
 ```
 
-## Recovery Algorithm
+## Non-normative implementation guidance
 
-### Locating T via binary search
+This section describes one possible wallet strategy. Wallets may use any search and recovery algorithm compatible with the `d_gap` protocol above.
 
-The wallet uses binary search over the nonce space `[0, 2^32 - 1]` to find `T` (the highest index for which the mint has an issued signature) with O(log N) queries to the mint's [NUT-09][09] restore endpoint.
+### Tracking the dynamic gap
+
+A wallet can store the secret derivation index (`counter_k`) for each unspent or pending `Proof` in its local database. When generating outputs for a swap, mint, or melt-change request, it can find `first_unspent`, calculate `d_gap` as defined above, and attach the result to each `BlindedMessage`.
+
+### Recovery strategy
+
+#### Locating T via binary search
+
+A wallet can use binary search over the nonce space `[0, 2^32 - 1]` to find `T` (the highest index for which the mint has an issued signature) with O(log N) queries to the mint's [NUT-09][09] restore endpoint.
 
 At each step, the wallet queries the mint with a single `BlindedMessage` derived from the midpoint index `m`. If the mint returns a `BlindSignature` for it, `m ≤ T`; otherwise, `m > T`.
 
@@ -121,7 +125,7 @@ function find_t(keyset_id) {
 }
 ```
 
-### Decrypting `d_gap`
+#### Decrypting `d_gap`
 
 Once `T` is found, the wallet retrieves the `BlindSignature` for `T` and decrypts its `d_gap` value to find the unspent window start.
 
@@ -133,7 +137,7 @@ function decrypt_d_gap(encrypted_hex, r) {
 }
 ```
 
-### Recovering unspent proofs
+#### Recovering unspent proofs
 
 With `T` and `d_gap` known, all unspent tokens are guaranteed to reside in the nonce window `[T - d_gap, T]`. The wallet sends a single batch request to the [NUT-09][09] endpoint with `BlindedMessages` for indices `T - d_gap` through `T`, then filters out spent `Proofs` using [NUT-07][07].
 
@@ -156,13 +160,13 @@ function recover_unspent_proofs(keyset_id, t) {
 }
 ```
 
-### Full recovery procedure
+#### Full recovery procedure
 
-Wallets implementing this NUT **SHOULD** use the binary search to locate `T`, fetch the `d_gap` of `T` to determine the start of the unspent token window, and then execute a batch recovery of all nonces in the range `[T - d_gap, T]` instead of the linear scan defined in [NUT-13][13].
+In this strategy, the wallet uses binary search to locate `T`, fetches the `d_gap` of `T` to determine the start of the unspent token window, and then executes a batch recovery of all nonces in the range `[T - d_gap, T]` instead of the linear scan defined in [NUT-13][13]. Other strategies may locate `T` differently.
 
-## Privacy and Efficiency Analysis
+### Privacy and efficiency analysis
 
-### Cost breakdown
+#### Cost breakdown
 
 With dynamic gap backup, recovery requires only a tiny fraction of the requests compared to NUT-13.
 
@@ -183,17 +187,8 @@ This approach has several distinct advantages:
 This NUT is fully backwards-compatible:
 
 - **Mint**: Implementing this NUT is optional for mints. If supported, the mint saves and returns the optional `d_gap` field. Mints that do not support this NUT will ignore the `d_gap` field.
-- **Wallet**: Wallets that support this NUT can fall back to the [NUT-13][13] linear scan recovery if the mint does not return a `d_gap` in the `BlindSignature` response for `T`.
-- **Interoperability**: If a wallet is restored on a mint that does not support `d_gap` storage, or if recovering an older wallet that did not backup `d_gap`, the restored signature for `T` will not contain `d_gap`. In this case, the wallet **MUST** fall back to the [NUT-13][13] linear scan.
-
-## Implementation notes
-
-### Wallets
-
-Wallets that implement this NUT **MUST**:
-
-- Store the secret derivation index (`counter_k`) for each `Proof` in their local database.
-- Calculate and include `d_gap` (preferably encrypted) in every `BlindedMessage`.
+- **Wallet**: Wallets that support this NUT can use another recovery strategy, such as the [NUT-13][13] linear scan, if the relevant `BlindSignature` response does not contain `d_gap`.
+- **Interoperability**: If a wallet is restored on a mint that does not support `d_gap` storage, or if recovering an older wallet that did not back up `d_gap`, the restored signatures will not contain `d_gap`. The absence of the optional field does not affect existing recovery strategies.
 
 [03]: 03.md
 [06]: 06.md

--- a/342.md
+++ b/342.md
@@ -6,7 +6,7 @@
 
 ---
 
-This NUT extends `BlindedMessage` and `BlindSignature` with `d_gap`, a wallet-provided recovery hint. The hint records the distance between an output's derivation index and the oldest unspent or pending proof known to the wallet. Mints store and return the hint so wallets can reduce the number of `BlindedMessages` revealed during [NUT-13][13] recovery.
+This NUT extends `BlindedMessage` and `BlindSignature` with a `metadata` map whose values are bounded by the NUT defining each key. It defines metadata key `342` as an encrypted wallet-provided recovery hint. The hint records the distance (`d_gap`) between an output's derivation index and the oldest unspent or pending proof known to the wallet. Mints store and return the metadata so wallets can reduce the number of `BlindedMessages` revealed during [NUT-13][13] recovery.
 
 How a wallet locates the latest issued output and uses its hint is an implementation detail. A non-normative strategy is described below.
 
@@ -22,7 +22,7 @@ d_gap = current_index - first_unspent
 
 where `first_unspent` is the minimum derivation index among all unspent or pending proofs known to the wallet when it creates the output. If there are no such proofs, `d_gap` is `0`.
 
-A wallet using this NUT **MUST** include `d_gap` in every newly generated `BlindedMessage`. This definition guarantees that the hint on the latest issued output covers every older unspent or pending proof known when that output was created.
+A wallet using this NUT **MUST** include an encrypted `d_gap` under metadata key `342` in every newly generated `BlindedMessage`. This definition guarantees that the hint on the latest issued output covers every older unspent or pending proof known when that output was created.
 
 ### Encryption
 
@@ -30,52 +30,64 @@ To prevent the mint from learning the wallet's activity patterns or the exact nu
 
 #### Encryption Procedure
 
-1. **Derive key**: Let `r` be the 32-byte private blinding factor used to construct the corresponding `BlindedMessage`'s `B_` (`B_ = Y + rG`). Derive a 128-bit key using SHA-256:
+1. **Derive key and nonce**: Let `r` be the 32-byte private blinding factor used to construct the corresponding `BlindedMessage`'s `B_` (`B_ = Y + rG`). Derive a 128-bit key and a 96-bit nonce using HKDF-SHA256 with an empty salt and the following distinct info values:
    ```
-   K_aes = SHA256(r)[0:16]
+   K_aes = HKDF-SHA256(ikm=r, salt="", info="cashu:nut-342:d-gap:key:v1", L=16)
+   nonce = HKDF-SHA256(ikm=r, salt="", info="cashu:nut-342:d-gap:nonce:v1", L=12)
    ```
-2. **Encrypt**: Convert `d_gap` to a 4-byte big-endian byte array. Encrypt using AES-128-GCM with a random 12-byte nonce:
+   Each `r` **MUST** be used for only one `BlindedMessage`, ensuring that the derived key and nonce pair is unique.
+2. **Encrypt**: Convert `d_gap` to a 4-byte unsigned big-endian byte array. Encrypt it using AES-128-GCM:
    ```
    ciphertext, tag = AES_128_GCM_Encrypt(key=K_aes, nonce=nonce, plaintext=d_gap_bytes)
    ```
-3. **Serialize**: Store the hex-encoded concatenation of the nonce, ciphertext, and authentication tag in the `d_gap` field of the `BlindedMessage`:
+3. **Serialize**: Store the lowercase hex-encoded concatenation of the ciphertext and 16-byte authentication tag under metadata key `342`. The derived nonce is not transmitted:
    ```
-   d_gap = hex(nonce || ciphertext || tag)
+   metadata["342"] = hex(ciphertext || tag)
    ```
+
+The decoded metadata value is exactly 20 bytes: 4 bytes of ciphertext followed by a 16-byte authentication tag. Therefore, `metadata["342"]` **MUST** be a lowercase hexadecimal string of exactly 40 characters. Mints supporting this NUT **MUST** reject outputs whose `342` metadata value does not satisfy this requirement.
+
+### `metadata`
+
+`metadata` is an optional map from a NUT number encoded as a decimal string to an opaque string value. Each NUT using this map defines the encoding and size of its value. A mint **MUST NOT** accept a metadata entry unless it advertises support for the NUT identified by its key.
 
 ### `BlindedMessage`
 
-The `BlindedMessage` object is extended with an optional `d_gap` field:
+The `BlindedMessage` object is extended with an optional `metadata` field:
 
 ```json
 {
   "amount": int,
   "id": hex_str,
   "B_": hex_str,
-  "d_gap": hex_str
+  "metadata": {
+    "342": hex_str
+  }
 }
 ```
 
-- `d_gap`: The hex-encoded `nonce || ciphertext || tag` produced by the encryption procedure above.
+- `metadata["342"]`: The 40-character hex-encoded `ciphertext || tag` produced by the encryption procedure above.
 
 ### `BlindSignature`
 
-The `BlindSignature` object returned by the mint is also extended with the corresponding `d_gap` field received in the request:
+The `BlindSignature` object returned by the mint is also extended with the corresponding `metadata` field received in the request:
 
 ```json
 {
   "amount": int,
   "id": hex_str,
   "C_": hex_str,
-  "d_gap": hex_str
+  "metadata": {
+    "342": hex_str
+  }
 }
 ```
 
-- `d_gap`: The exact `d_gap` value received by the mint in the requesting `BlindedMessage`.
+- `metadata`: The exact metadata map accepted by the mint in the requesting `BlindedMessage`.
 
 ### Mint Requirements
 
-Mints **MUST** store the `d_gap` field alongside the `BlindedMessage` and `BlindSignature` in their database. When returning a `BlindSignature` (either during the initial response or in response to a [NUT-09][09] restore request), the mint **MUST** return the corresponding stored `d_gap` value.
+Mints **MUST** store accepted metadata alongside the `BlindedMessage` and `BlindSignature` in their database. When returning a `BlindSignature` (either during the initial response or in response to a [NUT-09][09] restore request), the mint **MUST** return the corresponding stored metadata unchanged.
 
 ### Mint info setting
 
@@ -95,7 +107,7 @@ This section describes one possible wallet strategy. Wallets may use any search 
 
 ### Tracking the dynamic gap
 
-A wallet can store the secret derivation index (`counter_k`) for each unspent or pending `Proof` in its local database. When generating outputs for a swap, mint, or melt-change request, it can find `first_unspent`, calculate `d_gap` as defined above, and attach the result to each `BlindedMessage`.
+A wallet can store the secret derivation index (`counter_k`) for each unspent or pending `Proof` in its local database. When generating outputs for a swap, mint, or melt-change request, it can find `first_unspent`, calculate `d_gap` as defined above, encrypt it, and attach the result under metadata key `342` in each `BlindedMessage`.
 
 ### Recovery strategy
 
@@ -131,8 +143,9 @@ Once `T` is found, the wallet retrieves the `BlindSignature` for `T` and decrypt
 
 ```
 function decrypt_d_gap(encrypted_hex, r) {
-    key = SHA256(r)[0:16]
-    nonce, ciphertext, tag = split(encrypted_hex)
+    key = HKDF-SHA256(ikm=r, salt="", info="cashu:nut-342:d-gap:key:v1", L=16)
+    nonce = HKDF-SHA256(ikm=r, salt="", info="cashu:nut-342:d-gap:nonce:v1", L=12)
+    ciphertext, tag = split(encrypted_hex, 4, 16)
     return AES_128_GCM_Decrypt(key, nonce, ciphertext, tag)
 }
 ```
@@ -146,7 +159,7 @@ function recover_unspent_proofs(keyset_id, t) {
     signature = restore_signature(keyset_id, t)
 
     r = get_r(keyset_id, t)
-    d_gap = decrypt_d_gap(signature.d_gap, r)
+    d_gap = decrypt_d_gap(signature.metadata["342"], r)
 
     start = max(0, t - d_gap)
     signatures = restore_signatures_batch(keyset_id, start, t)
@@ -182,9 +195,9 @@ This approach has several distinct advantages:
 
 This NUT is fully backwards-compatible:
 
-- **Mint**: Implementing this NUT is optional for mints. If supported, the mint saves and returns the optional `d_gap` field. Mints that do not support this NUT will ignore the `d_gap` field.
-- **Wallet**: Wallets that support this NUT can use another recovery strategy, such as the [NUT-13][13] linear scan, if the relevant `BlindSignature` response does not contain `d_gap`.
-- **Interoperability**: If a wallet is restored on a mint that does not support `d_gap` storage, or if recovering an older wallet that did not back up `d_gap`, the restored signatures will not contain `d_gap`. The absence of the optional field does not affect existing recovery strategies.
+- **Mint**: Implementing this NUT is optional for mints. Mints advertise the metadata keys they support and store only validated values for those keys.
+- **Wallet**: Wallets that support this NUT can use another recovery strategy, such as the [NUT-13][13] linear scan, if the relevant `BlindSignature` response does not contain metadata key `342`.
+- **Interoperability**: If a wallet is restored on a mint that does not support NUT-342 metadata, or if recovering an older wallet that did not back up `d_gap`, the restored signatures will not contain metadata key `342`. Its absence does not affect existing recovery strategies.
 
 [03]: 03.md
 [06]: 06.md

--- a/XX.md
+++ b/XX.md
@@ -200,6 +200,22 @@ This NUT is fully backwards-compatible:
 - **Wallet**: Implementing this NUT is optional. Wallets that do not implement it continue to use the [NUT-13][13] linear scan.
 - **Interoperability**: Wallets that implement this NUT can recover funds from any [NUT-13][13] wallet. However, if the original wallet did NOT maintain the Depth Invariant, unspent tokens outside the `(T - d, T]` window will not be recovered. In this case, wallets **SHOULD** fall back to the [NUT-13][13] linear scan over `[0, T]` to ensure complete recovery.
 
+### Nostr mint backups (NUT-27)
+
+To signal to a restoring wallet that the original wallet maintained the Depth Invariant, wallets that implement this NUT and perform [NUT-27][27] backups **SHOULD** include a `nut_xx: true` field in the unencrypted JSON payload.
+
+Example of a [NUT-27][27] backup payload with the `nut_xx` hint:
+
+```json
+{
+  "mints": ["https://mint.example.com", "https://another-mint.org"],
+  "timestamp": 1703721600,
+  "nut_xx": true
+}
+```
+
+A restoring wallet that finds this flag **MAY** safely assume the depth invariant was maintained and skip the [NUT-13][13] linear scan fallback.
+
 ### Migration
 
 Existing wallets that adopt this NUT **SHOULD** perform a one-time consolidation at activation to bring all unspent proofs into the `(T - d, T]` window, establishing the Depth Invariant for future recoveries.
@@ -229,3 +245,4 @@ TBD — to be added before this NUT moves to final status.
 [07]: 07.md
 [09]: 09.md
 [13]: 13.md
+[27]: 27.md

--- a/XX.md
+++ b/XX.md
@@ -1,0 +1,248 @@
+# NUT-XX: Efficient Wallet Recovery
+
+`optional`
+
+`depends on: NUT-03, NUT-07, NUT-09, NUT-13`
+
+---
+
+This NUT defines an improved recovery algorithm for [NUT-13][13] wallets. It is motivated by the privacy and efficiency limitations of the current linear scan approach described in [nuts#301](https://github.com/cashubtc/nuts/issues/301).
+
+The recovery procedure defined in [NUT-13][13] reveals the wallet's entire transaction history to the mint. During recovery, the wallet sends every `BlindedMessage` it has ever generated — including nonces for tokens that were never issued — to the mint in sequential batches. This has two consequences:
+
+1. **Privacy**: The mint can correlate all of the user's past ecash activity retroactively, defeating the unlinkability guarantees of ecash.
+2. **Efficiency**: Recovery requires O(T/b) network requests, where T is the total number of issued notes and b is the batch size.
+
+This NUT reduces leakage to O(log N + g + d) `BlindedMessages`, where N is the nonce space (2^32), g is a gap-tolerance window, and d is a configurable depth parameter that bounds the unspent token region. This is achieved by combining a binary search to locate the last issued nonce index T, and maintaining a **Depth Invariant** that confines all unspent tokens to the last `d` nonce indices.
+
+## Depth Invariant
+
+This NUT introduces a protocol invariant that wallets **MUST** maintain during normal operation:
+
+> **All unspent `Proofs` must have a nonce index greater than `T - d`.**
+
+Where:
+
+- **T** is the index of the nonce used for the last issued `BlindedMessage`. No issued note has a nonce index greater than T.
+- **d** is a configurable positive integer defining the maximum depth of the unspent token window. Wallets **SHOULD** use d = 100 as the default.
+- **g** is a configurable positive integer defining a gap-tolerance window scanned beyond the candidate T to handle failed operations. Wallets **SHOULD** use g = 50 as the default.
+- **Nonce index** is the `counter_k` value used by [NUT-13][13] to derive the secret and blinding factor for a `Proof`.
+
+Formally, for every unspent `Proof` with nonce index `i`: `i > T - d`
+
+```
+[0] |=============================[T-d]-----[T]>
+     spent or reissued               unspent proofs (-), at most d of them
+```
+
+This invariant guarantees that all unspent tokens are confined to the nonce window `(T - d, T]`, whose size is bounded by `d`.
+
+### Maintaining the invariant
+
+To maintain the invariant, wallets that implement this NUT **MUST**:
+
+1. **On receive (mint/swap-in)**: After receiving new tokens, T increases. If any existing unspent `Proof` now has a nonce index `i ≤ T - d`, the wallet **MUST** consolidate those proofs by re-issuing them via a [NUT-03][03] swap. The re-issued proofs receive new nonce indices near T, restoring the invariant.
+
+2. **On send (swap-to-send)**: A send operation involves a [NUT-03][03] swap that creates new outputs (send proofs + change proofs), which increases T. If this increase causes any remaining unspent proofs (those not involved in the swap) to have index `i ≤ T - d`, the wallet **MUST** consolidate them. Note: a pure melt (paying a Lightning invoice without swap) does not increase T and therefore cannot violate the invariant.
+
+3. **Coin selection**: Wallets **MAY** use arbitrary coin selection. After any operation that increases T, the wallet **MUST** check whether any unspent proof now has index `i ≤ T - d` and consolidate if so. This preserves free coin selection while enforcing the invariant.
+
+> [!NOTE]
+> The consolidation swap is a standard [NUT-03][03] swap — it does not reveal any additional information about the wallet's history beyond what is already implicit in the swap operation itself.
+
+### Consolidation strategy
+
+Since recovery can be triggered at any time by data loss, the invariant **MUST** hold at all times — not just "before recovery". Wallets **MUST** consolidate violating proofs immediately after any operation that increases T.
+
+In practice, a simple strategy is:
+
+- After each operation that increases T, check whether any unspent proof has index `i ≤ T - d`.
+- If so, consolidate all such proofs in a single [NUT-03][03] swap before the operation is considered complete.
+
+This ensures the invariant is never violated, even if the wallet crashes or loses data immediately after the operation.
+
+## Recovery algorithm
+
+### Locating T via binary search
+
+The wallet uses binary search over the nonce space `[0, 2^32 - 1]` to find T with O(log N) queries to the mint's [NUT-09][09] restore endpoint.
+
+At each step, the wallet queries the mint with a single `BlindedMessage` derived from the midpoint index `m`. If the mint returns a `BlindSignature` for it, `m ≤ T`; otherwise, `m > T`.
+
+Where `query(keyset_id, index)` sends a single `BlindedMessage` (derived from `keyset_id` and `counter = index`) to the [NUT-09][09] endpoint and returns the mint's response.
+
+Python:
+
+```python
+async def find_t(keyset_id: str) -> int:
+    """Binary search to find T (last issued nonce index)."""
+    lo = 0
+    hi = 2**32 - 1
+
+    # Edge case: nothing has been issued
+    if not await query(keyset_id, 0):
+        return -1
+
+    while lo < hi:
+        m = (lo + hi + 1) // 2
+        if await query(keyset_id, m):
+            lo = m       # T is at m or to the right
+        else:
+            hi = m - 1   # T is to the left of m
+
+    return lo  # lo == hi == T_candidate
+```
+
+### Gap tolerance
+
+Failed wallet operations (e.g., network interruptions after the counter was incremented but before the mint signed) may create gaps in the issued nonce space. A single gap at index `m` would cause the binary search to return a T less than the true value, potentially missing valid tokens.
+
+To mitigate this, after `find_t` returns a candidate `T_candidate`, wallets **MUST** perform a forward linear scan of `[T_candidate + 1, T_candidate + g]` to verify that no issued nonces exist beyond `T_candidate`. If any are found, `T_candidate` is updated to the highest found index, and the scan window shifts forward from the new `T_candidate`.
+
+Python:
+
+```python
+async def scan_gap(keyset_id: str, t_candidate: int, g: int = 50) -> int:
+    """Forward scan to handle gaps in the nonce space."""
+    t = t_candidate
+    i = t + 1
+    limit = t + g
+
+    while i <= limit:
+        if await query(keyset_id, i):
+            t = i
+            limit = i + g   # extend window from new T
+        i += 1
+
+    return t
+```
+
+This adds at most `g` queries per gap encountered. For wallets with no gaps (the common case), it adds exactly `g` queries total.
+
+> [!NOTE]
+> The gap scan can be implemented as a single [NUT-09][09] batch request containing `g` `BlindedMessages`, rather than `g` individual requests. If any signatures are returned, the wallet extends the window from the highest found index and sends another batch. This reduces total requests without affecting the number of nonces revealed.
+
+### Recovering unspent proofs
+
+With T known, all unspent tokens are in the nonce window `(T - d, T]` thanks to the Depth Invariant. The wallet sends a single batch request to the [NUT-09][09] endpoint with `BlindedMessages` for indices `T - d + 1` through `T`, then filters out spent `Proofs` using [NUT-07][07].
+
+Python:
+
+```python
+async def recover(keyset_id: str, t: int, d: int = 100) -> list:
+    """Recover unspent proofs from the bounded window."""
+    start = max(0, t - d + 1)
+    outputs = [blinded_message(keyset_id, i) for i in range(start, t + 1)]
+    signatures = await restore(outputs)          # NUT-09
+    proofs = unblind(signatures)
+    unspent = await check_states(proofs)         # NUT-07
+    return [p for p in unspent if p.state == "UNSPENT"]
+```
+
+This step requires exactly one [NUT-09][09] request (with at most `d` outputs) plus one [NUT-07][07] state check.
+
+### Full recovery procedure
+
+Wallets implementing this NUT **SHOULD** use the following procedure instead of the linear scan defined in [NUT-13][13]:
+
+Python:
+
+```python
+async def recover_wallet(mnemonic: str, d: int = 100, g: int = 50):
+    """Full wallet recovery using binary search."""
+    init_from_mnemonic(mnemonic)
+    for keyset_id in get_keysets():
+        t_candidate = await find_t(keyset_id)
+        if t_candidate == -1:
+            continue
+
+        t = await scan_gap(keyset_id, t_candidate, g)
+        unspent = await recover(keyset_id, t, d)
+        store(unspent)
+        set_counter(keyset_id, t + 1)
+```
+
+## Privacy analysis
+
+### Cost breakdown
+
+With default parameters d = 100, g = 50:
+
+| Component | Nonces revealed | Requests (individual) | Requests (batched) |
+|---|---|---|---|
+| Binary search | log₂(N) = 32 | 32 (sequential, cannot be batched) | 32 |
+| Gap scan | g = 50 | 50 | 1–2 (single [NUT-09][09] batch) |
+| Recovery | d = 100 | 1 ([NUT-09][09] batch) | 1 |
+| State check | 0 | 1 ([NUT-07][07]) | 1 |
+| **Total** | **182** | **84** | **~35** |
+
+### Comparison with NUT-13
+
+| Approach | Nonces revealed | Requests |
+|---|---|---|
+| [NUT-13][13] linear scan (batch=25) | T + 50 | T/25 + 2 |
+| This NUT (d=100, g=50, batched) | 182 (constant) | ~35 |
+
+Examples:
+
+| Wallet size (T) | NUT-13 nonces | This NUT nonces | NUT-13 requests | This NUT requests |
+|---|---|---|---|---|
+| 100 | 150 | 182 | 6 | ~35 |
+| 500 | 550 | 182 | 22 | ~35 |
+| 1,000 | 1,050 | 182 | 42 | ~35 |
+| 5,000 | 5,050 | 182 | 202 | ~35 |
+| 100,000 | 100,050 | 182 | 4,002 | ~35 |
+
+### Breakeven points
+
+This NUT reveals **more** nonces than [NUT-13][13] for small wallets:
+
+- **Privacy breakeven**: T ≈ 132. For wallets with T < 132, [NUT-13][13] reveals fewer nonces.
+- **Efficiency breakeven**: T ≈ 825 (with batched gap scan). For wallets with T < 825, [NUT-13][13] makes fewer requests.
+
+For wallets below these thresholds, the overhead of binary search (32 sequential round-trips) and the fixed recovery window (`d` nonces) exceeds the cost of a simple linear scan. Wallets **MAY** use a heuristic: if a previous recovery or local state suggests T < 200, fall back to the [NUT-13][13] linear scan.
+
+### Privacy properties
+
+The privacy gain for wallets above the breakeven comes from two properties:
+
+1. **Bounded leakage**: The number of revealed nonces is constant (182) regardless of wallet history size. A wallet with T = 1,000 reveals the same number of nonces as one with T = 100,000.
+2. **Non-sequential probes**: The 32 binary search probes are spread across the entire nonce space and are non-contiguous, making transaction history correlation significantly harder for the mint compared to the sequential batches of [NUT-13][13].
+
+## Backwards compatibility
+
+This NUT is fully backwards-compatible:
+
+- **Mint**: No changes required. The wallet uses the existing [NUT-09][09] restore endpoint with single-element batches during binary search and a standard batch for the final recovery. No new endpoints or response fields are needed.
+- **Wallet**: Implementing this NUT is optional. Wallets that do not implement it continue to use the [NUT-13][13] linear scan.
+- **Interoperability**: Wallets that implement this NUT can recover funds from any [NUT-13][13] wallet. However, if the original wallet did NOT maintain the Depth Invariant, unspent tokens outside the `(T - d, T]` window will not be recovered. In this case, wallets **SHOULD** fall back to the [NUT-13][13] linear scan over `[0, T]` to ensure complete recovery.
+
+### Migration
+
+Existing wallets that adopt this NUT **SHOULD** perform a one-time consolidation at activation to bring all unspent proofs into the `(T - d, T]` window, establishing the Depth Invariant for future recoveries.
+
+## Implementation notes
+
+### Mints
+
+No changes to the mint are required. The existing [NUT-09][09] restore endpoint is used as-is.
+
+### Wallets
+
+Wallets that implement this NUT **MUST**:
+- Implement the consolidation logic to maintain the Depth Invariant after send and receive operations
+- Store the nonce index (`counter_k`) for each `Proof` in their local database, so that violation checks can be performed efficiently
+
+Wallets **SHOULD**:
+- Use d = 100 as the default depth parameter
+- Use g = 50 as the default gap-tolerance window
+- Expose `d` as a user-configurable setting for advanced users who want to trade off recovery window size against consolidation frequency
+
+## Test vectors
+
+TBD — to be added before this NUT moves to final status.
+
+[03]: 03.md
+[07]: 07.md
+[09]: 09.md
+[13]: 13.md

--- a/XX.md
+++ b/XX.md
@@ -6,14 +6,7 @@
 
 ---
 
-This NUT defines an improved recovery algorithm for [NUT-13][13] wallets. It is motivated by the privacy and efficiency limitations of the current linear scan approach described in [nuts#301](https://github.com/cashubtc/nuts/issues/301).
-
-The recovery procedure defined in [NUT-13][13] reveals the wallet's entire transaction history to the mint. During recovery, the wallet sends every `BlindedMessage` it has ever generated — including nonces for tokens that were never issued — to the mint in sequential batches. This has two consequences:
-
-1. **Privacy**: The mint can correlate all of the user's past ecash activity retroactively, defeating the unlinkability guarantees of ecash.
-2. **Efficiency**: Recovery requires O(T/b) network requests, where T is the total number of issued notes and b is the batch size.
-
-This NUT reduces leakage to O(log N + g + d) `BlindedMessages`, where N is the nonce space (2^32), g is a gap-tolerance window, and d is a configurable depth parameter that bounds the unspent token region. This is achieved by combining a binary search to locate the last issued nonce index T, and maintaining a **Depth Invariant** that confines all unspent tokens to the last `d` nonce indices.
+This NUT defines an improved recovery algorithm for [NUT-13][13] wallets that reduces the number of `BlindedMessages` revealed to the mint from O(T) to a constant (~182), improving both privacy and efficiency. It combines a binary search to locate the last issued nonce index T with a **Depth Invariant** that confines all unspent tokens to the last `d` nonce indices.
 
 ## Depth Invariant
 

--- a/XX.md
+++ b/XX.md
@@ -45,7 +45,7 @@ To maintain the invariant, wallets that implement this NUT **MUST**:
 
 ### Consolidation strategy
 
-Since recovery can be triggered at any time by data loss, the invariant **MUST** hold at all times — not just "before recovery". Wallets **MUST** consolidate violating proofs immediately after any operation that increases T.
+Since recovery can be triggered at any time by data loss, the invariant **MUST** hold at all times — not just "before recovery". Wallets **MUST** consolidate violating proofs immediately before any operation that increases T.
 
 In practice, a simple strategy is:
 

--- a/XX.md
+++ b/XX.md
@@ -40,6 +40,8 @@ To maintain the invariant, wallets that implement this NUT **MUST**:
 
 3. **Coin selection**: Wallets **MAY** use arbitrary coin selection. After any operation that increases T, the wallet **MUST** check whether any unspent proof now has index `i ≤ T - d` and consolidate if so. This preserves free coin selection while enforcing the invariant.
 
+4. **Compaction**: If the wallet already holds `d` or more unspent proofs, any operation that creates new outputs would violate the invariant regardless of consolidation. In this case, the wallet **MUST** first compact its existing proofs by combining multiple proofs into fewer outputs via a [NUT-03][03] swap, reducing the number of unspent proofs before proceeding.
+
 > [!NOTE]
 > The consolidation swap is a standard [NUT-03][03] swap — it does not reveal any additional information about the wallet's history beyond what is already implicit in the swap operation itself.
 
@@ -186,21 +188,9 @@ Examples:
 | 5,000 | 5,050 | 182 | 202 | ~35 |
 | 100,000 | 100,050 | 182 | 4,002 | ~35 |
 
-### Breakeven points
+### Breakeven note
 
-This NUT reveals **more** nonces than [NUT-13][13] for small wallets:
-
-- **Privacy breakeven**: T ≈ 132. For wallets with T < 132, [NUT-13][13] reveals fewer nonces.
-- **Efficiency breakeven**: T ≈ 825 (with batched gap scan). For wallets with T < 825, [NUT-13][13] makes fewer requests.
-
-For wallets below these thresholds, the overhead of binary search (32 sequential round-trips) and the fixed recovery window (`d` nonces) exceeds the cost of a simple linear scan. Wallets **MAY** use a heuristic: if a previous recovery or local state suggests T < 200, fall back to the [NUT-13][13] linear scan.
-
-### Privacy properties
-
-The privacy gain for wallets above the breakeven comes from two properties:
-
-1. **Bounded leakage**: The number of revealed nonces is constant (182) regardless of wallet history size. A wallet with T = 1,000 reveals the same number of nonces as one with T = 100,000.
-2. **Non-sequential probes**: The 32 binary search probes are spread across the entire nonce space and are non-contiguous, making transaction history correlation significantly harder for the mint compared to the sequential batches of [NUT-13][13].
+This NUT reveals **more** nonces than [NUT-13][13] for small wallets (T < ~132), because the fixed cost of binary search (32 probes) plus the recovery window (`d` nonces) exceeds the cost of a linear scan. Since T is only discovered during recovery, wallets cannot decide in advance which strategy is cheaper.
 
 ## Backwards compatibility
 


### PR DESCRIPTION
Motivated by #301 . Replaces the NUT-13 linear scan with binary search + a depth invariant that bounds unspent proofs to the last `d` nonce indices.

Reduces BlindedMessages revealed to the mint from O(T) to ~182 (constant), and requests from O(T/b) to ~35. No mint changes required.

Builds on the binary search and d-invariant ideas from #301 . Credit to @a1denvalu3  for the original proposal and algorithm design, @robwoodgate  for the halfway-house approach and the concerns around coin-selection that shaped the final invariant, @gandlafbtc  for the local-search alternative that framed the trade-offs, and @davidcaseria  for raising the practicality constraints that led to the relaxed invariant.

Open for discussion this is a draft NUT, not final. Feedback welcome especially on: the Depth Invariant definition, the gap-tolerance approach, and the default value of `d`.
