### PR TITLE
nut10: Add witness section and warning

### DIFF
--- a/10.md
+++ b/10.md
@@ -73,7 +73,7 @@ Signatures or other witness data are provided in the `Proof.witness` as a serial
 
 > [!IMPORTANT]
 > `Proof.witness` is only expected for proofs containing a NUT-10 Well-known Secret.
-> A mint MAY reject a Proof containing a witness field if its secret is not NUT-10 compliant
+> A mint MAY reject a Proof containing a witness field if its secret cannot be parsed as a [Well-known Secret](#well-known-secret)).
 
 ## Examples
 

--- a/10.md
+++ b/10.md
@@ -67,6 +67,14 @@ Each individual tag is an array of **ONE or more strings**. The first element of
 `["locktime", 1765300829]` - a tag must contain **strings** only\
 `["locktime", ""]` - a tag must contain **non-empty strings** only
 
+## Witness
+
+Signatures or other witness data are provided in the `Proof.witness` as a serialized JSON string of the witness object for the NUT-10 kind.
+
+> [!IMPORTANT]
+> `Proof.witness` is only expected for proofs containing a NUT-10 Well-known Secret.
+> A mint MAY reject a Proof containing a witness field if its secret is not NUT-10 compliant
+
 ## Examples
 
 Example use cases of this secret format are


### PR DESCRIPTION
Mints currently treat Proofs with a witness field but a plain (non-NUT-10) secret differently.

Nutshell rejects, CDK ignores the witness.

This PR codifies this behavior with a warning.