### PR TITLE
feat: add NUT-29 batch minting error codes

### DIFF
--- a/29.md
+++ b/29.md
@@ -180,7 +180,7 @@ Content-Type: application/json
 The mint MUST validate the following before processing a batch mint request:
 
 1. **Non-empty batch**: The `quotes` array MUST NOT be empty
-2. **Unique quotes**: All quote IDs in the `quotes` array MUST be unique (no duplicates)
+2. **Unique quotes**: All quote IDs in the `quotes` array MUST be unique (no duplicates) — error code `11016`
 3. **Valid quote IDs**: All quote IDs MUST exist in the mint's database
 4. **Payment method consistency**: All quotes MUST have the same payment method, matching `{method}` in the URL path
 5. **Currency unit consistency**: All quotes MUST use the same currency unit
@@ -268,7 +268,7 @@ Mints MAY advertise a maximum batch size through the [NUT-06][06] mint info endp
 
 Fields:
 
-- `max_batch_size` (optional): Maximum number of quotes allowed in a single batch request. If omitted, the batch size limit is implementation-defined and clients MUST handle `BATCH_SIZE_EXCEEDED` errors gracefully.
+- `max_batch_size` (optional): Maximum number of quotes allowed in a single batch request. If omitted, the batch size limit is implementation-defined and clients MUST handle error code `11017` gracefully.
 - `methods` (optional): Array of payment methods supported for batch minting. If omitted, all methods supported by the mint (per NUT-04) are available for batching.
 
 [00]: 00.md

--- a/29.md
+++ b/29.md
@@ -180,7 +180,7 @@ Content-Type: application/json
 The mint MUST validate the following before processing a batch mint request:
 
 1. **Non-empty batch**: The `quotes` array MUST NOT be empty
-2. **Unique quotes**: All quote IDs in the `quotes` array MUST be unique (no duplicates)
+2. **Unique quotes**: All quote IDs in the `quotes` array MUST be unique (no duplicates) — error code `11016`
 3. **Valid quote IDs**: All quote IDs MUST exist in the mint's database
 4. **Payment method consistency**: All quotes MUST have the same payment method, matching `{method}` in the URL path
 5. **Currency unit consistency**: All quotes MUST use the same currency unit
@@ -268,7 +268,7 @@ Mints MAY advertise a maximum batch size through the [NUT-06][06] mint info endp
 
 Fields:
 
-- `max_batch_size` (optional): Maximum number of quotes allowed in a single batch request. If omitted, the batch size limit is implementation-defined and clients MUST handle `BATCH_SIZE_EXCEEDED` errors gracefully.
+- `max_batch_size` (optional): Maximum number of quotes allowed in a single batch request. If omitted, the batch size limit is implementation-defined and clients MUST handle `BATCH_SIZE_EXCEEDED` (error code `11017`) errors gracefully.
 - `methods` (optional): Array of payment methods supported for batch minting. If omitted, all methods supported by the mint (per NUT-04) are available for batching.
 
 [00]: 00.md

--- a/29.md
+++ b/29.md
@@ -268,7 +268,7 @@ Mints MAY advertise a maximum batch size through the [NUT-06][06] mint info endp
 
 Fields:
 
-- `max_batch_size` (optional): Maximum number of quotes allowed in a single batch request. If omitted, the batch size limit is implementation-defined and clients MUST handle `BATCH_SIZE_EXCEEDED` (error code `11017`) errors gracefully.
+- `max_batch_size` (optional): Maximum number of quotes allowed in a single batch request. If omitted, the batch size limit is implementation-defined and clients MUST handle error code `11017` gracefully.
 - `methods` (optional): Array of payment methods supported for batch minting. If omitted, all methods supported by the mint (per NUT-04) are available for batching.
 
 [00]: 00.md

--- a/error_codes.md
+++ b/error_codes.md
@@ -18,6 +18,8 @@
 | 11013 | Unit in request is not supported                | [NUT-04][04], [NUT-05][05]               |
 | 11014 | Max inputs exceeded                             | [NUT-03][03], [NUT-05][05]               |
 | 11015 | Max outputs exceeded                            | [NUT-03][03], [NUT-04][04], [NUT-05][05] |
+| 11016 | Duplicate quote IDs provided                    | [NUT-29][29]                             |
+| 11017 | Max batch size exceeded                         | [NUT-29][29]                             |
 | 12001 | Keyset is not known                             | [NUT-02][02], [NUT-04][04]               |
 | 12002 | Keyset is inactive, cannot sign messages        | [NUT-02][02], [NUT-03][03], [NUT-04][04] |
 | 20001 | Quote request is not paid                       | [NUT-04][04]                             |

--- a/tests/29-tests.md
+++ b/tests/29-tests.md
@@ -83,7 +83,7 @@ The following is an invalid batch mint request with duplicate quote IDs.
 
 Expected behavior:
 
-- The mint rejects the request because quote IDs must be unique.
+- The mint rejects the request because quote IDs must be unique (error code `11016`).
 - No outputs are signed.
 
 ## Batch mint rejects mixed payment methods


### PR DESCRIPTION
## Summary

Adds two error codes for NUT-29 batch minting validation failures that have no existing coverage.

`11016 Duplicate quote IDs provided`: quote IDs are a distinct entity from proof inputs (11007) and blinded outputs (11008). The NUT-29 spec explicitly mandates uniqueness in validation rule 2 and `29-tests.md` has a test vector for this failure path.

`11017 Max batch size exceeded`: covers the max_batch_size enforcement path. Same family as `11014 (max inputs)` and `11015 (max outputs)`.  Identified as missing during CTS NUT-29 implementation.

Both codes follow the 110xx structural validation family numbering.

- [ ] cdk: https://github.com/cashubtc/cdk/pull/1944
- [ ] nutshell: 

## Changes

- Updates `29.md` validation rules and batch size section to reference the new codes. 
- Updates `29-tests.md`with expected error code for the duplicate quotes test vector.