### PR TITLE
NUT-13: Use only HMAC-SHA256 derivation for v2 keyset recovery

### DIFF
--- a/13.md
+++ b/13.md
@@ -268,7 +268,7 @@ The wallet takes the following steps during recovery:
 1. Determine the keyset version from the keyset ID
 2. Generate `secret` and `r` from `counter` and `keyset` using the appropriate derivation method:
    - For keyset version `00`: Use legacy BIP32 derivation
-   - For keyset version `01`: Use legacy BIP32 derivation and HMAC-SHA256 derivation (more on this below)
+   - For keyset version `01`: Use HMAC-SHA256 derivation
 3. Generate `BlindedMessage` from `secret`
 4. Obtain `BlindSignature` for `secret` from the mint
 5. Unblind `BlindSignature` to `C` using `r`
@@ -279,11 +279,6 @@ The wallet takes the following steps during recovery:
 
 To generate the `BlindedMessages`, the wallet starts with a `counter := 0` and, for each increment of the `counter`, generates a `secret` and `r` using the appropriate derivation method based on the keyset version.
 
-> [!CAUTION]
-> We assume old wallets don't know the difference between `00` and `01` keyset ID and secret derivation: they might have generated secrets using the
-> legacy derivation whereas the new derivation was required.
-> Therefore, when performing a recovering for a `01` keyset, up-to-date wallets **MUST** check secrets with both derivation methods. (see [Restoring batches](#restoring-batches))
-
 **For keyset version `00` (legacy):**
 
 ```python
@@ -291,16 +286,7 @@ secret = bip32.get_privkey_from_path(secret_derivation_path).hex()
 r = self.bip32.get_privkey_from_path(r_derivation_path)
 ```
 
-**For keyset version `01` (legacy and HMAC-SHA256):**
-
-First:
-
-```python
-secret = bip32.get_privkey_from_path(secret_derivation_path).hex()
-r = self.bip32.get_privkey_from_path(r_derivation_path)
-```
-
-Then:
+**For keyset version `01` (HMAC-SHA256):**
 
 ```python
 secret, r = derive_secret_and_r_hmac(seed, keyset_id, counter)


### PR DESCRIPTION
Updates NUT-13 to run recovery only once using the new HMAC-SHA256 derivation for v2 keysets. Removes the requirement to check secrets with both legacy and new derivation.