### PR TITLE
feat(nut04/05): add method_name to [Mint|Melt]MethodSetting

### DIFF
--- a/04.md
+++ b/04.md
@@ -140,7 +140,7 @@ The settings for this NUT indicate the supported method-unit pairs for minting. 
 }
 ```
 
-`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs. `method_name` is a human-readable name for the method.
+`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs. `method_name` is a human-readable name for the payment method.
 
 ## Unblinding Signatures
 

--- a/04.md
+++ b/04.md
@@ -133,13 +133,14 @@ The settings for this NUT indicate the supported method-unit pairs for minting. 
 {
   "method": <str>,
   "unit": <str>,
+  "method_name": <str|null>,
   "min_amount": <int|null>,
   "max_amount": <int|null>,
   "options": <Object|null>
 }
 ```
 
-`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs.
+`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs. `method_name` is a human-readable name for the method.
 
 ## Unblinding Signatures
 

--- a/04.md
+++ b/04.md
@@ -140,7 +140,9 @@ The settings for this NUT indicate the supported method-unit pairs for minting. 
 }
 ```
 
-`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs. `method_name` is a human-readable name for the payment method.
+`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs.
+
+`method_name` is a human-readable name for the payment method. If `null` or omitted, it is derived from `method` by replacing `_` and `-` with spaces and title-casing each word (e.g. `bolt11` -> `Bolt11`, `apple-pay` -> `Apple Pay`).
 
 ## Unblinding Signatures
 

--- a/04.md
+++ b/04.md
@@ -30,7 +30,7 @@ The minting process follows these steps for all payment methods:
 
 ### Requesting a Mint Quote
 
-To request a mint quote, the wallet of `Alice` makes a `POST /v1/mint/quote/{method}` request where `method` is the payment method requested (e.g., `bolt11`, `bolt12`, etc.).
+To request a mint quote, the wallet of `Alice` makes a `POST /v1/mint/quote/{method}` request where `method` is the payment method requested (e.g., `bolt11`, `bolt12`, etc.). `method` **MUST** match `[a-z0-9_-]+`.
 
 ```http
 POST https://mint.host:3338/v1/mint/quote/{method}

--- a/04.md
+++ b/04.md
@@ -142,7 +142,7 @@ The settings for this NUT indicate the supported method-unit pairs for minting. 
 
 `min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs.
 
-`method_name` is a human-readable name for the payment method. If `null` or omitted, it is derived from `method` by replacing `_` and `-` with spaces and title-casing each word (e.g. `bolt11` -> `Bolt11`, `apple-pay` -> `Apple Pay`).
+`method_name` is a human-readable name for the payment method. If `null` or omitted, wallets **SHOULD** derive it from `method` by replacing `_` and `-` with spaces and title-casing each word (e.g. `bolt11` -> `Bolt11`, `apple-pay` -> `Apple Pay`).
 
 ## Unblinding Signatures
 

--- a/05.md
+++ b/05.md
@@ -245,7 +245,7 @@ The mint's settings for this NUT indicate the supported method-unit pairs for me
 
 `min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs.
 
-`method_name` is a human-readable name for the payment method. If `null` or omitted, it is derived from `method` by replacing `_` and `-` with spaces and title-casing each word (e.g. `bolt11` -> `Bolt11`, `apple-pay` -> `Apple Pay`).
+`method_name` is a human-readable name for the payment method. If `null` or omitted, wallets **SHOULD** derive it from `method` by replacing `_` and `-` with spaces and title-casing each word (e.g. `bolt11` -> `Bolt11`, `apple-pay` -> `Apple Pay`).
 
 [00]: 00.md
 [01]: 01.md

--- a/05.md
+++ b/05.md
@@ -35,7 +35,7 @@ The melting process follows these steps for all payment methods:
 
 ### Requesting a Melt Quote
 
-To request a melt quote, the wallet of `Alice` makes a `POST /v1/melt/quote/{method}` request where `method` is the payment method requested (e.g., `bolt11`, `bolt12`, etc.).
+To request a melt quote, the wallet of `Alice` makes a `POST /v1/melt/quote/{method}` request where `method` is the payment method requested (e.g., `bolt11`, `bolt12`, etc.). `method` **MUST** match `[a-z0-9_-]+`.
 
 ```http
 POST https://mint.host:3338/v1/melt/quote/{method}

--- a/05.md
+++ b/05.md
@@ -236,13 +236,14 @@ The mint's settings for this NUT indicate the supported method-unit pairs for me
 {
   "method": <str>,
   "unit": <str>,
+  "method_name": <str|null>,
   "min_amount": <int|null>,
   "max_amount": <int|null>,
   "options": <Object|null>
 }
 ```
 
-`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs.
+`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs. `method_name` is a human-readable name for the method.
 
 [00]: 00.md
 [01]: 01.md

--- a/05.md
+++ b/05.md
@@ -243,7 +243,7 @@ The mint's settings for this NUT indicate the supported method-unit pairs for me
 }
 ```
 
-`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs. `method_name` is a human-readable name for the method.
+`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs. `method_name` is a human-readable name for the payment method.
 
 [00]: 00.md
 [01]: 01.md

--- a/05.md
+++ b/05.md
@@ -243,7 +243,9 @@ The mint's settings for this NUT indicate the supported method-unit pairs for me
 }
 ```
 
-`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs. `method_name` is a human-readable name for the payment method.
+`min_amount` and `max_amount` indicate the minimum and maximum amount for an operation of this method-unit pair. `options` are method-specific and can be defined in method-specific NUTs.
+
+`method_name` is a human-readable name for the payment method. If `null` or omitted, it is derived from `method` by replacing `_` and `-` with spaces and title-casing each word (e.g. `bolt11` -> `Bolt11`, `apple-pay` -> `Apple Pay`).
 
 [00]: 00.md
 [01]: 01.md


### PR DESCRIPTION
- [x] Cashu-TS - https://github.com/cashubtc/cashu-ts/pull/672 and https://github.com/cashubtc/cashu-ts/pull/707
- [x] CDK - https://github.com/cashubtc/cdk/pull/2120
- [ ] Nutshell - https://github.com/cashubtc/nutshell/pull/1063

This PR adds an optional `method_name` param to the NUT-04 `MintMethodSetting`, and NUT-05 `MeltMethodSetting`.

The motivation is to make it easy for wallets to support custom payment methods in their UI.

## 