### PR TITLE
Tighten nut-11 spending conditions

### DIFF
--- a/11.md
+++ b/11.md
@@ -82,6 +82,8 @@ Supported tags are:
 - `refund: <hex_str>` are additional public keys that can provide signatures after `locktime` (_allows multiple entries_)
 - `n_sigs_refund: <int>` specifies the minimum number of [Refund Multisig](#refund-multisig) public keys providing valid signatures after `locktime` expires
 
+Each of the above tags may appear exactly **ONCE** in a secret. If a tag appears more than once, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
+
 > [!NOTE]
 >
 > The tag serialization type is `[<str>, <str>, ...]` but some tag values are `int`. Wallets and mints must cast types appropriately for de/serialization.
@@ -96,6 +98,8 @@ Signature flags are defined in the tag `Secret.tags['sigflag']`. Currently, ther
 If any one input has the signature flag `SIG_ALL`, then all inputs are required to have the same kind, the flag `SIG_ALL` and the same `Secret.data` and `Secret.tags`, otherwise an error is returned.
 
 `SIG_INPUTS` is only enforced if no input is `SIG_ALL`.
+
+If a proof has any other signature flag value, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
 
 ### Signature flag `SIG_INPUTS`
 
@@ -252,6 +256,36 @@ The signature flag `sigflag` indicates that signatures are necessary on the `inp
   }
 ]
 ```
+
+## Public Key Canonicalisation
+
+A public key may appear in both the [Locktime Multisig](#locktime-multisig) and [Refund Multisig](#refund-multisig) pathways at the same time, but only **ONCE** in each pathway.
+
+Keys are compared using their lowercase form, with the `02` or `03` parity prefix ignored.
+
+Example: the following keys are considered duplicates:
+
+```
+02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904
+03698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904
+02698C4E2B5F9534CD0687D87513C759790CF829AA5739184A3E3735471FBDA904
+```
+
+Example: key duplicated in main pathway:
+
+```
+"data": "02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904",
+"pubkeys": "03698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904"
+```
+
+Example: key allowed in both pathways:
+
+```
+"data": "02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904",
+"refund": "03698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904"
+```
+
+If a pathway contains a duplicate key, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
 
 ## Use cases
 

--- a/11.md
+++ b/11.md
@@ -84,6 +84,8 @@ Supported tags are:
 
 Each of the above tags may appear exactly **ONCE** in a P2PK secret. If a tag appears more than once, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
 
+If `n_sigs` or `n_sigs_refund` is not a positive integer, or exceeds the total number of keys in its pathway, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
+
 > [!NOTE]
 >
 > The tag serialization type is `[<str>, <str>, ...]` but some tag values are `int`. Wallets and mints must cast types appropriately for de/serialization.
@@ -261,7 +263,7 @@ The signature flag `sigflag` indicates that signatures are necessary on the `inp
 
 Public keys **MUST** use the [compressed Secp256k1 public key format](https://learnmeabitcoin.com/technical/public-key#public-key-format).
 
-A public key may appear in both the [Locktime Multisig](#locktime-multisig) and [Refund Multisig](#refund-multisig) pathways at the same time, but only **ONCE** in each pathway.
+Each key **MUST** appear at most **ONCE** per [multi-signature](#Multisig) pathway. The same key **MAY** appear in both pathways.
 
 Keys are compared using their lowercase x-coordinate (`02` or `03` y-parity prefix ignored).
 
@@ -276,7 +278,7 @@ Example: the following keys are considered equivalent because they all have the 
 03698C4e2B5f9534cD0687d87513C759790cF829aa5739184a3e3735471fbda904 // 03 mixed case
 ```
 
-Example: key duplicated in main pathway:
+Example: key duplicated in main pathway (malformed):
 
 ```
 "data": "02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904",

--- a/11.md
+++ b/11.md
@@ -259,16 +259,21 @@ The signature flag `sigflag` indicates that signatures are necessary on the `inp
 
 ## Public Key Canonicalisation
 
+Public keys **MUST** use the [compressed Secp256k1 public key format](https://learnmeabitcoin.com/technical/public-key#public-key-format).
+
 A public key may appear in both the [Locktime Multisig](#locktime-multisig) and [Refund Multisig](#refund-multisig) pathways at the same time, but only **ONCE** in each pathway.
 
 Keys are compared using their lowercase form, with the `02` or `03` parity prefix ignored.
 
 Example: the following keys are considered duplicates:
 
-```
-02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904
-03698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904
-02698C4E2B5F9534CD0687D87513C759790CF829AA5739184A3E3735471FBDA904
+```json
+02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904 // 02 lowercase
+02698C4E2B5F9534CD0687D87513C759790CF829AA5739184A3E3735471FBDA904 // 02 uppercase
+02698C4e2B5f9534cD0687d87513C759790cF829aa5739184a3e3735471fbda904 // 02 mixed case
+03698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904 // 03 lowercase
+03698C4E2B5F9534CD0687D87513C759790CF829AA5739184A3E3735471FBDA904 // 03 uppercase
+03698C4e2B5f9534cD0687d87513C759790cF829aa5739184a3e3735471fbda904 // 03 mixed case
 ```
 
 Example: key duplicated in main pathway:

--- a/11.md
+++ b/11.md
@@ -82,9 +82,9 @@ Supported tags are:
 - `refund: <hex_str>` are additional public keys that can provide signatures after `locktime` (_allows multiple entries_)
 - `n_sigs_refund: <int>` specifies the minimum number of [Refund Multisig](#refund-multisig) public keys providing valid signatures after `locktime` expires
 
-Each of the above tags may appear exactly **ONCE** in a P2PK secret. If a tag appears more than once, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
+Each of the above tags may appear exactly **ONCE** in a P2PK secret. If a tag appears more than once, the P2PK secret is malformed and the Proof **MUST** be rejected as unspendable.
 
-If `n_sigs` or `n_sigs_refund` is not a positive integer, or exceeds the total number of keys in its pathway, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
+If `n_sigs` or `n_sigs_refund` is not a positive integer, or exceeds the total number of keys in its pathway, the P2PK secret is malformed and the Proof **MUST** be rejected as unspendable.
 
 > [!NOTE]
 >
@@ -101,7 +101,7 @@ If any one input has the signature flag `SIG_ALL`, then all inputs are required 
 
 `SIG_INPUTS` is only enforced if no input is `SIG_ALL`.
 
-If a P2PK secret has any other signature flag value, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
+If a P2PK secret has any other signature flag value, the P2PK secret is malformed and the Proof **MUST** be rejected as unspendable.
 
 ### Signature flag `SIG_INPUTS`
 
@@ -292,7 +292,7 @@ Example: key allowed in both pathways:
 "refund": "03698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904"
 ```
 
-If a pathway contains a duplicate key, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
+If a pathway contains a duplicate key, the P2PK secret is malformed and the Proof **MUST** be rejected as unspendable.
 
 ## Use cases
 

--- a/11.md
+++ b/11.md
@@ -82,7 +82,7 @@ Supported tags are:
 - `refund: <hex_str>` are additional public keys that can provide signatures after `locktime` (_allows multiple entries_)
 - `n_sigs_refund: <int>` specifies the minimum number of [Refund Multisig](#refund-multisig) public keys providing valid signatures after `locktime` expires
 
-Each of the above tags may appear exactly **ONCE** in a secret. If a tag appears more than once, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
+Each of the above tags may appear exactly **ONCE** in a P2PK secret. If a tag appears more than once, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
 
 > [!NOTE]
 >
@@ -99,7 +99,7 @@ If any one input has the signature flag `SIG_ALL`, then all inputs are required 
 
 `SIG_INPUTS` is only enforced if no input is `SIG_ALL`.
 
-If a proof has any other signature flag value, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
+If a P2PK secret has any other signature flag value, the P2PK secret is malformed and the Proof **MUST** be rejected as invalid.
 
 ### Signature flag `SIG_INPUTS`
 
@@ -263,9 +263,9 @@ Public keys **MUST** use the [compressed Secp256k1 public key format](https://le
 
 A public key may appear in both the [Locktime Multisig](#locktime-multisig) and [Refund Multisig](#refund-multisig) pathways at the same time, but only **ONCE** in each pathway.
 
-Keys are compared using their lowercase form, with the `02` or `03` parity prefix ignored.
+Keys are compared using their lowercase x-coordinate (`02` or `03` y-parity prefix ignored).
 
-Example: the following keys are considered duplicates:
+Example: the following keys are considered equivalent because they all have the same lowercase x-coordinate, so can all be Schnorr signed using the same secret key:
 
 ```json
 02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904 // 02 lowercase


### PR DESCRIPTION
This PR removes ambiguity by tightening the spending conditions to specifically reject malformed P2PK secrets.

- Nutshell: https://github.com/cashubtc/nutshell/pull/969
- CDK: https://github.com/cashubtc/cdk/pull/1880
- Cashu-TS: https://github.com/cashubtc/cashu-ts/pull/578