### PR TITLE
docs(nut14): clarify pubkey-less HTLC spends on preimage alone

### DIFF
--- a/14.md
+++ b/14.md
@@ -62,6 +62,8 @@ The receiver(s) listed in the `pubkeys` tag can spend the proof by providing **B
 
 This pathway is **ALWAYS** available to the receivers, as possession of the preimage confirms performance of the Sender's wishes.
 
+**NOTE:** If the `pubkeys` tag is absent, the preimage alone spends the proof; no signature is required.
+
 ### Sender Pathway (timelocked refund)
 
 The sender(s) listed in the `refund` tag can spend the proof once the `locktime` lock has "expired" by providing signature(s) as per the [NUT-11][11] rules for **Refund MultiSig**.


### PR DESCRIPTION
## Summary

Clarifies that an HTLC with no `pubkeys` tag is spendable by the preimage alone, with no signature required.

The Receiver Pathway currently says the receiver provides **BOTH** the preimage **and** a Locktime MultiSig signature, which reads as if a `pubkeys` tag is mandatory. But an HTLC locks to a hashlock in `Secret.data` (not a pubkey), so the `pubkeys` tag is optional — when it is absent there are no keys to sign and the preimage alone should spend the proof.

This adds a one-line `**NOTE:**` to the Receiver Pathway, mirroring the existing note on the Sender Pathway that covers the absent-`refund`/`locktime` cases.

## Motivation

The absent-`pubkeys` case is currently undefined, so implementations diverge: the reference implementation (CDK) treats an empty pubkey list as a zero-signature receiver pathway and spends on the preimage alone, which is the behaviour this note documents.