### PR TITLE
nut24(402 payments): explicitly allow creqB payment requests

### DIFF
--- a/24.md
+++ b/24.md
@@ -4,7 +4,7 @@
 
 `uses: NUT-12`
 
-`depends on: NUT-18`
+`depends on: NUT-18, NUT-26`
 
 ---
 
@@ -12,7 +12,9 @@ This NUT describes how Cashu tokens can be used with HTTP 402 Payment Required r
 
 ### Server response
 
-HTTP servers may respond with the HTTP status code 402 with a `X-Cashu` header containing an [encoded][18-encoding] NUT-18 [payment request][18] with the following fields:
+HTTP servers may respond with the HTTP status code 402 and an `X-Cashu` header containing a payment request, encoded in either [NUT-18][18] `creqA` or [NUT-26][26] `creqB` formats. Wallets **MUST** support both formats.
+
+The decoded payment request has the following fields:
 
 ```
 {
@@ -28,7 +30,7 @@ HTTP servers may respond with the HTTP status code 402 with a `X-Cashu` header c
 - `m`: Array of mint URLs that the server accepts tokens from
 - `nut10`: The required [NUT-10][10] locking condition
 
-Note that there is no transport field since we expect an in-band payment.
+Note: there is no transport field since we expect an in-band payment.
 
 ### Client payment
 
@@ -43,4 +45,4 @@ If the server receives tokens from a mint that is not in the `mints` array, an i
 [10]: 10.md
 [12]: 12.md
 [18]: 18.md
-[18-encoding]: 18.md#encoded-request
+[26]: 26.md


### PR DESCRIPTION
# Fixes #392 

Explicitly permits NUT-26 (bech32) encoded payment requests in NUT-24 (402 Payments)