### PR TITLE
format: remove inline comments, they are in where section

### DIFF
--- a/20.md
+++ b/20.md
@@ -107,15 +107,16 @@ Response of `Bob`:
 To authenticate a mint request, the signer commits to the quote ID and all `BlindedMessages` (the outputs, see [NUT-00][00]) of the `PostMintBolt11Request`, in the order they appear in the request. The message is built over raw bytes:
 
 ```
-msg_to_sign = "Cashu_MintQuoteSig_v1"                 // domain-separation tag (ASCII, not length-prefixed)
-              || len32(quote) || quote                // quote = UTF-8 quote id
+msg_to_sign = b"Cashu_MintQuoteSig_v1"
+              || len32(quote) || quote
               || for each output i (in request order):
-                   len32(amount_i) || amount_i        // amount = canonical minimal big-endian
-                   || len32(B_i)     || B_i           // B_ = raw compressed point bytes
+                   len32(amount_i) || amount_i
+                   || len32(B_i)   || B_i
 ```
 
 Where:
 
+- `b"Cashu_MintQuoteSig_v1"` is the domain-separation tag as raw ASCII bytes, not length-prefixed.
 - `||` denotes byte concatenation and `len32(x)` is the 32-bit (4-byte) big-endian length of the byte array `x` in bytes.
 - `quote` is the UTF-8 quote id from the `PostMintQuoteBolt11Response`.
 - `amount_i` is the output amount as canonical minimal big-endian bytes (e.g. `0` → empty byte array, `1` → `0x01`, `256` → `0x0100`); thus `len32(amount_i)` is its length in bytes as a 32-bit integer (e.g. `0` for amount `0`, `1` for amount `1`, `2` for amount `256`).

--- a/29.md
+++ b/29.md
@@ -226,15 +226,16 @@ Each locked quote is signed independently exactly as in [NUT-20][20]: `signature
 Following the [NUT-20 message aggregation][20-msg-agg] pattern, the signature message for `quotes[i]` is computed as:
 
 ```
-msg_to_sign = "Cashu_MintQuoteSig_v1"                 // domain-separation tag (ASCII, not length-prefixed)
-              || len32(quotes[i]) || quotes[i]        // quotes[i] = UTF-8 quote id at index i
+msg_to_sign = b"Cashu_MintQuoteSig_v1"
+              || len32(quotes[i]) || quotes[i]
               || for each output j (in request order):
-                   len32(amount_j) || amount_j        // amount_j = canonical minimal big-endian
-                   || len32(B_j)     || B_j           // B_j = raw compressed point bytes
+                   len32(amount_j) || amount_j
+                   || len32(B_j)   || B_j
 ```
 
 Where:
 
+- `b"Cashu_MintQuoteSig_v1"` is the domain-separation tag as raw ASCII bytes, not length-prefixed.
 - `quotes[i]` is the UTF-8 encoded quote ID from the request's `quotes` array at index `i`
 - `outputs` are **all blinded messages** from the request's `outputs` array (regardless of which quote they correspond to)
 - `||` denotes byte concatenation and `len32(x)` is the 32-bit (4-byte) big-endian length of the following data `x`.


### PR DESCRIPTION
This is the minor nit tweak I was going to add to #375 

Reason - the "where" block handles the definitions, so the formula itself doesn't need the inline comments