### PR TITLE
feat(nut-18, nut-26): add preferred_mints to payment requests

### DIFF
--- a/18.md
+++ b/18.md
@@ -37,8 +37,8 @@ Here, the fields are
 - `a`: The amount of the requested payment
 - `u`: The unit of the requested payment (MUST be set if `a` is set)
 - `s`: Whether the payment request is for single use
-- `m`: A set of mints from which the payment is requested
-- `pm`: A set of preferred mints the receiver supports. The sender can choose to pay from one of these mints for faster and cheaper transactions
+- `m`: A set of mints from which the payment is requested. If this field is defined, the receiver SHOULD only accept proofs from these mints.
+- `pm`: A set of preferred mints the receiver supports. If this field is defined, the receiver will accept proofs from any mint but prefers these mints for faster and cheaper transactions.
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)
 - `nut10`: The required [NUT-10][10] locking condition

--- a/18.md
+++ b/18.md
@@ -24,6 +24,7 @@ A Payment Request is defined as follows
   "u": str <optional>,
   "s": bool <optional>,
   "m": Array[str] <optional>,
+  "pm": Array[str] <optional>,
   "d": str <optional>,
   "t": Array[Transport] <optional>,
   "nut10": NUT10Option <optional>,
@@ -37,6 +38,7 @@ Here, the fields are
 - `u`: The unit of the requested payment (MUST be set if `a` is set)
 - `s`: Whether the payment request is for single use
 - `m`: A set of mints from which the payment is requested
+- `pm`: A set of preferred mints the receiver supports. The sender can choose to pay from one of these mints for faster and cheaper transactions
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)
 - `nut10`: The required [NUT-10][10] locking condition

--- a/18.md
+++ b/18.md
@@ -37,8 +37,8 @@ Here, the fields are
 - `a`: The amount of the requested payment
 - `u`: The unit of the requested payment (MUST be set if `a` is set)
 - `s`: Whether the payment request is for single use
-- `m`: A set of mints from which the payment is requested. If this field is defined, the sender SHOULD only send proofs from these mints.
-- `pm`: A set of preferred mints the receiver supports. If this field is defined, the receiver will accept proofs from any mint but prefers these mints for faster and cheaper transactions.
+- `m`: A set of mints from which the payment is requested. If this field is defined, the sender SHOULD only send proofs from these mints. The fields `m` and `pm` are mutually exclusive; a payment request MUST NOT contain both fields.
+- `pm`: A set of preferred mints the receiver supports. If this field is defined, the receiver will accept proofs from any mint but prefers these mints for faster and cheaper transactions. The fields `m` and `pm` are mutually exclusive; a payment request MUST NOT contain both fields.
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)
 - `nut10`: The required [NUT-10][10] locking condition

--- a/18.md
+++ b/18.md
@@ -37,7 +37,7 @@ Here, the fields are
 - `a`: The amount of the requested payment
 - `u`: The unit of the requested payment (MUST be set if `a` is set)
 - `s`: Whether the payment request is for single use
-- `m`: A set of mints from which the payment is requested. If this field is defined, the receiver SHOULD only accept proofs from these mints.
+- `m`: A set of mints from which the payment is requested. If this field is defined, the sender SHOULD only send proofs from these mints.
 - `pm`: A set of preferred mints the receiver supports. If this field is defined, the receiver will accept proofs from any mint but prefers these mints for faster and cheaper transactions.
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)

--- a/18.md
+++ b/18.md
@@ -25,6 +25,7 @@ A Payment Request is defined as follows
   "s": bool <optional>,
   "m": Array[str] <optional>,
   "pm": Array[str] <optional>,
+  "sm": Array[str] <optional>,
   "d": str <optional>,
   "t": Array[Transport] <optional>,
   "nut10": NUT10Option <optional>,
@@ -39,6 +40,7 @@ Here, the fields are
 - `s`: Whether the payment request is for single use
 - `m`: A set of mints from which the payment is requested. If this field is defined, the sender SHOULD only send proofs from these mints. The fields `m` and `pm` are mutually exclusive; a payment request MUST NOT contain both fields.
 - `pm`: A set of preferred mints the receiver supports. If this field is defined, the receiver will accept proofs from any mint but prefers these mints for faster and cheaper transactions. The fields `m` and `pm` are mutually exclusive; a payment request MUST NOT contain both fields.
