### PR TITLE
feat: preferred mints

### DIFF
--- a/18.md
+++ b/18.md
@@ -24,6 +24,7 @@ A Payment Request is defined as follows
   "u": str <optional>,
   "s": bool <optional>,
   "m": Array[str] <optional>,
+  "ms": bool <optional>,
   "d": str <optional>,
   "t": Array[Transport] <optional>,
   "nut10": NUT10Option <optional>,
@@ -37,9 +38,14 @@ Here, the fields are
 - `u`: The unit of the requested payment (MUST be set if `a` is set)
 - `s`: Whether the payment request is for single use
 - `m`: A set of mints from which the payment is requested
+- `ms`: A flag indicating whether the mint list is strict; defaults to `true`
 - `d`: A human readable description that the sending wallet will display after scanning the request
 - `t`: The method of `Transport` chosen to transmit the payment (can be multiple, sorted by preference)
 - `nut10`: The required [NUT-10][10] locking condition
+
+## Mint list
+
+A Payment Request containing a mint list `m` describes the mints it accepts payments from. If `ms` is not present, or is `true`, the recipient **MUST** reject payments from mints not in the list. If `ms` is set to `false`, the list is just a suggestion for the payer.
 
 ## Locking conditions
 

--- a/26.md
+++ b/26.md
@@ -33,16 +33,16 @@ The payment request is encoded as a sequence of TLV fields. Each TLV entry consi
 
 ### Top-Level TLV Tags
 
-| Tag  | Field       | Type      | Description                                                          |
-| ---- | ----------- | --------- | -------------------------------------------------------------------- |
-| 0x01 | id          | string    | Payment identifier (corresponds to `i` in JSON)                      |
-| 0x02 | amount      | u64       | Amount in base units (corresponds to `a` in JSON)                    |
-| 0x03 | unit        | u8/string | Currency unit (corresponds to `u` in JSON)                           |
-| 0x04 | single_use  | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)        |
-| 0x05 | mint        | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON) |
-| 0x06 | description | string    | Human-readable description (corresponds to `d` in JSON)              |
-| 0x07 | transport   | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)     |
-| 0x08 | nut10       | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)          |
+| Tag  | Field       | Type      | Description                                                                                    |
+| ---- | ----------- | --------- | ---------------------------------------------------------------------------------------------- |
+| 0x01 | id          | string    | Payment identifier (corresponds to `i` in JSON)                                                |
+| 0x02 | amount      | u64       | Amount in base units (corresponds to `a` in JSON)                                              |
+| 0x03 | unit        | u8/string | Currency unit (corresponds to `u` in JSON)                                                     |
+| 0x04 | single_use  | u8        | Single-use flag: 0=false, 1=true (corresponds to `s` in JSON)                                  |
+| 0x05 | mint        | string    | Mint URL (repeatable for multiple mints, corresponds to `m` in JSON)                           |
+| 0x06 | description | string    | Human-readable description (corresponds to `d` in JSON)                                        |
+| 0x07 | transport   | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)                               |
+| 0x08 | nut10       | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)                                    |
 | 0x09 | mint_strict | u8        | Mint list strict flag: 0=false, 1=true; if absent, defaults to 1 (corresponds to `ms` in JSON) |
 
 All fields are optional. Unknown tags MUST be ignored to maintain forward compatibility.

--- a/26.md
+++ b/26.md
@@ -43,6 +43,7 @@ The payment request is encoded as a sequence of TLV fields. Each TLV entry consi
 | 0x06 | description | string    | Human-readable description (corresponds to `d` in JSON)              |
 | 0x07 | transport   | sub-TLV   | Transport configuration (repeatable, corresponds to `t` in JSON)     |
 | 0x08 | nut10       | sub-TLV   | NUT-10 spending conditions (corresponds to `nut10` in JSON)          |
+| 0x09 | mint_strict | u8        | Mint list strict flag: 0=false, 1=true; if absent, defaults to 1 (corresponds to `ms` in JSON) |
 
 All fields are optional. Unknown tags MUST be ignored to maintain forward compatibility.
 


### PR DESCRIPTION
Add ms (mint strict) field to NUT-18 Payment Requests

Adds a new optional ms boolean field to the Payment Request that controls whether the mint list m is treated as a strict requirement or a suggestion for the payer.

When ms is absent or true (default), the recipient MUST reject payments from mints not in the list. When ms is false, the mint list serves only as a hint to the payer.

This allows receivers to either enforce specific mints or merely express a preference while still accepting payments from any mint.

Implementations
- [x] cashu-ts: https://github.com/cashubtc/cashu-ts/pull/683
- [x] cdk: https://github.com/cashubtc/cdk/pull/2007
- [x] dotnut:  https://github.com/Kukks/DotNut/pull/37