### PR TITLE
NUT-27: fix nostr pubkey

### DIFF
--- a/27.md
+++ b/27.md
@@ -74,7 +74,7 @@ The mint backup uses Nostr event kind `30078` (addressable event) as specified i
   - `d` tag with value `"mint-list"` (addressable event identifier)
   - `client` tag with the client name (optional but recommended)
 - `created_at`: Unix timestamp of the backup creation
-- `pubkey`: The derived public key for mint backup
+- `pubkey`: The derived public key for mint backup (x-only, 32-byte hex)
 
 ### Backup Data Format
 
@@ -130,7 +130,7 @@ Note: The same private and public key pair is used for both sides of the convers
     ["client", "cashu.me"]
   ],
   "created_at": 1703721600,
-  "pubkey": "02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea",
+  "pubkey": "bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea",
   "sig": "..."
 }
 ```


### PR DESCRIPTION
Nostr public keys are 32-byte, x-only (64 hex characters). This PR fixes the example and notes the requirement, which is different to the usual Cashu pubkey format.