+- `sm`: A list of supported methods (e.g. `"bolt11"`, `"bolt12"`, `"on-chain"`) that the mint from which the payer sends ecash MUST support.
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)
 - `nut10`: The required [NUT-10][10] locking condition

--- a/26.md
+++ b/26.md
@@ -42,8 +42,8 @@ The payment request is encoded as a sequence of TLV fields. Each TLV entry consi
 | 0x05 | mint           | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON)            |
 | 0x06 | description    | string    | Human-readable description (corresponds to `d` in JSON)                         |
 | 0x07 | transport      | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)                |
-| 0x08 | nut10          | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)                     |
-| 0x09 | preferred_mint | string    | Preferred mint URL (repeatable for multiple mints, corresponds to `pm` in JSON) |
+| 0x08 | nut10          | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)          |
+| 0x09 | preferred_mints | string    | Preferred mint URL (repeatable for multiple mints, corresponds to `pm` in JSON) |
 
 All fields are optional. Unknown tags MUST be ignored to maintain forward compatibility.
 

--- a/26.md
+++ b/26.md
@@ -33,16 +33,16 @@ The payment request is encoded as a sequence of TLV fields. Each TLV entry consi
 
 ### Top-Level TLV Tags
 
-| Tag  | Field          | Type      | Description                                                          |
-| ---- | -------------- | --------- | -------------------------------------------------------------------- |
-| 0x01 | id             | string    | Payment identifier (corresponds to `i` in JSON)                      |
-| 0x02 | amount         | u64       | Amount in base units (corresponds to `a` in JSON)                    |
-| 0x03 | unit           | u8/string | Currency unit (corresponds to `u` in JSON)                           |
-| 0x04 | single_use     | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)        |
-| 0x05 | mint           | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON) |
-| 0x06 | description    | string    | Human-readable description (corresponds to `d` in JSON)              |
-| 0x07 | transport      | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)     |
-| 0x08 | nut10          | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)          |
+| Tag  | Field          | Type      | Description                                                                     |
+| ---- | -------------- | --------- | ------------------------------------------------------------------------------- |
+| 0x01 | id             | string    | Payment identifier (corresponds to `i` in JSON)                                 |
+| 0x02 | amount         | u64       | Amount in base units (corresponds to `a` in JSON)                               |
+| 0x03 | unit           | u8/string | Currency unit (corresponds to `u` in JSON)                                      |
+| 0x04 | single_use     | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)                   |
+| 0x05 | mint           | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON)            |
+| 0x06 | description    | string    | Human-readable description (corresponds to `d` in JSON)                         |
+| 0x07 | transport      | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)                |
+| 0x08 | nut10          | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)                     |
 | 0x09 | preferred_mint | string    | Preferred mint URL (repeatable for multiple mints, corresponds to `pm` in JSON) |
 
 All fields are optional. Unknown tags MUST be ignored to maintain forward compatibility.

--- a/26.md
+++ b/26.md
@@ -33,16 +33,17 @@ The payment request is encoded as a sequence of TLV fields. Each TLV entry consi
 
 ### Top-Level TLV Tags
 
-| Tag  | Field       | Type      | Description                                                          |
-| ---- | ----------- | --------- | -------------------------------------------------------------------- |
-| 0x01 | id          | string    | Payment identifier (corresponds to `i` in JSON)                      |
-| 0x02 | amount      | u64       | Amount in base units (corresponds to `a` in JSON)                    |
-| 0x03 | unit        | u8/string | Currency unit (corresponds to `u` in JSON)                           |
-| 0x04 | single_use  | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)        |
-| 0x05 | mint        | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON) |
-| 0x06 | description | string    | Human-readable description (corresponds to `d` in JSON)              |
-| 0x07 | transport   | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)     |
-| 0x08 | nut10       | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)          |
+| Tag  | Field          | Type      | Description                                                          |
+| ---- | -------------- | --------- | -------------------------------------------------------------------- |
+| 0x01 | id             | string    | Payment identifier (corresponds to `i` in JSON)                      |
+| 0x02 | amount         | u64       | Amount in base units (corresponds to `a` in JSON)                    |
+| 0x03 | unit           | u8/string | Currency unit (corresponds to `u` in JSON)                           |
+| 0x04 | single_use     | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)        |
+| 0x05 | mint           | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON) |
+| 0x06 | description    | string    | Human-readable description (corresponds to `d` in JSON)              |
+| 0x07 | transport      | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)     |
+| 0x08 | nut10          | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)          |
+| 0x09 | preferred_mint | string    | Preferred mint URL (repeatable for multiple mints, corresponds to `pm` in JSON) |
 
 All fields are optional. Unknown tags MUST be ignored to maintain forward compatibility.
 

