### PR TITLE
Specify NUT-22 authA serialization

### DIFF
--- a/22.md
+++ b/22.md
@@ -170,13 +170,15 @@ The wallet checks the `MintBlindAuthSetting` of the mint to determine which endp
 
 ### Serialization
 
-To add a blind authentication token (BAT) to the request header, we need to serialize a single `AuthProof` JSON as URL-safe base64 encoding **with padding** (RFC 4648 §5) with the prefix `authA`:
+To add a blind authentication token (BAT) to the request header, we need to serialize a single `AuthProof` JSON as base64url with the prefix `authA`:
 
 ```sh
-authA[base64urlpadded_authproof_json]
+authA[base64url_authproof_json]
 ```
 
 This string is a BAT.
+
+Note that `base64_url` strings may have padding characters (usually `=`) at the end, which can be omitted. Mints **MUST** accept and decode both padded and unpadded forms.
 
 > [!CAUTION]
 >

--- a/22.md
+++ b/22.md
@@ -170,10 +170,10 @@ The wallet checks the `MintBlindAuthSetting` of the mint to determine which endp
 
 ### Serialization
 
-To add a blind authentication token (BAT) to the request header, we need to serialize a single `AuthProof` JSON in base64 with the prefix `authA`:
+To add a blind authentication token (BAT) to the request header, we need to serialize a single `AuthProof` JSON as URL-safe base64 encoding **with padding** (RFC 4648 §5) with the prefix `authA`:
 
 ```sh
-authA[base64_authproof_json]
+authA[base64urlpadded_authproof_json]
 ```
 
 This string is a BAT.


### PR DESCRIPTION
NUT-22 does not specify the base64 encoding variant to use.

CDK uses [general_purpose::URL_SAFE](https://github.com/cashubtc/cdk/blob/8ed5c86625ef6e238692761c8a64231ebd560a57/crates/cashu/src/nuts/auth/nut22.rs#L244), which requires base64 URL _**with padding**_ .

This PR requires mints to support both padded and unpadded forms (as per https://github.com/cashubtc/nuts/pull/147).

# Implementation
- [x] Cashu-TS: https://github.com/cashubtc/cashu-ts/pull/529 (sends padded)
- [x] CDK: https://github.com/cashubtc/cdk/issues/1740
- [x] Nutshell: https://github.com/cashubtc/nutshell/issues/919

**NOTE:** This was not an issue prior to keysets v2, as keyset v1 IDs (16 chars) produced serialized BAT JSON of exactly 174 bytes, and 174 % 3 = 0 — so base64 encoding never produced any padding before.