### PR TITLE
NUT-29: use valid curve points in the batch mint example

### DIFF
--- a/29.md
+++ b/29.md
@@ -161,12 +161,12 @@ Content-Type: application/json
     {
       "amount": 4,
       "id": "009a1f293253e41e",
-      "B_": "03b85be0c0a9f51056375b632a2f2c8149831b9827fad677be9807455e7d84b584"
+      "B_": "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
     },
     {
       "amount": 2,
       "id": "009a1f293253e41e",
-      "B_": "0276bbcf69e1b1238e6d39fc14c84e7cdfd519fee07f3369d2b2b23045390e2efc"
+      "B_": "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
     }
   ]
 }


### PR DESCRIPTION
Two output `B_` values in the batch mint request example are not valid secp256k1 points, so implementations that validate points on parse (e.g. cdk) would reject the example verbatim. Replaces them with the compressed points for the well-known test keys `02` and `03`.

Found while pinning the vectors for https://github.com/cashubtc/nuts/pull/404.