--- a/26.md
+++ b/26.md
@@ -33,16 +33,16 @@ The payment request is encoded as a sequence of TLV fields. Each TLV entry consi
 
 ### Top-Level TLV Tags
 
-| Tag  | Field          | Type      | Description                                                                     |
-| ---- | -------------- | --------- | ------------------------------------------------------------------------------- |
-| 0x01 | id             | string    | Payment identifier (corresponds to `i` in JSON)                                 |
-| 0x02 | amount         | u64       | Amount in base units (corresponds to `a` in JSON)                               |
-| 0x03 | unit           | u8/string | Currency unit (corresponds to `u` in JSON)                                      |
-| 0x04 | single_use     | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)                   |
-| 0x05 | mint           | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON)            |
-| 0x06 | description    | string    | Human-readable description (corresponds to `d` in JSON)                         |
-| 0x07 | transport      | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)                |
-| 0x08 | nut10          | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)          |
+| Tag  | Field           | Type      | Description                                                                     |
+| ---- | --------------- | --------- | ------------------------------------------------------------------------------- |
+| 0x01 | id              | string    | Payment identifier (corresponds to `i` in JSON)                                 |
+| 0x02 | amount          | u64       | Amount in base units (corresponds to `a` in JSON)                               |
+| 0x03 | unit            | u8/string | Currency unit (corresponds to `u` in JSON)                                      |
+| 0x04 | single_use      | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)                   |
+| 0x05 | mint            | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON)            |
+| 0x06 | description     | string    | Human-readable description (corresponds to `d` in JSON)                         |
+| 0x07 | transport       | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)                |
+| 0x08 | nut10           | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)                     |
 | 0x09 | preferred_mints | string    | Preferred mint URL (repeatable for multiple mints, corresponds to `pm` in JSON) |
 
 All fields are optional. Unknown tags MUST be ignored to maintain forward compatibility.

--- a/26.md
+++ b/26.md
@@ -33,17 +33,18 @@ The payment request is encoded as a sequence of TLV fields. Each TLV entry consi
 
 ### Top-Level TLV Tags
 
-| Tag  | Field           | Type      | Description                                                                     |
-| ---- | --------------- | --------- | ------------------------------------------------------------------------------- |
-| 0x01 | id              | string    | Payment identifier (corresponds to `i` in JSON)                                 |
-| 0x02 | amount          | u64       | Amount in base units (corresponds to `a` in JSON)                               |
-| 0x03 | unit            | u8/string | Currency unit (corresponds to `u` in JSON)                                      |
-| 0x04 | single_use      | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)                   |
-| 0x05 | mint            | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON)            |
-| 0x06 | description     | string    | Human-readable description (corresponds to `d` in JSON)                         |
-| 0x07 | transport       | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)                |
-| 0x08 | nut10           | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)                     |
-| 0x09 | preferred_mints | string    | Preferred mint URL (repeatable for multiple mints, corresponds to `pm` in JSON) |
+| Tag  | Field             | Type      | Description                                                                       |
+| ---- | ----------------- | --------- | --------------------------------------------------------------------------------- |
+| 0x01 | id                | string    | Payment identifier (corresponds to `i` in JSON)                                   |
+| 0x02 | amount            | u64       | Amount in base units (corresponds to `a` in JSON)                                 |
+| 0x03 | unit              | u8/string | Currency unit (corresponds to `u` in JSON)                                        |
+| 0x04 | single_use        | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)                     |
+| 0x05 | mint              | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON)              |
+| 0x06 | description       | string    | Human-readable description (corresponds to `d` in JSON)                           |
+| 0x07 | transport         | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)                  |
+| 0x08 | nut10             | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)                       |
+| 0x09 | preferred_mints   | string    | Preferred mint URL (repeatable for multiple mints, corresponds to `pm` in JSON)   |
+| 0x0a | supported_methods | string    | Supported method (repeatable for multiple methods, corresponds to `sm` in JSON) |
 
 All fields are optional. Unknown tags MUST be ignored to maintain forward compatibility.
 

