### PR TITLE
format: add amount_j and B_j definitions to NUT-29 where section

### DIFF
--- a/29.md
+++ b/29.md
@@ -238,6 +238,8 @@ Where:
 - `b"Cashu_MintQuoteSig_v1"` is the domain-separation tag as raw ASCII bytes, not length-prefixed.
 - `quotes[i]` is the UTF-8 encoded quote ID from the request's `quotes` array at index `i`
 - `outputs` are **all blinded messages** from the request's `outputs` array (regardless of which quote they correspond to)
+- `amount_j` is the output amount as canonical minimal big-endian bytes (e.g. `0` → empty byte array, `1` → `0x01`, `256` → `0x0100`); thus `len32(amount_j)` is its length in bytes as a 32-bit integer (e.g. `0` for amount `0`, `1` for amount `1`, `2` for amount `256`).
+- `B_j` is the raw byte representation of the blinded message (e.g. 33-byte compressed secp256k1 or 48-byte BLS12-381 point), decoded from the request's hex string.
 - `||` denotes byte concatenation and `len32(x)` is the 32-bit (4-byte) big-endian length of the following data `x`.
 
 ### Signature Validation Failure


### PR DESCRIPTION
Follow-up to #399, which merged before this was pushed.

Reason - NUT-29's formula uses `amount_j` and `B_j` but its where section didn't define them, so this copies the definitions over from NUT-20