### PR TITLE
NUT-03/05: state unit consistency normatively

### DIFF
--- a/03.md
+++ b/03.md
@@ -37,6 +37,8 @@ With the data being of the form `PostSwapRequest`:
 }
 ```
 
+All `inputs` and `outputs` of a swap **MUST** be of the same currency unit. The mint **MUST** reject a swap that mixes units (see [Error Codes][errors] `11009` and `11010`).
+
 With curl:
 
 ```bash
@@ -89,3 +91,4 @@ If successful, `Bob` will respond with a `PostSwapResponse`
 [10]: 10.md
 [11]: 11.md
 [12]: 12.md
+[errors]: error_codes.md

--- a/05.md
+++ b/05.md
@@ -104,6 +104,8 @@ The wallet includes the following common data in its request:
 
 where `quote` is the melt quote ID, `inputs` are the proofs with a total amount sufficient to cover the requested amount plus any fees, and `prefer_async` requests asynchronous processing when set to `true`.
 
+The `inputs`, and any [NUT-08][08] change `outputs`, **MUST** be of the unit of the melt quote. The mint **MUST** reject a melt that mixes units (see [Error Codes][errors] `11009` and `11010`).
+
 #### Synchronous Processing
 
 > [!IMPORTANT]
@@ -265,3 +267,4 @@ The mint's settings for this NUT indicate the supported method-unit pairs for me
 [23]: 23.md
 [25]: 25.md
 [30]: 30.md
+[errors]: error_codes.md


### PR DESCRIPTION
Error codes `11009`/`11010` (inputs/outputs of multiple units, inputs and outputs not of same unit) already imply that a transaction cannot mix currency units, and both nutshell and cdk enforce it, but neither NUT-03 nor NUT-05 states the rule in prose. This adds one normative sentence to each.

Surfaced by https://github.com/cashubtc/nuts/pull/404, where the reasoning for not committing to the output keyset `id` relies on this invariant.