--- a/tests/18-tests.md
+++ b/tests/18-tests.md
@@ -157,3 +157,22 @@ Encoded:
 ```
 creqApWFpaGM5ZTQ1ZDJhYWEZAfRhdWNzYXRhbYF4GGh0dHBzOi8vbWludC5leGFtcGxlLmNvbWVudXQxMKNha2RQMlBLYWR4QjAyYzNiNWJiMjdlMzYxNDU3YzkyZDkzZDc4ZGQ3M2QzZDUzNzMyMTEwYjJjZmU4YjUwZmJjMGFiYzYxNWU5YzMzMWF0gYJndGltZW91dGQzNjAw
 ```
+
+### Preferred Mints Field
+
+A payment request specifying preferred mints using the `pm` field.
+
+```json
+{
+  "i": "pm_test",
+  "a": 100,
+  "u": "sat",
+  "pm": ["https://mint.example.com"]
+}
+```
+
+Encoded:
+
+```
+creqApGFpZ3BtX3Rlc3RhYRhkYXVjc2F0YnBtgXgYaHR0cHM6Ly9taW50LmV4YW1wbGUuY29t
+```

--- a/tests/18-tests.md
+++ b/tests/18-tests.md
@@ -176,3 +176,23 @@ Encoded:
 ```
 creqApGFpZ3BtX3Rlc3RhYRhkYXVjc2F0YnBtgXgYaHR0cHM6Ly9taW50LmV4YW1wbGUuY29t
 ```
+
+### Supported Methods Field
+
+A payment request specifying supported methods using the `sm` field.
+
+```json
+{
+  "i": "sm_test",
+  "a": 100,
+  "u": "sat",
+  "m": ["https://mint.example.com"],
+  "sm": ["bolt11", "bolt12"]
+}
+```
+
+Encoded:
+
+```
+creqAqaFpZdzbV90ZXN0YWEYZGF1Y3NhdGZib2x0MTFmYm9sdDEyYm1BeBhodHRwczovL21pbnQuZXhhbXBsZS5jb20=
+```

--- a/tests/26-test.md
+++ b/tests/26-test.md
@@ -413,3 +413,24 @@ Encoded:
 ```
 CREQB1QYQQKCM4WD6X7M2LW4HXJAQZQQYQQQQQQQQQQQRYQVQQXCN5VVZSQXRGW368QUE69UHK66TWWSHX27RPD4CXCEFWVDHK6PZHCW8
 ```
+
+---
+
+### Preferred Mints Field
+
+A payment request specifying preferred mints using the `pm` field (tag 0x09).
+
+```json
+{
+  "i": "pm_test",
+  "a": 100,
+  "u": "sat",
+  "pm": ["https://mint.example.com"]
+}
+```
+
+Encoded:
+
+```
+CREQB1QYQQWURDTA6X2UM5QGQQSQQQQQQQQQQQVSPSQQGQPYQPS6R5W3C8XW309AKKJMN59EJHSCTDWPKX2TNRDAKSYWN0VM
+```

--- a/tests/26-test.md
+++ b/tests/26-test.md
@@ -434,3 +434,25 @@ Encoded:
 ```
 CREQB1QYQQWURDTA6X2UM5QGQQSQQQQQQQQQQQVSPSQQGQPYQPS6R5W3C8XW309AKKJMN59EJHSCTDWPKX2TNRDAKSYWN0VM
 ```
+
+---
+
+### Supported Methods Field
+
+A payment request specifying supported methods using the `sm` field (tag 0x0a).
+
+```json
+{
+  "i": "sm_test",
+  "a": 100,
+  "u": "sat",
+  "m": ["https://mint.example.com"],
+  "sm": ["bolt11", "bolt12"]
+}
+```
+
+Encoded:
+
+```
+CREQB1QYQQGNRDTA6X2UM5QGQQSQQQQQQQQQQQVSPSQQGQQ5QPS6R5W3C8XW309AKKJMN59EJHSCTDWPKX2TNRDAKS2Q6XQZ096XJ3GCRVWEKXZ2N3W
+```


### PR DESCRIPTION
## Summary
- Introduces `preferred_mints` field (`pm` in JSON, `0x09` in TLV) to payment requests in NUT-18 and NUT-26.
- This allows the originator of the request to specify mints they support.
- Paying wallets can optionally use these preferred mints for faster and cheaper transactions without bridging through the lightning network.