### PR TITLE
NUT-Exchange: Atomic Multi-Asset Exchange

### DIFF
--- a/error_codes.md
+++ b/error_codes.md
@@ -1,52 +1,52 @@
 # NUT Errors
 
-| Code  | Description                                     | Relevant nuts                                          |
-| ----- | ----------------------------------------------- | ------------------------------------------------------ |
-| 10001 | Proof verification failed                       | [NUT-03][03], [NUT-05][05]                             |
-| 11001 | Proofs already spent                            | [NUT-03][03], [NUT-05][05]                             |
-| 11002 | Proofs are pending                              | [NUT-03][03], [NUT-05][05]                             |
-| 11003 | Outputs already signed                          | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11004 | Outputs are pending                             | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11005 | Transaction is not balanced (inputs != outputs) | [NUT-02][02], [NUT-03][03], [NUT-05][05]               |
-| 11006 | Amount outside of limit range                   | [NUT-04][04], [NUT-05][05]                             |
-| 11007 | Duplicate inputs provided                       | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11008 | Duplicate outputs provided                      | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11009 | Inputs/Outputs of multiple units                | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11010 | Inputs and outputs not of same unit             | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11011 | Amountless invoice is not supported             | [NUT-05][05]                                           |
-| 11012 | Amount in request does not equal invoice        | [NUT-05][05]                                           |
-| 11013 | Unit in request is not supported                | [NUT-04][04], [NUT-05][05]                             |
-| 11014 | Max inputs exceeded                             | [NUT-03][03], [NUT-05][05]                             |
-| 11015 | Max outputs exceeded                            | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11016 | Duplicate quote IDs provided                    | [NUT-29][29]                                           |
-| 11017 | Max batch size exceeded                         | [NUT-29][29]                                           |
-| 12001 | Keyset is not known                             | [NUT-02][02], [NUT-04][04]                             |
-| 12002 | Keyset is inactive, cannot sign messages        | [NUT-02][02], [NUT-03][03], [NUT-04][04]               |
-| 12003 | Keyset has expired                              | [NUT-02][02], [NUT-03][03], [NUT-04][04], [NUT-05][05] |
-| 20001 | Quote request is not paid                       | [NUT-04][04]                                           |
-| 20002 | Quote has already been issued                   | [NUT-04][04]                                           |
-| 20003 | Minting is disabled                             | [NUT-04][04]                                           |
-| 20004 | Lightning payment failed                        | [NUT-05][05]                                           |
-| 20005 | Quote is pending                                | [NUT-04][04], [NUT-05][05], [NUT-29][29]               |
-| 20006 | Invoice already paid                            | [NUT-05][05]                                           |
-| 20007 | Quote is expired                                | [NUT-04][04], [NUT-05][05]                             |
-| 20008 | Signature for mint request invalid              | [NUT-20][20]                                           |
-| 20009 | Pubkey required for mint quote                  | [NUT-20][20]                                           |
-| 30001 | Endpoint requires clear auth                    | [NUT-21][21]                                           |
-| 30002 | Clear authentication failed                     | [NUT-21][21]                                           |
-| 31001 | Endpoint requires blind auth                    | [NUT-22][22]                                           |
-| 31002 | Blind authentication failed                     | [NUT-22][22]                                           |
-| 31003 | Maximum BAT mint amount exceeded                | [NUT-22][22]                                           |
-| 31004 | BAT mint rate limit exceeded                    | [NUT-22][22]                                           |
-| 15001 | Unsupported or malformed `PAY_TO_UNLOCK` condition      | [NUT-Exchange][exchange] |
-| 15002 | `swap_id` mismatch across participants                   | [NUT-Exchange][exchange] |
-| 15003 | Receive-output commitment (`H_recv`) mismatch            | [NUT-Exchange][exchange] |
-| 15004 | Offer/receive keyset relationship violated               | [NUT-Exchange][exchange] |
-| 15005 | Exchange settlement submitted after `expiry`             | [NUT-Exchange][exchange] |
-| 15006 | Refund submitted before `expiry`                         | [NUT-Exchange][exchange] |
-| 15007 | Refund signature missing or invalid                      | [NUT-Exchange][exchange] |
-| 15009 | Exchange request exceeds advertised limits               | [NUT-Exchange][exchange] |
-| 15010 | Conflicting request for `swap_id` or input (idempotency) | [NUT-Exchange][exchange] |
+| Code  | Description                                              | Relevant nuts                                          |
+| ----- | -------------------------------------------------------- | ------------------------------------------------------ |
+| 10001 | Proof verification failed                                | [NUT-03][03], [NUT-05][05]                             |
+| 11001 | Proofs already spent                                     | [NUT-03][03], [NUT-05][05]                             |
+| 11002 | Proofs are pending                                       | [NUT-03][03], [NUT-05][05]                             |
+| 11003 | Outputs already signed                                   | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11004 | Outputs are pending                                      | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11005 | Transaction is not balanced (inputs != outputs)          | [NUT-02][02], [NUT-03][03], [NUT-05][05]               |
+| 11006 | Amount outside of limit range                            | [NUT-04][04], [NUT-05][05]                             |
+| 11007 | Duplicate inputs provided                                | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11008 | Duplicate outputs provided                               | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11009 | Inputs/Outputs of multiple units                         | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11010 | Inputs and outputs not of same unit                      | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11011 | Amountless invoice is not supported                      | [NUT-05][05]                                           |
+| 11012 | Amount in request does not equal invoice                 | [NUT-05][05]                                           |
+| 11013 | Unit in request is not supported                         | [NUT-04][04], [NUT-05][05]                             |
+| 11014 | Max inputs exceeded                                      | [NUT-03][03], [NUT-05][05]                             |
+| 11015 | Max outputs exceeded                                     | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11016 | Duplicate quote IDs provided                             | [NUT-29][29]                                           |
+| 11017 | Max batch size exceeded                                  | [NUT-29][29]                                           |
+| 12001 | Keyset is not known                                      | [NUT-02][02], [NUT-04][04]                             |
+| 12002 | Keyset is inactive, cannot sign messages                 | [NUT-02][02], [NUT-03][03], [NUT-04][04]               |
+| 12003 | Keyset has expired                                       | [NUT-02][02], [NUT-03][03], [NUT-04][04], [NUT-05][05] |
+| 20001 | Quote request is not paid                                | [NUT-04][04]                                           |
+| 20002 | Quote has already been issued                            | [NUT-04][04]                                           |
+| 20003 | Minting is disabled                                      | [NUT-04][04]                                           |
+| 20004 | Lightning payment failed                                 | [NUT-05][05]                                           |
+| 20005 | Quote is pending                                         | [NUT-04][04], [NUT-05][05], [NUT-29][29]               |
+| 20006 | Invoice already paid                                     | [NUT-05][05]                                           |
+| 20007 | Quote is expired                                         | [NUT-04][04], [NUT-05][05]                             |
+| 20008 | Signature for mint request invalid                       | [NUT-20][20]                                           |
+| 20009 | Pubkey required for mint quote                           | [NUT-20][20]                                           |
+| 30001 | Endpoint requires clear auth                             | [NUT-21][21]                                           |
+| 30002 | Clear authentication failed                              | [NUT-21][21]                                           |
+| 31001 | Endpoint requires blind auth                             | [NUT-22][22]                                           |
+| 31002 | Blind authentication failed                              | [NUT-22][22]                                           |
+| 31003 | Maximum BAT mint amount exceeded                         | [NUT-22][22]                                           |
+| 31004 | BAT mint rate limit exceeded                             | [NUT-22][22]                                           |
+| 15001 | Unsupported or malformed `PAY_TO_UNLOCK` condition       | [NUT-Exchange][exchange]                               |
+| 15002 | `swap_id` mismatch across participants                   | [NUT-Exchange][exchange]                               |
+| 15003 | Receive-output commitment (`H_recv`) mismatch            | [NUT-Exchange][exchange]                               |
+| 15004 | Offer/receive keyset relationship violated               | [NUT-Exchange][exchange]                               |
+| 15005 | Exchange settlement submitted after `expiry`             | [NUT-Exchange][exchange]                               |
+| 15006 | Refund submitted before `expiry`                         | [NUT-Exchange][exchange]                               |
+| 15007 | Refund signature missing or invalid                      | [NUT-Exchange][exchange]                               |
+| 15009 | Exchange request exceeds advertised limits               | [NUT-Exchange][exchange]                               |
+| 15010 | Conflicting request for `swap_id` or input (idempotency) | [NUT-Exchange][exchange]                               |
 
 [00]: 00.md
 [01]: 01.md

--- a/error_codes.md
+++ b/error_codes.md
@@ -41,6 +41,8 @@
 | 15001 | Unsupported or malformed `PAY_TO_UNLOCK` condition       | [NUT-Exchange][exchange]                               |
 | 15003 | Receive-output commitment (`H_recv`) mismatch            | [NUT-Exchange][exchange]                               |
 | 15004 | Offer/receive keyset relationship violated               | [NUT-Exchange][exchange]                               |
+| 15005 | Exchange settlement submitted after `expiry`             | [NUT-Exchange][exchange]                               |
+| 15006 | Refund submitted before `expiry`                         | [NUT-Exchange][exchange]                               |
 | 15007 | Refund signature missing or invalid                      | [NUT-Exchange][exchange]                               |
 | 15009 | Exchange request exceeds advertised limits               | [NUT-Exchange][exchange]                               |
 | 15010 | Conflicting request or reused input (idempotency)        | [NUT-Exchange][exchange]                               |

--- a/error_codes.md
+++ b/error_codes.md
@@ -1,51 +1,55 @@
 # NUT Errors
 
-| Code  | Description                                              | Relevant nuts                                          |
-| ----- | -------------------------------------------------------- | ------------------------------------------------------ |
-| 10001 | Proof verification failed                                | [NUT-03][03], [NUT-05][05]                             |
-| 11001 | Proofs already spent                                     | [NUT-03][03], [NUT-05][05]                             |
-| 11002 | Proofs are pending                                       | [NUT-03][03], [NUT-05][05]                             |
-| 11003 | Outputs already signed                                   | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11004 | Outputs are pending                                      | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11005 | Transaction is not balanced (inputs != outputs)          | [NUT-02][02], [NUT-03][03], [NUT-05][05]               |
-| 11006 | Amount outside of limit range                            | [NUT-04][04], [NUT-05][05]                             |
-| 11007 | Duplicate inputs provided                                | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11008 | Duplicate outputs provided                               | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11009 | Inputs/Outputs of multiple units                         | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11010 | Inputs and outputs not of same unit                      | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11011 | Amountless invoice is not supported                      | [NUT-05][05]                                           |
-| 11012 | Amount in request does not equal invoice                 | [NUT-05][05]                                           |
-| 11013 | Unit in request is not supported                         | [NUT-04][04], [NUT-05][05]                             |
-| 11014 | Max inputs exceeded                                      | [NUT-03][03], [NUT-05][05]                             |
-| 11015 | Max outputs exceeded                                     | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11016 | Duplicate quote IDs provided                             | [NUT-29][29]                                           |
-| 11017 | Max batch size exceeded                                  | [NUT-29][29]                                           |
-| 12001 | Keyset is not known                                      | [NUT-02][02], [NUT-04][04]                             |
-| 12002 | Keyset is inactive, cannot sign messages                 | [NUT-02][02], [NUT-03][03], [NUT-04][04]               |
-| 12003 | Keyset has expired                                       | [NUT-02][02], [NUT-03][03], [NUT-04][04], [NUT-05][05] |
-| 20001 | Quote request is not paid                                | [NUT-04][04]                                           |
-| 20002 | Quote has already been issued                            | [NUT-04][04]                                           |
-| 20003 | Minting is disabled                                      | [NUT-04][04]                                           |
-| 20004 | Lightning payment failed                                 | [NUT-05][05]                                           |
-| 20005 | Quote is pending                                         | [NUT-04][04], [NUT-05][05], [NUT-29][29]               |
-| 20006 | Invoice already paid                                     | [NUT-05][05]                                           |
-| 20007 | Quote is expired                                         | [NUT-04][04], [NUT-05][05]                             |
-| 20008 | Signature for mint request invalid                       | [NUT-20][20]                                           |
-| 20009 | Pubkey required for mint quote                           | [NUT-20][20]                                           |
-| 30001 | Endpoint requires clear auth                             | [NUT-21][21]                                           |
-| 30002 | Clear authentication failed                              | [NUT-21][21]                                           |
-| 31001 | Endpoint requires blind auth                             | [NUT-22][22]                                           |
-| 31002 | Blind authentication failed                              | [NUT-22][22]                                           |
-| 31003 | Maximum BAT mint amount exceeded                         | [NUT-22][22]                                           |
-| 31004 | BAT mint rate limit exceeded                             | [NUT-22][22]                                           |
-| 15001 | Unsupported or malformed `PAY_TO_UNLOCK` condition       | [NUT-Exchange][exchange]                               |
-| 15003 | Receive-output commitment (`H_recv`) mismatch            | [NUT-Exchange][exchange]                               |
-| 15004 | Offer/receive keyset relationship violated               | [NUT-Exchange][exchange]                               |
-| 15005 | Exchange settlement submitted after `expiry`             | [NUT-Exchange][exchange]                               |
-| 15006 | Refund submitted before `expiry`                         | [NUT-Exchange][exchange]                               |
-| 15007 | Refund signature missing or invalid                      | [NUT-Exchange][exchange]                               |
-| 15009 | Exchange request exceeds advertised limits               | [NUT-Exchange][exchange]                               |
-| 15010 | Conflicting request or reused input (idempotency)        | [NUT-Exchange][exchange]                               |
+| Code  | Description                                        | Relevant nuts                                          |
+| ----- | -------------------------------------------------- | ------------------------------------------------------ |
+| 10001 | Proof verification failed                          | [NUT-03][03], [NUT-05][05]                             |
+| 11001 | Proofs already spent                               | [NUT-03][03], [NUT-05][05]                             |
+| 11002 | Proofs are pending                                 | [NUT-03][03], [NUT-05][05]                             |
+| 11003 | Outputs already signed                             | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11004 | Outputs are pending                                | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11005 | Transaction is not balanced (inputs != outputs)    | [NUT-02][02], [NUT-03][03], [NUT-05][05]               |
+| 11006 | Amount outside of limit range                      | [NUT-04][04], [NUT-05][05]                             |
+| 11007 | Duplicate inputs provided                          | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11008 | Duplicate outputs provided                         | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11009 | Inputs/Outputs of multiple units                   | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11010 | Inputs and outputs not of same unit                | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11011 | Amountless invoice is not supported                | [NUT-05][05]                                           |
+| 11012 | Amount in request does not equal invoice           | [NUT-05][05]                                           |
+| 11013 | Unit in request is not supported                   | [NUT-04][04], [NUT-05][05]                             |
+| 11014 | Max inputs exceeded                                | [NUT-03][03], [NUT-05][05]                             |
+| 11015 | Max outputs exceeded                               | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11016 | Duplicate quote IDs provided                       | [NUT-29][29]                                           |
+| 11017 | Max batch size exceeded                            | [NUT-29][29]                                           |
+| 12001 | Keyset is not known                                | [NUT-02][02], [NUT-04][04]                             |
+| 12002 | Keyset is inactive, cannot sign messages           | [NUT-02][02], [NUT-03][03], [NUT-04][04]               |
+| 12003 | Keyset has expired                                 | [NUT-02][02], [NUT-03][03], [NUT-04][04], [NUT-05][05] |
+| 20001 | Quote request is not paid                          | [NUT-04][04]                                           |
+| 20002 | Quote has already been issued                      | [NUT-04][04]                                           |
+| 20003 | Minting is disabled                                | [NUT-04][04]                                           |
+| 20004 | Lightning payment failed                           | [NUT-05][05]                                           |
+| 20005 | Quote is pending                                   | [NUT-04][04], [NUT-05][05], [NUT-29][29]               |
+| 20006 | Invoice already paid                               | [NUT-05][05]                                           |
+| 20007 | Quote is expired                                   | [NUT-04][04], [NUT-05][05]                             |
+| 20008 | Signature for mint request invalid                 | [NUT-20][20]                                           |
+| 20009 | Pubkey required for mint quote                     | [NUT-20][20]                                           |
+| 30001 | Endpoint requires clear auth                       | [NUT-21][21]                                           |
+| 30002 | Clear authentication failed                        | [NUT-21][21]                                           |
+| 31001 | Endpoint requires blind auth                       | [NUT-22][22]                                           |
+| 31002 | Blind authentication failed                        | [NUT-22][22]                                           |
+| 31003 | Maximum BAT mint amount exceeded                   | [NUT-22][22]                                           |
+| 31004 | BAT mint rate limit exceeded                       | [NUT-22][22]                                           |
+| 15001 | Unsupported or malformed `PAY_TO_UNLOCK` condition | [NUT-Exchange][exchange]                               |
+| 15003 | Receive-output commitment (`H_recv`) mismatch      | [NUT-Exchange][exchange]                               |
+| 15004 | Offer/receive keyset relationship violated         | [NUT-Exchange][exchange]                               |
+| 15005 | Exchange settlement submitted after `expiry`       | [NUT-Exchange][exchange]                               |
+| 15006 | Refund submitted before `expiry`                   | [NUT-Exchange][exchange]                               |
+| 15007 | Refund signature missing or invalid                | [NUT-Exchange][exchange]                               |
+| 15009 | Exchange request exceeds advertised limits         | [NUT-Exchange][exchange]                               |
+| 15010 | Conflicting request or reused input (idempotency)  | [NUT-Exchange][exchange]                               |
+| 15011 | Pool manifest hash (`H_manifest`) mismatch         | [NUT-Exchange-partial-fill][partial-fill]              |
+| 15012 | Pool selection does not match `outputs`            | [NUT-Exchange-partial-fill][partial-fill]              |
+| 15013 | Pool role/keyset or two-class consistency violated | [NUT-Exchange-partial-fill][partial-fill]              |
+| 15014 | Pool policy violation (rate/min/max/overflow)      | [NUT-Exchange-partial-fill][partial-fill]              |
 
 [00]: 00.md
 [01]: 01.md
@@ -65,3 +69,4 @@
 [22]: 22.md
 [29]: 29.md
 [exchange]: exchange.md
+[partial-fill]: exchange-partial-fill.md

--- a/error_codes.md
+++ b/error_codes.md
@@ -38,6 +38,15 @@
 | 31002 | Blind authentication failed                     | [NUT-22][22]                                           |
 | 31003 | Maximum BAT mint amount exceeded                | [NUT-22][22]                                           |
 | 31004 | BAT mint rate limit exceeded                    | [NUT-22][22]                                           |
+| 15001 | Unsupported or malformed `PAY_TO_UNLOCK` condition      | [NUT-Exchange][exchange] |
+| 15002 | `swap_id` mismatch across participants                   | [NUT-Exchange][exchange] |
+| 15003 | Receive-output commitment (`H_recv`) mismatch            | [NUT-Exchange][exchange] |
+| 15004 | Offer/receive keyset relationship violated               | [NUT-Exchange][exchange] |
+| 15005 | Exchange settlement submitted after `expiry`             | [NUT-Exchange][exchange] |
+| 15006 | Refund submitted before `expiry`                         | [NUT-Exchange][exchange] |
+| 15007 | Refund signature missing or invalid                      | [NUT-Exchange][exchange] |
+| 15009 | Exchange request exceeds advertised limits               | [NUT-Exchange][exchange] |
+| 15010 | Conflicting request for `swap_id` or input (idempotency) | [NUT-Exchange][exchange] |
 
 [00]: 00.md
 [01]: 01.md
@@ -56,3 +65,4 @@
 [21]: 21.md
 [22]: 22.md
 [29]: 29.md
+[exchange]: exchange.md

--- a/error_codes.md
+++ b/error_codes.md
@@ -39,14 +39,11 @@
 | 31003 | Maximum BAT mint amount exceeded                         | [NUT-22][22]                                           |
 | 31004 | BAT mint rate limit exceeded                             | [NUT-22][22]                                           |
 | 15001 | Unsupported or malformed `PAY_TO_UNLOCK` condition       | [NUT-Exchange][exchange]                               |
-| 15002 | `swap_id` mismatch across participants                   | [NUT-Exchange][exchange]                               |
 | 15003 | Receive-output commitment (`H_recv`) mismatch            | [NUT-Exchange][exchange]                               |
 | 15004 | Offer/receive keyset relationship violated               | [NUT-Exchange][exchange]                               |
-| 15005 | Exchange settlement submitted after `expiry`             | [NUT-Exchange][exchange]                               |
-| 15006 | Refund submitted before `expiry`                         | [NUT-Exchange][exchange]                               |
 | 15007 | Refund signature missing or invalid                      | [NUT-Exchange][exchange]                               |
 | 15009 | Exchange request exceeds advertised limits               | [NUT-Exchange][exchange]                               |
-| 15010 | Conflicting request for `swap_id` or input (idempotency) | [NUT-Exchange][exchange]                               |
+| 15010 | Conflicting request or reused input (idempotency)        | [NUT-Exchange][exchange]                               |
 
 [00]: 00.md
 [01]: 01.md

--- a/error_codes.md
+++ b/error_codes.md
@@ -1,55 +1,56 @@
 # NUT Errors
 
-| Code  | Description                                        | Relevant nuts                                          |
-| ----- | -------------------------------------------------- | ------------------------------------------------------ |
-| 10001 | Proof verification failed                          | [NUT-03][03], [NUT-05][05]                             |
-| 11001 | Proofs already spent                               | [NUT-03][03], [NUT-05][05]                             |
-| 11002 | Proofs are pending                                 | [NUT-03][03], [NUT-05][05]                             |
-| 11003 | Outputs already signed                             | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11004 | Outputs are pending                                | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11005 | Transaction is not balanced (inputs != outputs)    | [NUT-02][02], [NUT-03][03], [NUT-05][05]               |
-| 11006 | Amount outside of limit range                      | [NUT-04][04], [NUT-05][05]                             |
-| 11007 | Duplicate inputs provided                          | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11008 | Duplicate outputs provided                         | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11009 | Inputs/Outputs of multiple units                   | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11010 | Inputs and outputs not of same unit                | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11011 | Amountless invoice is not supported                | [NUT-05][05]                                           |
-| 11012 | Amount in request does not equal invoice           | [NUT-05][05]                                           |
-| 11013 | Unit in request is not supported                   | [NUT-04][04], [NUT-05][05]                             |
-| 11014 | Max inputs exceeded                                | [NUT-03][03], [NUT-05][05]                             |
-| 11015 | Max outputs exceeded                               | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
-| 11016 | Duplicate quote IDs provided                       | [NUT-29][29]                                           |
-| 11017 | Max batch size exceeded                            | [NUT-29][29]                                           |
-| 12001 | Keyset is not known                                | [NUT-02][02], [NUT-04][04]                             |
-| 12002 | Keyset is inactive, cannot sign messages           | [NUT-02][02], [NUT-03][03], [NUT-04][04]               |
-| 12003 | Keyset has expired                                 | [NUT-02][02], [NUT-03][03], [NUT-04][04], [NUT-05][05] |
-| 20001 | Quote request is not paid                          | [NUT-04][04]                                           |
-| 20002 | Quote has already been issued                      | [NUT-04][04]                                           |
-| 20003 | Minting is disabled                                | [NUT-04][04]                                           |
-| 20004 | Lightning payment failed                           | [NUT-05][05]                                           |
-| 20005 | Quote is pending                                   | [NUT-04][04], [NUT-05][05], [NUT-29][29]               |
-| 20006 | Invoice already paid                               | [NUT-05][05]                                           |
-| 20007 | Quote is expired                                   | [NUT-04][04], [NUT-05][05]                             |
-| 20008 | Signature for mint request invalid                 | [NUT-20][20]                                           |
-| 20009 | Pubkey required for mint quote                     | [NUT-20][20]                                           |
-| 30001 | Endpoint requires clear auth                       | [NUT-21][21]                                           |
-| 30002 | Clear authentication failed                        | [NUT-21][21]                                           |
-| 31001 | Endpoint requires blind auth                       | [NUT-22][22]                                           |
-| 31002 | Blind authentication failed                        | [NUT-22][22]                                           |
-| 31003 | Maximum BAT mint amount exceeded                   | [NUT-22][22]                                           |
-| 31004 | BAT mint rate limit exceeded                       | [NUT-22][22]                                           |
-| 15001 | Unsupported or malformed `PAY_TO_UNLOCK` condition | [NUT-Exchange][exchange]                               |
-| 15003 | Receive-output commitment (`H_recv`) mismatch      | [NUT-Exchange][exchange]                               |
-| 15004 | Offer/receive keyset relationship violated         | [NUT-Exchange][exchange]                               |
-| 15005 | Exchange settlement submitted after `expiry`       | [NUT-Exchange][exchange]                               |
-| 15006 | Refund submitted before `expiry`                   | [NUT-Exchange][exchange]                               |
-| 15007 | Refund signature missing or invalid                | [NUT-Exchange][exchange]                               |
-| 15009 | Exchange request exceeds advertised limits         | [NUT-Exchange][exchange]                               |
-| 15010 | Conflicting request or reused input (idempotency)  | [NUT-Exchange][exchange]                               |
-| 15011 | Pool manifest hash (`H_manifest`) mismatch         | [NUT-Exchange-partial-fill][partial-fill]              |
-| 15012 | Pool selection does not match `outputs`            | [NUT-Exchange-partial-fill][partial-fill]              |
-| 15013 | Pool role/keyset or two-class consistency violated | [NUT-Exchange-partial-fill][partial-fill]              |
-| 15014 | Pool policy violation (rate/min/max/overflow)      | [NUT-Exchange-partial-fill][partial-fill]              |
+| Code  | Description                                                                                             | Relevant nuts                                          |
+| ----- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| 10001 | Proof verification failed                                                                               | [NUT-03][03], [NUT-05][05]                             |
+| 11001 | Proofs already spent                                                                                    | [NUT-03][03], [NUT-05][05]                             |
+| 11002 | Proofs are pending                                                                                      | [NUT-03][03], [NUT-05][05]                             |
+| 11003 | Outputs already signed                                                                                  | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11004 | Outputs are pending                                                                                     | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11005 | Transaction is not balanced (inputs != outputs)                                                         | [NUT-02][02], [NUT-03][03], [NUT-05][05]               |
+| 11006 | Amount outside of limit range                                                                           | [NUT-04][04], [NUT-05][05]                             |
+| 11007 | Duplicate inputs provided                                                                               | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11008 | Duplicate outputs provided                                                                              | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11009 | Inputs/Outputs of multiple units                                                                        | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11010 | Inputs and outputs not of same unit                                                                     | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11011 | Amountless invoice is not supported                                                                     | [NUT-05][05]                                           |
+| 11012 | Amount in request does not equal invoice                                                                | [NUT-05][05]                                           |
+| 11013 | Unit in request is not supported                                                                        | [NUT-04][04], [NUT-05][05]                             |
+| 11014 | Max inputs exceeded                                                                                     | [NUT-03][03], [NUT-05][05]                             |
+| 11015 | Max outputs exceeded                                                                                    | [NUT-03][03], [NUT-04][04], [NUT-05][05]               |
+| 11016 | Duplicate quote IDs provided                                                                            | [NUT-29][29]                                           |
+| 11017 | Max batch size exceeded                                                                                 | [NUT-29][29]                                           |
+| 12001 | Keyset is not known                                                                                     | [NUT-02][02], [NUT-04][04]                             |
+| 12002 | Keyset is inactive, cannot sign messages                                                                | [NUT-02][02], [NUT-03][03], [NUT-04][04]               |
+| 12003 | Keyset has expired                                                                                      | [NUT-02][02], [NUT-03][03], [NUT-04][04], [NUT-05][05] |
+| 20001 | Quote request is not paid                                                                               | [NUT-04][04]                                           |
+| 20002 | Quote has already been issued                                                                           | [NUT-04][04]                                           |
+| 20003 | Minting is disabled                                                                                     | [NUT-04][04]                                           |
+| 20004 | Lightning payment failed                                                                                | [NUT-05][05]                                           |
+| 20005 | Quote is pending                                                                                        | [NUT-04][04], [NUT-05][05], [NUT-29][29]               |
+| 20006 | Invoice already paid                                                                                    | [NUT-05][05]                                           |
+| 20007 | Quote is expired                                                                                        | [NUT-04][04], [NUT-05][05]                             |
+| 20008 | Signature for mint request invalid                                                                      | [NUT-20][20]                                           |
+| 20009 | Pubkey required for mint quote                                                                          | [NUT-20][20]                                           |
+| 30001 | Endpoint requires clear auth                                                                            | [NUT-21][21]                                           |
+| 30002 | Clear authentication failed                                                                             | [NUT-21][21]                                           |
+| 31001 | Endpoint requires blind auth                                                                            | [NUT-22][22]                                           |
+| 31002 | Blind authentication failed                                                                             | [NUT-22][22]                                           |
+| 31003 | Maximum BAT mint amount exceeded                                                                        | [NUT-22][22]                                           |
+| 31004 | BAT mint rate limit exceeded                                                                            | [NUT-22][22]                                           |
+| 15001 | Unsupported or malformed `PAY_TO_UNLOCK` condition                                                      | [NUT-Exchange][exchange]                               |
+| 15003 | Receive-output commitment (`H_recv`) mismatch                                                           | [NUT-Exchange][exchange]                               |
+| 15004 | Offer/receive keyset relationship violated                                                              | [NUT-Exchange][exchange]                               |
+| 15005 | Exchange settlement submitted after `expiry`                                                            | [NUT-Exchange][exchange]                               |
+| 15006 | Refund submitted before `expiry`                                                                        | [NUT-Exchange][exchange]                               |
+| 15007 | Refund signature missing or invalid                                                                     | [NUT-Exchange][exchange]                               |
+| 15009 | Exchange request exceeds advertised limits                                                              | [NUT-Exchange][exchange]                               |
+| 15010 | Conflicting request or reused input (idempotency)                                                       | [NUT-Exchange][exchange]                               |
+| 15011 | Pool manifest hash (`H_manifest`) mismatch                                                              | [NUT-Exchange-partial-fill][partial-fill]              |
+| 15012 | Pool selection does not match `outputs`                                                                 | [NUT-Exchange-partial-fill][partial-fill]              |
+| 15013 | Pool role/keyset or two-class consistency violated                                                      | [NUT-Exchange-partial-fill][partial-fill]              |
+| 15014 | Pool policy violation (rate/min/max/overflow)                                                           | [NUT-Exchange-partial-fill][partial-fill]              |
+| 15015 | Coordinator authorization failed (key disagreement / missing, invalid, or unexpected `coordinator_sig`) | [NUT-Exchange][exchange]                               |
 
 [00]: 00.md
 [01]: 01.md

--- a/exchange-partial-fill.md
+++ b/exchange-partial-fill.md
@@ -4,7 +4,7 @@
 
 `optional`
 
-`depends on: NUT-Exchange, NUT-02, NUT-03, NUT-06, NUT-09, NUT-10, NUT-11, NUT-12`
+`depends on: NUT-Exchange, NUT-01, NUT-02, NUT-03, NUT-06, NUT-09, NUT-10, NUT-11, NUT-12`
 
 ---
 
@@ -41,39 +41,41 @@ Pool mode is signaled by the presence of `rate_n` and `rate_d` tags. When absent
 
 **Pool-mode tags** (presence signals pool mode; all four required together):
 
-- `rate_n` / `rate_d`: minimum receive rate, expressed as a rational `rate_n / rate_d`. The mint enforces `receive_total × rate_d ≥ debit_total × rate_n` using checked `u128` cross-multiplication (no division, no rounding ambiguity). This is an **inequality** — better prices are automatically admitted.
+- `rate_n` / `rate_d`: minimum receive rate in integer keyset minor units: at least `rate_n` receive-keyset units for every `rate_d` offer-keyset units debited. `rate_d` MUST be greater than zero. The mint enforces `receive_total × rate_d ≥ debit_total × rate_n` using checked `u128` cross-multiplication, with no division or rounding. Implementations MUST NOT convert either total to display units before this comparison. For a sat receive keyset and a USD offer keyset whose amount `1` is one cent, one sat per cent is encoded as `rate_n = 1, rate_d = 1`. The inequality admits every better price.
 - `min_receive`: minimum total receive-keyset output amount. Prevents dust fills. MUST be positive.
-- `max_debit`: maximum total debit (`input_total − change_total`). Caps the spending. MUST be ≤ the participant's input total.
+- `max_debit`: maximum total debit (`input_total − change_total`). Caps spending and MUST be no greater than the participant's input total. The mint MUST reject a request whose selected `change_total` exceeds `input_total`; it MUST NOT perform a wrapping subtraction.
 
-Every proof contributed by one participant MUST carry the same condition (same `nonce`, `data`, tags), with unique per-proof nonces (same rule as [NUT-Exchange][exchange]).
+Every proof contributed by one participant MUST carry the same `data` and the same tags (`offer_keyset`, `expiry`, `refund`, `rate_n`, `rate_d`, `min_receive`, `max_debit`), while each proof MUST use a unique `nonce`, following the per-proof nonce rule in [NUT-Exchange][exchange].
 
 ## Output pools
 
 The owner generates two pools of `BlindedMessage` entries:
 
-- **Receive pool:** entries in the receive keyset, at powers-of-2 denominations (1, 2, 4, 8, ..., 2^k). Any subset sums to any integer from 0 to `2^(k+1) − 1`.
+- **Receive pool:** entries in the receive keyset, at powers-of-2 denominations.
 - **Change pool:** entries in the offer keyset, at powers-of-2 denominations covering the possible change range.
 
 Each entry has a `role` (`receive` or `change`), `amount`, `id` (keyset), and `B_` (blinded point). The owner retains every entry's secret and blinding factor.
 
-Denominations MUST be powers of 2 (1, 2, 4, 8, ..., 2^k), matching the Cashu binary keyset convention ([NUT-00][00]). For a max receive of `R` units, `⌈log₂(R+1)⌉` entries cover every integer from 0 to `R`. For a max change of `C` units, `⌈log₂(C+1)⌉` entries suffice. Total entries: `O(log R + log C)` — typically 15–25 for most orders.
+For each participant, every `receive` entry MUST have the same `id`, called that participant's receive keyset. Every `change` entry MUST have `id` equal to the condition's `offer_keyset`. Both roles MUST be present, and the receive keyset MUST differ from `offer_keyset`; therefore each participant's complete manifest contains exactly those two keyset IDs. Across the complete exchange request, the union of every participant's `offer_keyset` and derived receive keyset MUST contain exactly two distinct keyset IDs.
+
+Pool mode uses powers-of-two denominations (`1, 2, 4, 8, ..., 2^k`), but Cashu does not guarantee that a keyset publishes those denominations. A wallet MUST inspect the [NUT-01][01] key maps for the receive and offer keysets and MUST NOT create a pool unless each keyset is active for issuance and publishes a signing key for every amount placed in that keyset's pool. The mint MUST reject a manifest if any entry's `(id, amount)` does not identify a published signing key in an active keyset. Given that denomination coverage, `⌈log₂(R+1)⌉` receive entries can represent every integer from 0 through `R`, and `⌈log₂(C+1)⌉` change entries can represent every integer from 0 through `C`. Total entries remain `O(log R + log C)`.
 
 ## Manifest hash
 
-The `data` field is `H_manifest`, computed over the canonical encoding of all pool entries:
-
-```
-manifest_canonical = entry[0]_canonical || entry[1]_canonical || ... || entry[n-1]_canonical
-H_manifest = tagged_hash("Cashu/PAY_TO_UNLOCK/manifest", manifest_canonical)
-```
-
-Each `entry_canonical` is the JCS encoding of:
+The `data` field is `H_manifest`, computed over the complete ordered `pool_manifest`. `PoolEntry` is the only name for an entry in that array and has exactly these fields:
 
 ```json
-{"amount":"<decimal_str>","B_":"<hex>","id":"<keyset_id>","index":<uint>,"role":"receive|change"}
+{"index": <uint>, "role": "receive|change", "amount": <uint>, "id": "<keyset_id>", "B_": "<hex_str>"}
 ```
 
-Entries are sorted by `(role, index)`. Amounts are decimal strings (same precision rule as [NUT-Exchange][exchange]). The `index` field ensures unambiguous ordering even with duplicate amounts.
+`amount` is an unsigned 64-bit integer in the minor unit of the entry's keyset ([NUT-01][01]). `pool_manifest` MUST contain all `receive` entries first and all `change` entries second. Each entry's `index` MUST equal its zero-based position in `pool_manifest`; indices are unique and contiguous from `0` through `len(pool_manifest) − 1`.
+
+Each `PoolEntry` is encoded using the [RFC 8785][rfc8785] JCS defined by [NUT-Exchange][exchange]:
+
+```
+manifest_canonical = JCS(pool_manifest[0]) || JCS(pool_manifest[1]) || ... || JCS(pool_manifest[n-1])
+H_manifest = tagged_hash("Cashu/PAY_TO_UNLOCK/manifest", manifest_canonical)
+```
 
 ## Request format
 
@@ -93,18 +95,16 @@ Pool-mode participants include the full manifest and a selection bitmap:
 ```
 
 - `outputs`: the selected entries only — these are the `BlindedMessage` values the mint will sign. MUST be a subset of `pool_manifest`, in manifest index order.
-- `pool_manifest`: the full array of `PoolEntry` objects that the owner pre-generated. Each entry has `{index, role, amount, id, B_}`. The mint hashes this array (see [Manifest hash](#manifest-hash)) and verifies it matches the condition's `data` field. This proves every entry was created by the owner.
+- `pool_manifest`: the complete ordered array of `PoolEntry` values defined in [Manifest hash](#manifest-hash). The mint computes `H_manifest` from this array and verifies it against the condition's `data` field. This authenticates every candidate entry as part of the owner-created pool.
 - `pool_selection`: a hex-encoded bitmap selecting which manifest entries to sign. Bit `i` (0-indexed from the least-significant bit of the first byte) corresponds to `pool_manifest[i]`. Bit `1` = selected (include in `outputs`), bit `0` = skipped. Unused trailing bits MUST be zero. The selected entries, in index order, MUST exactly match the `outputs` array.
 
-**PoolEntry schema:**
+`pool_selection` tells the mint which authenticated candidate outputs to sign. An entry whose bit is zero is an unsigned candidate, not ecash: the mint MUST NOT sign or return it, and signing every manifest entry would violate the per-class conservation rule. The full-manifest form reveals to the mint that all listed `B_` values belong to one authorization, but an unselected value never becomes a proof. After successful settlement, refund, or expiry, the owner MUST discard every unselected entry's secret and blinding factor and MUST NOT reuse its `B_`; a later transaction requiring that denomination MUST generate a fresh secret, blinding factor, and `B_`.
 
-```json
-{"index": <uint>, "role": "receive|change", "amount": "<decimal_str>", "id": "<keyset_id>", "B_": "<hex_str>"}
-```
-
-Example: a manifest with 3 receive entries and 2 change entries. If the coordinator selects receive entries 0 and 2 plus change entry 0, the bitmap is `0b000010101` = `0x15` (bits 0, 2, and 4 set). `pool_selection = "15"`. `outputs` contains entries 0, 2, and 4 from the manifest, in that order.
+Example: a five-entry manifest has receive entries at manifest indices 0, 1, and 2 and change entries at manifest indices 3 and 4. Selecting manifest entries 0, 2, and 4 produces the bitmap `0b00010101` = `0x15`; therefore `pool_selection = "15"`, and `outputs` contains `pool_manifest[0]`, `pool_manifest[2]`, and `pool_manifest[4]`, in that order.
 
 Non-pool-mode participants omit `pool_manifest` and `pool_selection` (standard NUT-Exchange behavior).
+
+Version 1 uses the full manifest. Pool size is logarithmic in the representable receive and change ranges, and every request remains subject to both `max_pool_entries` per participant and NUT-Exchange's `max_request_bytes` for the complete request. The mint MUST reject a request exceeding either limit, and a wallet MUST NOT create a pool-mode authorization that cannot fit both advertised limits. Merkle roots and inclusion proofs are not valid version-1 request forms. A future Merkle form MUST use a separately advertised version or mode that defines the leaf encoding, global index binding, tree construction and domain separation, proof encoding, and proof-size limits.
 
 Response: same as NUT-Exchange — `{signatures: [...]}`, one `BlindSignature` array per participant. Pool-mode participants receive signatures for their selected entries only.
 
@@ -116,9 +116,9 @@ Pool-mode participants require additional validation beyond [NUT-Exchange][excha
 
 7p. **Selection consistency:** the entries indicated by `pool_selection` MUST exactly match the `outputs` array (same `B_`, `amount`, `id` values in the same order). Otherwise reject.
 
-8p. **Role/keyset consistency:** every selected `receive` entry MUST use the receive keyset (derived from the manifest's `role` field); every selected `change` entry MUST use the offer keyset. At least one `receive` entry MUST be selected.
+8p. **Role/keyset and two-class consistency:** validate the entire `pool_manifest`, not only selected entries. For each participant, all `receive` entries MUST share one `id`; all `change` entries MUST use the condition's `offer_keyset`; both roles MUST be present; and the derived receive keyset MUST differ from `offer_keyset`. No other keyset ID may occur in that manifest. Across all participants, exactly two distinct keyset IDs MUST occur among all conditions' `offer_keyset` values and all derived receive keysets. At least one `receive` entry MUST be selected for each participant. For every manifest entry, the mint MUST also verify that `id` is active for issuance and that the keyset publishes a signing key for `amount`.
 
-9p. **Policy:** compute `receive_total` (sum of selected receive amounts) and `debit_total` (input total − sum of selected change amounts). Enforce using checked `u128` arithmetic:
+9p. **Policy:** parse `rate_n`, `rate_d`, `min_receive`, and `max_debit` as unsigned `u128` values. Reject if parsing fails, if `rate_d = 0`, or if `min_receive = 0`. Using checked `u128` addition, compute `input_total` from the participant's inputs, `receive_total` from selected receive entries, and `change_total` from selected change entries. Reject if any conversion or sum overflows, if `max_debit > input_total`, or if `change_total > input_total`. Only after those checks, compute `debit_total = input_total − change_total` with checked subtraction. Compute both rate products with checked multiplication and reject if either product overflows. Then enforce:
 
 - `receive_total × rate_d ≥ debit_total × rate_n` (rate covenant)
 - `receive_total ≥ min_receive` (minimum fill)
@@ -126,55 +126,65 @@ Pool-mode participants require additional validation beyond [NUT-Exchange][excha
 
 10p. **Conservation:** standard per-class conservation from [NUT-Exchange][exchange] rule 10, applied with change entries in the offer keyset. The mint signs only `outputs`; `pool_manifest` entries are authentication material, not outputs to sign.
 
-Standard rules 7–8 from NUT-Exchange (single-keyset output constraint, two-keyset exchange) are **relaxed** for pool mode: outputs may use both the receive and offer keysets (change), exactly as with `allow_change` in NUT-Exchange.
+NUT-Exchange rule 7's per-participant single-keyset output constraint is replaced by rule 8p because selected pool outputs may use both that participant's receive keyset and offer keyset for change. NUT-Exchange rule 8's exactly-two-keysets invariant is not relaxed; rule 8p applies it to the keysets derived from every complete manifest and to the request as a whole.
 
 ## Example
 
-Alice wants to swap **10 USD for up to 1000 sats** at price **≤ 0.01 USD/sat**.
+Alice wants to swap **10000 cents (100 USD) for 1000 sats**. Here `input_total = 10000` cents is the value locked in the authorization; `max_debit = 1000` permits at most 1000 cents to be spent, so a complete 1000-sat fill at Alice's boundary rate returns 9000 cents as change.
 
 ### Preparation
 
 **Receive pool** (sats keyset, 10 entries): amounts 1, 2, 4, 8, 16, 32, 64, 128, 256, 512. Any subset sums to 0–1023.
 
-**Change pool** (USD keyset, 11 entries): amounts 0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12 (covering 0–10.23 USD). _(Adjust denominations to match keyset's supported amounts.)_
+**Change pool** (USD keyset; amounts are cents, 14 entries): amounts 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192. These entries can represent every integer change amount from 0 through 16383 cents.
 
-**Manifest:** 21 entries. `H_manifest = hash(canonical encoding)`.
+**Manifest:** 24 entries. `H_manifest` is computed from the canonical `PoolEntry` encodings defined above.
 
-**Policy:** `rate_n = 1, rate_d = 100` (receive ≥ 100 sats per USD debited), `min_receive = 1`, `max_debit = 1000` (cents).
+**Policy:** `rate_n = 1, rate_d = 1` (receive at least 1 sat per cent debited), `min_receive = 1` sat, `max_debit = 1000` cents.
 
-**Lock:** one 10-USD `PAY_TO_UNLOCK` proof in pool mode.
+**Lock:** one or more `PAY_TO_UNLOCK` proofs totaling 10000 cents, all carrying the same manifest and policy tags and unique per-proof nonces.
 
-### Settlement — fill 500 sats
+### Settlement — boundary fill of 500 sats
 
-Counterparty offers 500 sats for 5 USD.
+Counterparty offers 500 sats for 500 cents.
 
 Coordinator selects:
 
 - Receive: {256, 128, 64, 32, 16, 4} = 500 sats (6 entries)
-- Change: {5.12... } → nearest representable set summing to ~5 USD
+- Change: {8192, 1024, 256, 16, 8, 4} = 9500 cents (6 entries)
 
 Mint checks:
 
 - `H_manifest` matches condition `data` ✓
-- Selected entries match bitmap ✓
-- `receive_total = 500`, `debit_total = 500` (cents)
-- `500 × 100 ≥ 500 × 1` → `50000 ≥ 500` ✓ (price well within limit)
-- `500 ≥ 1` ✓, `500 ≤ 1000` ✓
-- Conservation: 10 USD in = 5 USD change + 5 USD to counterparty. 500 sats in = 500 sats out. ✓
+- Selected entries exactly match the bitmap and `outputs` ✓
+- `input_total = 10000`, `change_total = 9500`, so `debit_total = 10000 − 9500 = 500` cents ✓
+- Rate boundary: `500 × 1 ≥ 500 × 1` → `500 ≥ 500` ✓
+- `receive_total = 500 ≥ min_receive = 1` ✓
+- `debit_total = 500 ≤ max_debit = 1000` ✓
+- Conservation: 10000 cents in = 9500 cents change + 500 cents to the counterparty; 500 sats in = 500 sats out ✓
 
-Mint signs 8 selected BlindedMessages. Alice unblinds to get 500 sats + 5 USD change.
+Equality is accepted: this is exactly Alice's limit of one sat per cent. If the counterparty instead offered 499 sats for the same 500-cent debit, the mint would evaluate `499 × 1 ≥ 500 × 1`, which is false, and MUST reject the request.
 
-### Settlement — partial fill 237 sats
+The mint signs Alice's 12 selected `BlindedMessage` values. Alice unblinds them to obtain 500 sats and 9500 cents of change.
 
-Counterparty offers 237 sats for ~2.37 USD.
+### Settlement — better-price partial fill of 237 sats
 
-Coordinator searches for a valid (receive, change) pair:
+Counterparty offers 237 sats for 200 cents (2.00 USD).
 
-- Receive: {128, 64, 32, 8, 4, 1} = 237 sats
-- Change: subset summing to ~7.63 USD → nearest representable
-- Check: `237 × 100 ≥ debit × 1` → debit ≤ 23700 cents = 237 USD... wait, units.
+Coordinator selects:
 
-_(The coordinator optimizes over all valid subsets. The rate covenant ensures Alice never pays more than 0.01 USD/sat. The denomination granularity determines the exact achievable price.)_
+- Receive: {128, 64, 32, 8, 4, 1} = 237 sats (6 entries)
+- Change: {8192, 1024, 512, 64, 8} = 9800 cents (5 entries)
+
+Mint checks:
+
+- `input_total = 10000`, `change_total = 9800`, so `debit_total = 200` cents ✓
+- Rate: `237 × 1 ≥ 200 × 1` → `237 ≥ 200` ✓
+- `receive_total = 237 ≥ min_receive = 1` ✓
+- `debit_total = 200 ≤ max_debit = 1000` ✓
+- Conservation: 10000 cents in = 9800 cents change + 200 cents to the counterparty; 237 sats in = 237 sats out ✓
+
+The strict inequality admits this better price: Alice pays `200 / 237` cents per sat, less than her maximum of one cent per sat. The mint signs Alice's 11 selected `BlindedMessage` values, and Alice unblinds them to obtain 237 sats and 9800 cents of change.
 
 ## Recovery and refund
 
@@ -182,19 +192,24 @@ Identical to [NUT-Exchange][exchange]. Pool-mode proofs carry the same `expiry` 
 
 ## Mint info
 
-Pool-mode support is advertised via [NUT-06][06]:
-
 ```json
 {
   "exchange": {
     "supported": true,
+    "version": 1,
+    "max_participants": "<uint>",
+    "max_inputs": "<uint>",
+    "max_outputs": "<uint>",
+    "max_request_bytes": "<uint>",
+    "idempotent_retries": "<bool>",
+    "max_expiry_seconds": "<uint>",
     "partial_fill": true,
     "max_pool_entries": "<uint>"
   }
 }
 ```
 
-`max_pool_entries` bounds the total number of manifest entries per participant. A wallet MUST NOT create pool-mode conditions exceeding this limit.
+`max_pool_entries` bounds the total number of manifest entries per participant, while `max_request_bytes` bounds the complete serialized request, including every participant's manifest. A wallet MUST satisfy both limits and a mint MUST enforce both limits before signing or mutating state.
 
 ## FAQ
 
@@ -207,15 +222,13 @@ No. Every selected entry must be in Alice's authenticated manifest (verified by 
 **Does the mint enforce best execution?**
 No. The rate covenant enforces the owner's limit price. Any subset satisfying the covenant is valid. The coordinator may select the least favorable valid pair. Best execution is an off-mint concern.
 
-**How does this differ from `alt_outputs`?**
-`alt_outputs` enumerates complete bundles (O(T) preprocessing for T fill scenarios). Pool mode generates O(log N) entries and lets the mint evaluate a numeric policy. Pool mode scales to fine-grained FAK; `alt_outputs` does not.
-
 ## References
 
-- [NUT-Exchange][exchange] · [NUT-02](02.md) · [NUT-03](03.md) · [NUT-06](06.md) ·
-  [NUT-09](09.md) · [NUT-10](10.md) · [NUT-11](11.md) · [NUT-12](12.md)
+- [NUT-01](01.md) · [NUT-02](02.md) · [NUT-03](03.md) · [NUT-06](06.md) ·
+  [NUT-09](09.md) · [NUT-10](10.md) · [NUT-11](11.md) · [NUT-12](12.md) ·
+  [NUT-Exchange][exchange]
 
-[00]: 00.md
+[01]: 01.md
 [02]: 02.md
 [03]: 03.md
 [06]: 06.md
@@ -224,3 +237,4 @@ No. The rate covenant enforces the owner's limit price. Any subset satisfying th
 [11]: 11.md
 [12]: 12.md
 [exchange]: https://github.com/cashubtc/nuts/pull/410
+[rfc8785]: https://www.rfc-editor.org/rfc/rfc8785.html

--- a/exchange-partial-fill.md
+++ b/exchange-partial-fill.md
@@ -17,6 +17,8 @@ Readers should be familiar with [NUT-Exchange][exchange] (`PAY_TO_UNLOCK`, conse
 ## Condition
 
 Pool mode is signaled by the presence of `rate_n` and `rate_d` tags. When absent, the condition uses standard mode (exact `H_recv` match, as defined in [NUT-Exchange][exchange]). In pool mode the base optional tags `alt_outputs`, `allow_change`, and `min_output_amount` MUST be absent: `alt_outputs` is incompatible with rule 6p's exact `H_manifest`, change is authorized by the manifest's change role (rule 8p), and `min_receive` supersedes `min_output_amount` (base rule 12).
+The base `coordinator_pubkey` tag ([NUT-Exchange][exchange]) is permitted in pool
+mode unchanged.
 
 ```json
 [
@@ -45,7 +47,7 @@ Pool mode is signaled by the presence of `rate_n` and `rate_d` tags. When absent
 - `min_receive`: minimum total receive-keyset output amount. Prevents dust fills. MUST be positive.
 - `max_debit`: maximum total debit (`input_total − change_total`). Caps spending and MUST be no greater than the participant's input total. The mint MUST reject a request whose selected `change_total` exceeds `input_total`; it MUST NOT perform a wrapping subtraction.
 
-Every proof contributed by one participant MUST carry the same `data` and the same tags (`offer_keyset`, `expiry`, `refund`, `rate_n`, `rate_d`, `min_receive`, `max_debit`), while each proof MUST use a unique `nonce`, following the per-proof nonce rule in [NUT-Exchange][exchange].
+Every proof contributed by one participant MUST carry the same `data` and the same tags (`offer_keyset`, `expiry`, `refund`, `rate_n`, `rate_d`, `min_receive`, `max_debit`, and optionally `coordinator_pubkey`), while each proof MUST use a unique `nonce`, following the per-proof nonce rule in [NUT-Exchange][exchange].
 
 ## Output pools
 
@@ -110,7 +112,7 @@ Example: a five-entry manifest has receive entries at manifest indices 0, 1, and
 
 A single `/v1/exchange` request MAY mix pool-mode and standard-mode participants. Standard-mode participants omit `pool_manifest` and `pool_selection` and are validated under base [NUT-Exchange][exchange] rules; rule 8p derives each participant's receive keyset per mode — from the manifest for pool mode, from the outputs for standard mode.
 
-Version 1 uses the full manifest. Pool size is logarithmic in the representable receive and change ranges, and every request remains subject to both `max_pool_entries` per participant and NUT-Exchange's `max_request_bytes` for the complete request. The mint MUST reject a request exceeding either limit, and a wallet MUST NOT create a pool-mode authorization that cannot fit both advertised limits. For idempotent retries, a pool-mode participant's canonical record (and thus `request_digest`) includes `pool_manifest` and `pool_selection` in addition to `inputs` and `outputs`, so two requests differing only in manifest or selection cannot alias to one cached response. Merkle roots and inclusion proofs are not valid version-1 request forms. A future Merkle form MUST use a separately advertised version or mode that defines the leaf encoding, global index binding, tree construction and domain separation, proof encoding, and proof-size limits.
+Version 1 uses the full manifest. Pool size is logarithmic in the representable receive and change ranges, and every request remains subject to both `max_pool_entries` per participant and NUT-Exchange's `max_request_bytes` for the complete request. The mint MUST reject a request exceeding either limit, and a wallet MUST NOT create a pool-mode authorization that cannot fit both advertised limits. For idempotent retries, a pool-mode participant's canonical record is `JCS({"inputs": ..., "outputs": ..., "pool_manifest": ...}) || hex_decode(pool_selection)` (same JCS rules as base NUT-Exchange; `pool_manifest` in index order), appended to `req_canonical`, so two requests differing only in manifest or selection cannot alias to one cached response. `hex_decode(pool_selection)` is the raw bitmap (`⌈len(pool_manifest)/8⌉` bytes); its length is derivable from the manifest, so no length prefix is needed. Merkle roots and inclusion proofs are not valid version-1 request forms. A future Merkle form MUST use a separately advertised version or mode that defines the leaf encoding, global index binding, tree construction and domain separation, proof encoding, and proof-size limits.
 
 Response: same as NUT-Exchange — `{signatures: [...]}`, one `BlindSignature` array per participant. Pool-mode participants receive signatures for their selected entries only.
 

--- a/exchange-partial-fill.md
+++ b/exchange-partial-fill.md
@@ -8,7 +8,7 @@
 
 ---
 
-This NUT extends [NUT-Exchange][exchange]'s `PAY_TO_UNLOCK` condition with a **pool-based authorization mode** that enables FAK (fill-and-kill) orders: the owner locks a single input and authorizes a **range** of possible output bundles, with the actual fill amount determined at match time.
+This NUT extends [NUT-Exchange][exchange]'s `PAY_TO_UNLOCK` condition with a **pool-based authorization mode**: the owner locks a single input and authorizes a **range** of possible output bundles, with the actual output selection determined at match time.
 
 In standard mode (NUT-Exchange), `data` is `H_recv` — a hash of one exact output bundle. In pool mode (this NUT), `data` is a manifest hash over a small set of pre-generated output entries in binary denominations, plus a numeric rate policy that the mint enforces. The coordinator selects any subset satisfying the policy; the mint signs only the selected entries.
 
@@ -56,9 +56,7 @@ The owner generates two pools of `BlindedMessage` entries:
 
 Each entry has a `role` (`receive` or `change`), `amount`, `id` (keyset), and `B_` (blinded point). The owner retains every entry's secret and blinding factor.
 
-**Recommended denomination sets:** for a max receive of `R` units, use `⌈log₂(R+1)⌉` entries (1, 2, 4, ..., 2^(k-1)). For a max change of `C` units, use `⌈log₂(C+1)⌉` entries. Total entries: `O(log R + log C)` — typically 15–25 for most orders.
-
-**Non-power-of-2 keysets:** if the keyset does not support power-of-2 amounts, the owner must choose a denomination set that covers the needed range. The wallet cost is `O(pool_size)` regardless of denomination structure.
+Denominations MUST be powers of 2 (1, 2, 4, 8, ..., 2^k), matching the Cashu binary keyset convention ([NUT-00][00]). For a max receive of `R` units, `⌈log₂(R+1)⌉` entries cover every integer from 0 to `R`. For a max change of `C` units, `⌈log₂(C+1)⌉` entries suffice. Total entries: `O(log R + log C)` — typically 15–25 for most orders.
 
 ## Manifest hash
 
@@ -94,9 +92,17 @@ Pool-mode participants include the full manifest and a selection bitmap:
 }
 ```
 
-- `outputs`: the selected entries only — these are the entries the mint will sign.
-- `pool_manifest`: all pool entries (receive + change), in canonical order.
-- `pool_selection`: hex-encoded bitmap where bit `i` indicates whether manifest entry `i` is selected.
+- `outputs`: the selected entries only — these are the `BlindedMessage` values the mint will sign. MUST be a subset of `pool_manifest`, in manifest index order.
+- `pool_manifest`: the full array of `PoolEntry` objects that the owner pre-generated. Each entry has `{index, role, amount, id, B_}`. The mint hashes this array (see [Manifest hash](#manifest-hash)) and verifies it matches the condition's `data` field. This proves every entry was created by the owner.
+- `pool_selection`: a hex-encoded bitmap selecting which manifest entries to sign. Bit `i` (0-indexed from the least-significant bit of the first byte) corresponds to `pool_manifest[i]`. Bit `1` = selected (include in `outputs`), bit `0` = skipped. Unused trailing bits MUST be zero. The selected entries, in index order, MUST exactly match the `outputs` array.
+
+**PoolEntry schema:**
+
+```json
+{"index": <uint>, "role": "receive|change", "amount": "<decimal_str>", "id": "<keyset_id>", "B_": "<hex_str>"}
+```
+
+Example: a manifest with 3 receive entries and 2 change entries. If the coordinator selects receive entries 0 and 2 plus change entry 0, the bitmap is `0b000010101` = `0x15` (bits 0, 2, and 4 set). `pool_selection = "15"`. `outputs` contains entries 0, 2, and 4 from the manifest, in that order.
 
 Non-pool-mode participants omit `pool_manifest` and `pool_selection` (standard NUT-Exchange behavior).
 
@@ -209,6 +215,7 @@ No. The rate covenant enforces the owner's limit price. Any subset satisfying th
 - [NUT-Exchange][exchange] · [NUT-02](02.md) · [NUT-03](03.md) · [NUT-06](06.md) ·
   [NUT-09](09.md) · [NUT-10](10.md) · [NUT-11](11.md) · [NUT-12](12.md)
 
+[00]: 00.md
 [02]: 02.md
 [03]: 03.md
 [06]: 06.md

--- a/exchange-partial-fill.md
+++ b/exchange-partial-fill.md
@@ -16,7 +16,7 @@ Readers should be familiar with [NUT-Exchange][exchange] (`PAY_TO_UNLOCK`, conse
 
 ## Condition
 
-Pool mode is signaled by the presence of `rate_n` and `rate_d` tags. When absent, the condition uses standard mode (exact `H_recv` match, as defined in [NUT-Exchange][exchange]).
+Pool mode is signaled by the presence of `rate_n` and `rate_d` tags. When absent, the condition uses standard mode (exact `H_recv` match, as defined in [NUT-Exchange][exchange]). In pool mode the base optional tags `alt_outputs`, `allow_change`, and `min_output_amount` MUST be absent: `alt_outputs` is incompatible with rule 6p's exact `H_manifest`, change is authorized by the manifest's change role (rule 8p), and `min_receive` supersedes `min_output_amount` (base rule 12).
 
 ```json
 [
@@ -39,7 +39,7 @@ Pool mode is signaled by the presence of `rate_n` and `rate_d` tags. When absent
 
 **Required tags** (same as NUT-Exchange): `offer_keyset`, `expiry`, `refund`.
 
-**Pool-mode tags** (presence signals pool mode; all four required together):
+**Pool-mode tags** (presence signals pool mode; all four required together, each appearing exactly once as a minimal unsigned decimal string with no leading zeros):
 
 - `rate_n` / `rate_d`: minimum receive rate in integer keyset minor units: at least `rate_n` receive-keyset units for every `rate_d` offer-keyset units debited. `rate_d` MUST be greater than zero. The mint enforces `receive_total × rate_d ≥ debit_total × rate_n` using checked `u128` cross-multiplication, with no division or rounding. Implementations MUST NOT convert either total to display units before this comparison. For a sat receive keyset and a USD offer keyset whose amount `1` is one cent, one sat per cent is encoded as `rate_n = 1, rate_d = 1`. The inequality admits every better price.
 - `min_receive`: minimum total receive-keyset output amount. Prevents dust fills. MUST be positive.
@@ -51,26 +51,32 @@ Every proof contributed by one participant MUST carry the same `data` and the sa
 
 The owner generates two pools of `BlindedMessage` entries:
 
-- **Receive pool:** entries in the receive keyset, at powers-of-2 denominations.
+- **Receive pool:** entries in the receive keyset, at powers-of-2 denominations (the recommended wallet construction; see below).
 - **Change pool:** entries in the offer keyset, at powers-of-2 denominations covering the possible change range.
 
 Each entry has a `role` (`receive` or `change`), `amount`, `id` (keyset), and `B_` (blinded point). The owner retains every entry's secret and blinding factor.
 
 For each participant, every `receive` entry MUST have the same `id`, called that participant's receive keyset. Every `change` entry MUST have `id` equal to the condition's `offer_keyset`. Both roles MUST be present, and the receive keyset MUST differ from `offer_keyset`; therefore each participant's complete manifest contains exactly those two keyset IDs. Across the complete exchange request, the union of every participant's `offer_keyset` and derived receive keyset MUST contain exactly two distinct keyset IDs.
 
-Pool mode uses powers-of-two denominations (`1, 2, 4, 8, ..., 2^k`), but Cashu does not guarantee that a keyset publishes those denominations. A wallet MUST inspect the [NUT-01][01] key maps for the receive and offer keysets and MUST NOT create a pool unless each keyset is active for issuance and publishes a signing key for every amount placed in that keyset's pool. The mint MUST reject a manifest if any entry's `(id, amount)` does not identify a published signing key in an active keyset. Given that denomination coverage, `⌈log₂(R+1)⌉` receive entries can represent every integer from 0 through `R`, and `⌈log₂(C+1)⌉` change entries can represent every integer from 0 through `C`. Total entries remain `O(log R + log C)`.
+The recommended wallet construction places entries at powers-of-two denominations (`1, 2, 4, 8, ..., 2^k`), because `⌈log₂(R+1)⌉` such receive entries can represent every integer from `0` through `R` by subset sum, and likewise `⌈log₂(C+1)⌉` change entries cover `0` through `C`, keeping the pool at `O(log R + log C)` entries. Cashu does not guarantee that a keyset publishes those denominations, so a wallet MUST inspect the [NUT-01][01] key maps and MUST NOT create a pool unless each keyset is active for issuance and publishes a signing key for every amount placed in that keyset's pool. The denomination sequence is a wallet-side construction: the mint authenticates only the committed manifest and verifies per entry that `(id, amount)` identifies a published signing key in an active keyset (rule 8p); it does not require any particular denomination shape.
 
 ## Manifest hash
 
 The `data` field is `H_manifest`, computed over the complete ordered `pool_manifest`. `PoolEntry` is the only name for an entry in that array and has exactly these fields:
 
 ```json
-{"index": <uint>, "role": "receive|change", "amount": <uint>, "id": "<keyset_id>", "B_": "<hex_str>"}
+{
+  "index": "<decimal_str>",
+  "role": "receive|change",
+  "amount": "<decimal_str>",
+  "id": "<keyset_id>",
+  "B_": "<hex_str>"
+}
 ```
 
-`amount` is an unsigned 64-bit integer in the minor unit of the entry's keyset ([NUT-01][01]). `pool_manifest` MUST contain all `receive` entries first and all `change` entries second. Each entry's `index` MUST equal its zero-based position in `pool_manifest`; indices are unique and contiguous from `0` through `len(pool_manifest) − 1`.
+`amount` is an unsigned 64-bit integer in the minor unit of the entry's keyset ([NUT-01][01]); `index` is the entry's zero-based position. In the canonical encoding below, both `amount` and `index` are serialized as minimal decimal strings (no leading zeros), exactly as base NUT-Exchange serializes `amount`, to avoid IEEE-754 precision loss above 2^53 ([RFC 8785][rfc8785] §3.1). `pool_manifest` MUST contain all `receive` entries first and all `change` entries second. Each entry's `index` MUST equal its zero-based position in `pool_manifest`; indices are unique and contiguous from `0` through `len(pool_manifest) − 1`.
 
-Each `PoolEntry` is encoded using the [RFC 8785][rfc8785] JCS defined by [NUT-Exchange][exchange]:
+Each `PoolEntry` is encoded using the [RFC 8785][rfc8785] JCS defined by [NUT-Exchange][exchange], with `amount` and `index` as minimal decimal strings (object keys in lexicographic order: `B_`, `amount`, `id`, `index`, `role`):
 
 ```
 manifest_canonical = JCS(pool_manifest[0]) || JCS(pool_manifest[1]) || ... || JCS(pool_manifest[n-1])
@@ -96,41 +102,43 @@ Pool-mode participants include the full manifest and a selection bitmap:
 
 - `outputs`: the selected entries only — these are the `BlindedMessage` values the mint will sign. MUST be a subset of `pool_manifest`, in manifest index order.
 - `pool_manifest`: the complete ordered array of `PoolEntry` values defined in [Manifest hash](#manifest-hash). The mint computes `H_manifest` from this array and verifies it against the condition's `data` field. This authenticates every candidate entry as part of the owner-created pool.
-- `pool_selection`: a hex-encoded bitmap selecting which manifest entries to sign. Bit `i` (0-indexed from the least-significant bit of the first byte) corresponds to `pool_manifest[i]`. Bit `1` = selected (include in `outputs`), bit `0` = skipped. Unused trailing bits MUST be zero. The selected entries, in index order, MUST exactly match the `outputs` array.
+- `pool_selection`: a hex-encoded bitmap selecting which manifest entries to sign. The bitmap is exactly `⌈len(pool_manifest) / 8⌉` bytes, encoded as lowercase hex (even-length, no `0x` prefix); a string of any other byte length MUST be rejected. Bit `i` (0-indexed from the least-significant bit of the first byte) corresponds to `pool_manifest[i]`. Bit `1` = selected (include in `outputs`), bit `0` = skipped. Unused trailing bits (bit index `≥ len(pool_manifest)`) MUST be zero. The selected entries, in index order, MUST exactly match the `outputs` array.
 
-`pool_selection` tells the mint which authenticated candidate outputs to sign. An entry whose bit is zero is an unsigned candidate, not ecash: the mint MUST NOT sign or return it, and signing every manifest entry would violate the per-class conservation rule. The full-manifest form reveals to the mint that all listed `B_` values belong to one authorization, but an unselected value never becomes a proof. After successful settlement, refund, or expiry, the owner MUST discard every unselected entry's secret and blinding factor and MUST NOT reuse its `B_`; a later transaction requiring that denomination MUST generate a fresh secret, blinding factor, and `B_`.
+`pool_selection` tells the mint which authenticated candidate outputs to sign. An entry whose bit is zero is an unsigned candidate, not ecash: the mint MUST NOT sign or return it, and signing every manifest entry would violate the per-class conservation rule. The full-manifest form reveals to the mint that all listed `B_` values belong to one authorization, but an unselected value never becomes a proof. The owner MUST NOT discard any unselected entry's secret or blinding factor, or reuse its `B_`, until it has a definitive settlement outcome for the authorization: if no settlement response was received, the owner MUST first determine whether the mint spent the inputs and, if so, recover the actually-signed signatures via [NUT-09][09] by submitting every manifest entry's `BlindedMessage` (only entries the mint did not sign may then be discarded). After successful settlement, refund, or post-expiry recovery, a later transaction requiring that denomination MUST generate a fresh secret, blinding factor, and `B_`.
 
 Example: a five-entry manifest has receive entries at manifest indices 0, 1, and 2 and change entries at manifest indices 3 and 4. Selecting manifest entries 0, 2, and 4 produces the bitmap `0b00010101` = `0x15`; therefore `pool_selection = "15"`, and `outputs` contains `pool_manifest[0]`, `pool_manifest[2]`, and `pool_manifest[4]`, in that order.
 
-Non-pool-mode participants omit `pool_manifest` and `pool_selection` (standard NUT-Exchange behavior).
+A single `/v1/exchange` request MAY mix pool-mode and standard-mode participants. Standard-mode participants omit `pool_manifest` and `pool_selection` and are validated under base [NUT-Exchange][exchange] rules; rule 8p derives each participant's receive keyset per mode — from the manifest for pool mode, from the outputs for standard mode.
 
-Version 1 uses the full manifest. Pool size is logarithmic in the representable receive and change ranges, and every request remains subject to both `max_pool_entries` per participant and NUT-Exchange's `max_request_bytes` for the complete request. The mint MUST reject a request exceeding either limit, and a wallet MUST NOT create a pool-mode authorization that cannot fit both advertised limits. Merkle roots and inclusion proofs are not valid version-1 request forms. A future Merkle form MUST use a separately advertised version or mode that defines the leaf encoding, global index binding, tree construction and domain separation, proof encoding, and proof-size limits.
+Version 1 uses the full manifest. Pool size is logarithmic in the representable receive and change ranges, and every request remains subject to both `max_pool_entries` per participant and NUT-Exchange's `max_request_bytes` for the complete request. The mint MUST reject a request exceeding either limit, and a wallet MUST NOT create a pool-mode authorization that cannot fit both advertised limits. For idempotent retries, a pool-mode participant's canonical record (and thus `request_digest`) includes `pool_manifest` and `pool_selection` in addition to `inputs` and `outputs`, so two requests differing only in manifest or selection cannot alias to one cached response. Merkle roots and inclusion proofs are not valid version-1 request forms. A future Merkle form MUST use a separately advertised version or mode that defines the leaf encoding, global index binding, tree construction and domain separation, proof encoding, and proof-size limits.
 
 Response: same as NUT-Exchange — `{signatures: [...]}`, one `BlindSignature` array per participant. Pool-mode participants receive signatures for their selected entries only.
 
 ## Mint validation
 
-Pool-mode participants require additional validation beyond [NUT-Exchange][exchange] rules 1–5, 9, 11:
+Pool-mode participants require additional validation beyond [NUT-Exchange][exchange] rules 1–5, 9, 11. Rule 3's tag grammar is extended for pool mode: the four pool tags are required and the base optional tags `alt_outputs`, `allow_change`, and `min_output_amount` are forbidden (error 15001); rule 12 (`min_output_amount`) is superseded by rule 9p's `min_receive`:
 
-6p. **Manifest hash:** hash `pool_manifest` canonically → MUST equal condition `data`. Otherwise reject (error 13041).
+6p. **Manifest hash:** hash `pool_manifest` canonically → MUST equal condition `data`. Otherwise reject (error 15011).
 
-7p. **Selection consistency:** the entries indicated by `pool_selection` MUST exactly match the `outputs` array (same `B_`, `amount`, `id` values in the same order). Otherwise reject.
+7p. **Selection consistency:** the entries indicated by `pool_selection` MUST exactly match the `outputs` array (same `B_`, `amount`, `id` values in the same order), and `pool_selection` MUST be the canonical bitmap encoding from [Request format](#request-format). Otherwise reject (error 15012).
 
-8p. **Role/keyset and two-class consistency:** validate the entire `pool_manifest`, not only selected entries. For each participant, all `receive` entries MUST share one `id`; all `change` entries MUST use the condition's `offer_keyset`; both roles MUST be present; and the derived receive keyset MUST differ from `offer_keyset`. No other keyset ID may occur in that manifest. Across all participants, exactly two distinct keyset IDs MUST occur among all conditions' `offer_keyset` values and all derived receive keysets. At least one `receive` entry MUST be selected for each participant. For every manifest entry, the mint MUST also verify that `id` is active for issuance and that the keyset publishes a signing key for `amount`.
+8p. **Role/keyset and two-class consistency:** validate the entire `pool_manifest`, not only selected entries. For each pool-mode participant, all `receive` entries MUST share one `id`; all `change` entries MUST use the condition's `offer_keyset`; both roles MUST be present; and the derived receive keyset MUST differ from `offer_keyset`. No other keyset ID may occur in that manifest. Each participant's receive keyset is derived per mode — from the manifest for pool-mode participants, from the outputs under base rule 7 for standard-mode participants. Across all participants, exactly two distinct keyset IDs MUST occur among all conditions' `offer_keyset` values and all derived receive keysets. For every manifest entry, the mint MUST verify that `id` is a known, active keyset (else errors 12001/12002) and that the keyset publishes a signing key for `amount`. Violations of the role, per-mode, or two-class rules are rejected with error 15013.
 
-9p. **Policy:** parse `rate_n`, `rate_d`, `min_receive`, and `max_debit` as unsigned `u128` values. Reject if parsing fails, if `rate_d = 0`, or if `min_receive = 0`. Using checked `u128` addition, compute `input_total` from the participant's inputs, `receive_total` from selected receive entries, and `change_total` from selected change entries. Reject if any conversion or sum overflows, if `max_debit > input_total`, or if `change_total > input_total`. Only after those checks, compute `debit_total = input_total − change_total` with checked subtraction. Compute both rate products with checked multiplication and reject if either product overflows. Then enforce:
+9p. **Policy:** parse `rate_n`, `rate_d`, `min_receive`, and `max_debit` as unsigned `u128` values. Reject if parsing fails, if `rate_d = 0`, or if `min_receive = 0`. Using checked `u128` addition, compute `input_total` from the participant's inputs, `receive_total` from selected receive entries, and `change_total` from selected change entries. Reject if any conversion or sum overflows, if `max_debit > input_total`, or if `change_total > input_total`. Only after those checks, compute `debit_total = input_total − change_total` with checked subtraction. Compute both rate products with checked multiplication and reject if either product overflows. Then enforce (reject with error 15014 on any failure):
 
 - `receive_total × rate_d ≥ debit_total × rate_n` (rate covenant)
-- `receive_total ≥ min_receive` (minimum fill)
+- `receive_total ≥ min_receive` (minimum fill, which also requires at least one selected `receive` entry)
 - `debit_total ≤ max_debit` (spending cap)
 
-10p. **Conservation:** standard per-class conservation from [NUT-Exchange][exchange] rule 10, applied with change entries in the offer keyset. The mint signs only `outputs`; `pool_manifest` entries are authentication material, not outputs to sign.
+`debit_total` is gross of fees. Rule 10p burns `input_fees_c` from each offer class `c`, so the value actually delivered to the opposing side is `debit_total − input_fees_offer` in a two-party exchange and, in general, `Σ(debit_total over participants offering c) − input_fees_c` per class `c`. The rate covenant and spending cap use the gross `debit_total`; the worked examples below assume zero input fees.
 
-NUT-Exchange rule 7's per-participant single-keyset output constraint is replaced by rule 8p because selected pool outputs may use both that participant's receive keyset and offer keyset for change. NUT-Exchange rule 8's exactly-two-keysets invariant is not relaxed; rule 8p applies it to the keysets derived from every complete manifest and to the request as a whole.
+10p. **Conservation:** standard per-class conservation from [NUT-Exchange][exchange] rule 10, applied with change entries in the offer keyset (rejection uses error 11005). The mint signs only `outputs`; `pool_manifest` entries are authentication material, not outputs to sign.
+
+NUT-Exchange rule 7's per-participant single-keyset output constraint is replaced by rule 8p for pool-mode participants, because selected pool outputs may use both that participant's receive keyset and offer keyset for change; standard-mode participants still follow base rule 7. NUT-Exchange rule 8's exactly-two-keysets invariant is not relaxed; rule 8p applies it to the receive keysets derived per mode (manifest or outputs) and to the request as a whole.
 
 ## Example
 
-Alice wants to swap **10000 cents (100 USD) for 1000 sats**. Here `input_total = 10000` cents is the value locked in the authorization; `max_debit = 1000` permits at most 1000 cents to be spent, so a complete 1000-sat fill at Alice's boundary rate returns 9000 cents as change.
+Alice wants to swap **10000 cents (100 USD) for 1000 sats** at a limit of 10 cents per sat. Here `input_total = 10000` cents is the value locked in the authorization and `max_debit = 10000` permits the full input to be spent, so a complete 1000-sat fill at Alice's boundary rate (10 cents/sat) returns 0 cents as change; any partial or better-price fill returns the unspent portion as change.
 
 ### Preparation
 
@@ -140,55 +148,55 @@ Alice wants to swap **10000 cents (100 USD) for 1000 sats**. Here `input_total =
 
 **Manifest:** 24 entries. `H_manifest` is computed from the canonical `PoolEntry` encodings defined above.
 
-**Policy:** `rate_n = 1, rate_d = 1` (receive at least 1 sat per cent debited), `min_receive = 1` sat, `max_debit = 1000` cents.
+**Policy:** `rate_n = 1, rate_d = 10` (receive at least 1 sat per 10 cents debited, i.e., pay at most 10 cents per sat), `min_receive = 1` sat, `max_debit = 10000` cents.
 
 **Lock:** one or more `PAY_TO_UNLOCK` proofs totaling 10000 cents, all carrying the same manifest and policy tags and unique per-proof nonces.
 
 ### Settlement — boundary fill of 500 sats
 
-Counterparty offers 500 sats for 500 cents.
+Counterparty offers 500 sats for 5000 cents (the boundary rate of 10 cents/sat).
 
 Coordinator selects:
 
 - Receive: {256, 128, 64, 32, 16, 4} = 500 sats (6 entries)
-- Change: {8192, 1024, 256, 16, 8, 4} = 9500 cents (6 entries)
+- Change: {4096, 512, 256, 128, 8} = 5000 cents (5 entries)
 
 Mint checks:
 
 - `H_manifest` matches condition `data` ✓
 - Selected entries exactly match the bitmap and `outputs` ✓
-- `input_total = 10000`, `change_total = 9500`, so `debit_total = 10000 − 9500 = 500` cents ✓
-- Rate boundary: `500 × 1 ≥ 500 × 1` → `500 ≥ 500` ✓
+- `input_total = 10000`, `change_total = 5000`, so `debit_total = 10000 − 5000 = 5000` cents ✓
+- Rate boundary: `500 × 10 ≥ 5000 × 1` → `5000 ≥ 5000` ✓
 - `receive_total = 500 ≥ min_receive = 1` ✓
-- `debit_total = 500 ≤ max_debit = 1000` ✓
-- Conservation: 10000 cents in = 9500 cents change + 500 cents to the counterparty; 500 sats in = 500 sats out ✓
+- `debit_total = 5000 ≤ max_debit = 10000` ✓
+- Conservation (zero input fees): 10000 cents in = 5000 cents change + 5000 cents to the counterparty; 500 sats in = 500 sats out ✓
 
-Equality is accepted: this is exactly Alice's limit of one sat per cent. If the counterparty instead offered 499 sats for the same 500-cent debit, the mint would evaluate `499 × 1 ≥ 500 × 1`, which is false, and MUST reject the request.
+Equality is accepted: this is exactly Alice's limit of 10 cents per sat. If the counterparty instead offered 499 sats for the same 5000-cent debit, the mint would evaluate `499 × 10 ≥ 5000 × 1` → `4990 ≥ 5000`, which is false, and MUST reject the request.
 
-The mint signs Alice's 12 selected `BlindedMessage` values. Alice unblinds them to obtain 500 sats and 9500 cents of change.
+The mint signs Alice's 11 selected `BlindedMessage` values (6 receive + 5 change). Alice unblinds them to obtain 500 sats and 5000 cents of change.
 
 ### Settlement — better-price partial fill of 237 sats
 
-Counterparty offers 237 sats for 200 cents (2.00 USD).
+Counterparty offers 237 sats for 2000 cents (20.00 USD).
 
 Coordinator selects:
 
 - Receive: {128, 64, 32, 8, 4, 1} = 237 sats (6 entries)
-- Change: {8192, 1024, 512, 64, 8} = 9800 cents (5 entries)
+- Change: {4096, 2048, 1024, 512, 256, 64} = 8000 cents (6 entries)
 
 Mint checks:
 
-- `input_total = 10000`, `change_total = 9800`, so `debit_total = 200` cents ✓
-- Rate: `237 × 1 ≥ 200 × 1` → `237 ≥ 200` ✓
+- `input_total = 10000`, `change_total = 8000`, so `debit_total = 2000` cents ✓
+- Rate: `237 × 10 ≥ 2000 × 1` → `2370 ≥ 2000` ✓
 - `receive_total = 237 ≥ min_receive = 1` ✓
-- `debit_total = 200 ≤ max_debit = 1000` ✓
-- Conservation: 10000 cents in = 9800 cents change + 200 cents to the counterparty; 237 sats in = 237 sats out ✓
+- `debit_total = 2000 ≤ max_debit = 10000` ✓
+- Conservation (zero input fees): 10000 cents in = 8000 cents change + 2000 cents to the counterparty; 237 sats in = 237 sats out ✓
 
-The strict inequality admits this better price: Alice pays `200 / 237` cents per sat, less than her maximum of one cent per sat. The mint signs Alice's 11 selected `BlindedMessage` values, and Alice unblinds them to obtain 237 sats and 9800 cents of change.
+The strict inequality admits this better price: Alice pays `2000 / 237` ≈ 8.44 cents per sat, less than her maximum of 10 cents per sat. The mint signs Alice's 12 selected `BlindedMessage` values (6 receive + 6 change), and Alice unblinds them to obtain 237 sats and 8000 cents of change.
 
 ## Recovery and refund
 
-Identical to [NUT-Exchange][exchange]. Pool-mode proofs carry the same `expiry` and `refund` tags. After `expiry`, the owner refunds via NUT-03 swap with a `refund` signature. Unused pool entries are simply discarded — they were never spent.
+Identical to [NUT-Exchange][exchange]. Pool-mode proofs carry the same `expiry` and `refund` tags. After `expiry`, the owner refunds via NUT-03 swap with a `refund` signature. In the refund path the exchange never committed, so unused pool entries were never signed and may be discarded once the refund is complete; the discard safety rule in [Request format](#request-format) governs the settlement-loss case.
 
 ## Mint info
 

--- a/exchange-partial-fill.md
+++ b/exchange-partial-fill.md
@@ -1,0 +1,219 @@
+# NUT-Exchange-partial-fill: Partial-Fill Authorization
+
+`draft`
+
+`optional`
+
+`depends on: NUT-Exchange, NUT-02, NUT-03, NUT-06, NUT-09, NUT-10, NUT-11, NUT-12`
+
+---
+
+This NUT extends [NUT-Exchange][exchange]'s `PAY_TO_UNLOCK` condition with a **pool-based authorization mode** that enables FAK (fill-and-kill) orders: the owner locks a single input and authorizes a **range** of possible output bundles, with the actual fill amount determined at match time.
+
+In standard mode (NUT-Exchange), `data` is `H_recv` — a hash of one exact output bundle. In pool mode (this NUT), `data` is a manifest hash over a small set of pre-generated output entries in binary denominations, plus a numeric rate policy that the mint enforces. The coordinator selects any subset satisfying the policy; the mint signs only the selected entries.
+
+Readers should be familiar with [NUT-Exchange][exchange] (`PAY_TO_UNLOCK`, conservation rules, recovery, refund, the `participants` request shape).
+
+## Condition
+
+Pool mode is signaled by the presence of `rate_n` and `rate_d` tags. When absent, the condition uses standard mode (exact `H_recv` match, as defined in [NUT-Exchange][exchange]).
+
+```json
+[
+  "PAY_TO_UNLOCK",
+  {
+    "nonce": "<hex_str: 32 bytes>",
+    "data": "<hex_str: H_manifest>",
+    "tags": [
+      ["offer_keyset", "<keyset_id>"],
+      ["expiry", "<unix_seconds_str>"],
+      ["refund", "<xonly_pubkey_hex>"],
+      ["rate_n", "<uint_str>"],
+      ["rate_d", "<uint_str>"],
+      ["min_receive", "<uint_str>"],
+      ["max_debit", "<uint_str>"]
+    ]
+  }
+]
+```
+
+**Required tags** (same as NUT-Exchange): `offer_keyset`, `expiry`, `refund`.
+
+**Pool-mode tags** (presence signals pool mode; all four required together):
+
+- `rate_n` / `rate_d`: minimum receive rate, expressed as a rational `rate_n / rate_d`. The mint enforces `receive_total × rate_d ≥ debit_total × rate_n` using checked `u128` cross-multiplication (no division, no rounding ambiguity). This is an **inequality** — better prices are automatically admitted.
+- `min_receive`: minimum total receive-keyset output amount. Prevents dust fills. MUST be positive.
+- `max_debit`: maximum total debit (`input_total − change_total`). Caps the spending. MUST be ≤ the participant's input total.
+
+Every proof contributed by one participant MUST carry the same condition (same `nonce`, `data`, tags), with unique per-proof nonces (same rule as [NUT-Exchange][exchange]).
+
+## Output pools
+
+The owner generates two pools of `BlindedMessage` entries:
+
+- **Receive pool:** entries in the receive keyset, at powers-of-2 denominations (1, 2, 4, 8, ..., 2^k). Any subset sums to any integer from 0 to `2^(k+1) − 1`.
+- **Change pool:** entries in the offer keyset, at powers-of-2 denominations covering the possible change range.
+
+Each entry has a `role` (`receive` or `change`), `amount`, `id` (keyset), and `B_` (blinded point). The owner retains every entry's secret and blinding factor.
+
+**Recommended denomination sets:** for a max receive of `R` units, use `⌈log₂(R+1)⌉` entries (1, 2, 4, ..., 2^(k-1)). For a max change of `C` units, use `⌈log₂(C+1)⌉` entries. Total entries: `O(log R + log C)` — typically 15–25 for most orders.
+
+**Non-power-of-2 keysets:** if the keyset does not support power-of-2 amounts, the owner must choose a denomination set that covers the needed range. The wallet cost is `O(pool_size)` regardless of denomination structure.
+
+## Manifest hash
+
+The `data` field is `H_manifest`, computed over the canonical encoding of all pool entries:
+
+```
+manifest_canonical = entry[0]_canonical || entry[1]_canonical || ... || entry[n-1]_canonical
+H_manifest = tagged_hash("Cashu/PAY_TO_UNLOCK/manifest", manifest_canonical)
+```
+
+Each `entry_canonical` is the JCS encoding of:
+
+```json
+{"amount":"<decimal_str>","B_":"<hex>","id":"<keyset_id>","index":<uint>,"role":"receive|change"}
+```
+
+Entries are sorted by `(role, index)`. Amounts are decimal strings (same precision rule as [NUT-Exchange][exchange]). The `index` field ensures unambiguous ordering even with duplicate amounts.
+
+## Request format
+
+Pool-mode participants include the full manifest and a selection bitmap:
+
+```json
+{
+  "participants": [
+    {
+      "inputs": "<Array[Proof]>",
+      "outputs": "<Array[BlindedMessage] — selected entries only>",
+      "pool_manifest": "<Array[PoolEntry] — all entries>",
+      "pool_selection": "<hex_str — bitmap over manifest indices>"
+    }
+  ]
+}
+```
+
+- `outputs`: the selected entries only — these are the entries the mint will sign.
+- `pool_manifest`: all pool entries (receive + change), in canonical order.
+- `pool_selection`: hex-encoded bitmap where bit `i` indicates whether manifest entry `i` is selected.
+
+Non-pool-mode participants omit `pool_manifest` and `pool_selection` (standard NUT-Exchange behavior).
+
+Response: same as NUT-Exchange — `{signatures: [...]}`, one `BlindSignature` array per participant. Pool-mode participants receive signatures for their selected entries only.
+
+## Mint validation
+
+Pool-mode participants require additional validation beyond [NUT-Exchange][exchange] rules 1–5, 9, 11:
+
+6p. **Manifest hash:** hash `pool_manifest` canonically → MUST equal condition `data`. Otherwise reject (error 13041).
+
+7p. **Selection consistency:** the entries indicated by `pool_selection` MUST exactly match the `outputs` array (same `B_`, `amount`, `id` values in the same order). Otherwise reject.
+
+8p. **Role/keyset consistency:** every selected `receive` entry MUST use the receive keyset (derived from the manifest's `role` field); every selected `change` entry MUST use the offer keyset. At least one `receive` entry MUST be selected.
+
+9p. **Policy:** compute `receive_total` (sum of selected receive amounts) and `debit_total` (input total − sum of selected change amounts). Enforce using checked `u128` arithmetic:
+
+- `receive_total × rate_d ≥ debit_total × rate_n` (rate covenant)
+- `receive_total ≥ min_receive` (minimum fill)
+- `debit_total ≤ max_debit` (spending cap)
+
+10p. **Conservation:** standard per-class conservation from [NUT-Exchange][exchange] rule 10, applied with change entries in the offer keyset. The mint signs only `outputs`; `pool_manifest` entries are authentication material, not outputs to sign.
+
+Standard rules 7–8 from NUT-Exchange (single-keyset output constraint, two-keyset exchange) are **relaxed** for pool mode: outputs may use both the receive and offer keysets (change), exactly as with `allow_change` in NUT-Exchange.
+
+## Example
+
+Alice wants to swap **10 USD for up to 1000 sats** at price **≤ 0.01 USD/sat**.
+
+### Preparation
+
+**Receive pool** (sats keyset, 10 entries): amounts 1, 2, 4, 8, 16, 32, 64, 128, 256, 512. Any subset sums to 0–1023.
+
+**Change pool** (USD keyset, 11 entries): amounts 0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12 (covering 0–10.23 USD). _(Adjust denominations to match keyset's supported amounts.)_
+
+**Manifest:** 21 entries. `H_manifest = hash(canonical encoding)`.
+
+**Policy:** `rate_n = 1, rate_d = 100` (receive ≥ 100 sats per USD debited), `min_receive = 1`, `max_debit = 1000` (cents).
+
+**Lock:** one 10-USD `PAY_TO_UNLOCK` proof in pool mode.
+
+### Settlement — fill 500 sats
+
+Counterparty offers 500 sats for 5 USD.
+
+Coordinator selects:
+
+- Receive: {256, 128, 64, 32, 16, 4} = 500 sats (6 entries)
+- Change: {5.12... } → nearest representable set summing to ~5 USD
+
+Mint checks:
+
+- `H_manifest` matches condition `data` ✓
+- Selected entries match bitmap ✓
+- `receive_total = 500`, `debit_total = 500` (cents)
+- `500 × 100 ≥ 500 × 1` → `50000 ≥ 500` ✓ (price well within limit)
+- `500 ≥ 1` ✓, `500 ≤ 1000` ✓
+- Conservation: 10 USD in = 5 USD change + 5 USD to counterparty. 500 sats in = 500 sats out. ✓
+
+Mint signs 8 selected BlindedMessages. Alice unblinds to get 500 sats + 5 USD change.
+
+### Settlement — partial fill 237 sats
+
+Counterparty offers 237 sats for ~2.37 USD.
+
+Coordinator searches for a valid (receive, change) pair:
+
+- Receive: {128, 64, 32, 8, 4, 1} = 237 sats
+- Change: subset summing to ~7.63 USD → nearest representable
+- Check: `237 × 100 ≥ debit × 1` → debit ≤ 23700 cents = 237 USD... wait, units.
+
+_(The coordinator optimizes over all valid subsets. The rate covenant ensures Alice never pays more than 0.01 USD/sat. The denomination granularity determines the exact achievable price.)_
+
+## Recovery and refund
+
+Identical to [NUT-Exchange][exchange]. Pool-mode proofs carry the same `expiry` and `refund` tags. After `expiry`, the owner refunds via NUT-03 swap with a `refund` signature. Unused pool entries are simply discarded — they were never spent.
+
+## Mint info
+
+Pool-mode support is advertised via [NUT-06][06]:
+
+```json
+{
+  "exchange": {
+    "supported": true,
+    "partial_fill": true,
+    "max_pool_entries": "<uint>"
+  }
+}
+```
+
+`max_pool_entries` bounds the total number of manifest entries per participant. A wallet MUST NOT create pool-mode conditions exceeding this limit.
+
+## FAQ
+
+**Why powers-of-2 denominations?**
+`⌈log₂(N)⌉` entries cover every integer from 0 to `N−1` via subset sum. For a 1000-unit range: 10 entries. This keeps wallet cost logarithmic.
+
+**Can the coordinator steal outputs?**
+No. Every selected entry must be in Alice's authenticated manifest (verified by `H_manifest`). The coordinator can only select entries Alice pre-generated with her own blinding factors. It cannot inject its own `BlindedMessage` values.
+
+**Does the mint enforce best execution?**
+No. The rate covenant enforces the owner's limit price. Any subset satisfying the covenant is valid. The coordinator may select the least favorable valid pair. Best execution is an off-mint concern.
+
+**How does this differ from `alt_outputs`?**
+`alt_outputs` enumerates complete bundles (O(T) preprocessing for T fill scenarios). Pool mode generates O(log N) entries and lets the mint evaluate a numeric policy. Pool mode scales to fine-grained FAK; `alt_outputs` does not.
+
+## References
+
+- [NUT-Exchange][exchange] · [NUT-02](02.md) · [NUT-03](03.md) · [NUT-06](06.md) ·
+  [NUT-09](09.md) · [NUT-10](10.md) · [NUT-11](11.md) · [NUT-12](12.md)
+
+[02]: 02.md
+[03]: 03.md
+[06]: 06.md
+[09]: 09.md
+[10]: 10.md
+[11]: 11.md
+[12]: 12.md
+[exchange]: https://github.com/cashubtc/nuts/pull/410

--- a/exchange.md
+++ b/exchange.md
@@ -62,7 +62,7 @@ here. Two mitigations bound the added trust:
    This is incidental verifiability, not a published audit log.
 2. **Anonymity makes betrayal indiscriminate.** Fresh `swap_id`, refund key,
    proof secret, and output secret per authorization carry no stable owner
-   identity, so the mint cannot *selectively* betray a user. It can still censor,
+   identity, so the mint cannot _selectively_ betray a user. It can still censor,
    deny service, or betray an exchange wholesale — the same issuer trust NUT-11
    carries.
 
@@ -412,7 +412,7 @@ destination key would not give the same blind-issuance guarantee and would weake
 Cashu privacy.
 
 **Can a submitter or coordinator steal the funds?**
-No. (1) It receives only the *blinded* receive messages `B_`; without the
+No. (1) It receives only the _blinded_ receive messages `B_`; without the
 blinding factors it cannot unblind the returned signatures into spendable proofs,
 so it cannot steal what is received. (2) The input proofs it relays are locked by
 `PAY_TO_UNLOCK` to the owner's exact receive outputs, so it cannot redirect the

--- a/exchange.md
+++ b/exchange.md
@@ -453,7 +453,7 @@ worst delay notification or refuse to submit.
 - [NUT-02](02.md) · [NUT-03](03.md) · [NUT-06](06.md) · [NUT-07](07.md) ·
   [NUT-09](09.md) · [NUT-10](10.md) · [NUT-11](11.md) · [NUT-12](12.md) · [NUT-21](21.md) · [NUT-22](22.md)
 - [Maurice Herlihy, Atomic Cross-Chain Swaps](https://arxiv.org/abs/1801.09515)
-  — leader/follower topology and timelock hierarchy (the *structure* of an
+  — leader/follower topology and timelock hierarchy (the _structure_ of an
   adaptor-sig/HTLC swap).
 - [Mazumdar et al., Towards Faster Settlement in HTLC-based Cross-Chain
   Swaps](https://arxiv.org/abs/2211.15804) — the American-call-option-without-premium

--- a/exchange.md
+++ b/exchange.md
@@ -10,8 +10,8 @@
 
 This NUT defines an atomic exchange of two existing Cashu asset classes at one
 mint. Two or more participants each contribute bearer proofs of one asset class
-and commit to exact blinded receive outputs of the other class. The mint spends
-every input and signs every output in a single database transaction, or changes
+and commit to blinded receive outputs of the other class. The mint spends every
+input and signs every output in a single database transaction, or changes
 nothing.
 
 ## Premise
@@ -34,12 +34,12 @@ creates.
 
 ### Model
 
-Each participant first locks its bearer proofs to an exact receive-output
-commitment via a [NUT-10][10] `PAY_TO_UNLOCK` condition. The participants'
-conditioned proofs and public receive descriptors are assembled into one
-settlement request and submitted to the mint. The mint validates every condition
-and conserves each asset class independently, then commits all input spends and
-all output signatures in one transaction — or changes nothing.
+Each participant first locks its bearer proofs to a receive-output commitment
+via a [NUT-10][10] `PAY_TO_UNLOCK` condition. The participants' conditioned
+proofs and public receive descriptors are assembled into one settlement request
+and submitted to the mint. The mint validates every condition and conserves
+each asset class independently, then commits all input spends and all output
+signatures in one transaction — or changes nothing.
 
 Two preparation patterns are supported: a **direct two-party swap** where both
 participants are online, and a **coordinator-mediated swap** where a relay
@@ -70,17 +70,16 @@ here. Two mitigations bound the added trust:
 Version 1 supports:
 
 - one mint;
-- two or more participants in one atomic two-class exchange (any N-vs-M shape,
-  e.g. one taker against one or more makers, or multiple makers on both sides);
+- two or more participants in one atomic two-class exchange (any N-vs-M shape);
 - exactly two existing asset classes, one offered per side;
-- exact, owner-precommitted blinded receive outputs;
+- owner-precommitted blinded receive outputs, with optional change outputs in the
+  offer keyset and alternative output bundles for FAK-style orders;
 - per-asset-class conservation; and
 - one atomic commit (all participants settle or none).
 
 Version 1 does **not** support: a coordinator as a required party; cross-mint
-settlement; general N-way cycles (A wants B, B wants C, C wants A) that would
-require a solver; partial fills of one authorization; a mutable remaining
-balance; a venue-selected price or amount range; asset creation or destruction.
+settlement; general N-way cycles that would require a solver; asset creation or
+destruction.
 
 Separate `/v1/exchange` calls are independent: a failure or retry of one never
 rolls back another, since each is its own database transaction.
@@ -96,58 +95,89 @@ rolls back another, since each is its own database transaction.
   receives the other.
 - **Submitter**: whoever posts the settlement request to the mint — a participant
   or a relay. It is not a custody role.
+- **Change output**: an output in the participant's offer keyset, returning
+  unspent input value. Enabled by the condition's `allow_change` tag (see below).
 
 ### `PAY_TO_UNLOCK` condition
 
-A new [NUT-10][10] well-known secret `kind` named `PAY_TO_UNLOCK`. A proof
-carrying it authorizes one exact exchange.
+A [NUT-10][10] well-known secret `kind` named `PAY_TO_UNLOCK`. A proof carrying
+it authorises one exact exchange — or, if `alt_outputs` is present, one exchange
+chosen from a finite set of owner-authorised output bundles.
 
 ```json
 [
   "PAY_TO_UNLOCK",
   {
     "nonce": "<hex_str: 32 bytes>",
-    "data": "<hex_str: H_recv>",
+    "data": "<hex_str: H_recv (primary bundle)>",
     "tags": [
       ["offer_keyset", "<keyset_id>"],
       ["expiry", "<unix_seconds_str>"],
-      ["refund", "<xonly_pubkey_hex>"]
+      ["refund", "<xonly_pubkey_hex>"],
+      ["alt_outputs", "<H_recv_alt_1>", "<H_recv_alt_2>", "..."],
+      ["allow_change"],
+      ["min_output_amount", "<uint_str>"]
     ]
   }
 ]
 ```
 
-- `data` is `H_recv`, the commitment to this participant's complete ordered
-  receive-output list (see [Receive-output commitment](#receive-output-commitment)).
-- `offer_keyset` binds the participant's offered asset class. The receive asset class is the common `id` of all entries in the output bundle (authenticated by `H_recv`).
-- `expiry` is a unix timestamp checked against the mint clock. It is the binding
-  window of the commitment: settlement is valid only before it and refund only
-  after it (the two states are mutually exclusive). It MUST be set; a short window
-  (seconds to minutes) keeps a resting offer reliable without long lockup.
-- `refund` is a fresh x-only public key whose private half the owner retains. A
-  signature under it authorizes the reclaim path, valid only after `expiry`. A
-  wallet MUST use a fresh refund key per authorization and MUST NOT share its
-  private half (see [Refund](#refund)).
+**Required tags** (MUST appear exactly once):
 
-The condition answers one question:
+- `offer_keyset`: binds the participant's offered asset class. The mint MUST
+  verify `offer_keyset == Proof.id` on every input (prevents keyset-ID relabeling
+  when verification keys are shared across keysets).
+- `expiry`: unix timestamp. Settlement valid only before it; refund only after.
+- `refund`: fresh x-only public key whose private half the owner retains.
 
-> May this proof be consumed by a transaction that atomically creates exactly
-> these blinded outputs?
+**Optional tags** (MAY appear; each at most once):
 
-Every proof contributed by one participant MUST carry the same `offer_keyset`,
-`H_recv`, `expiry`, and `refund`. Across the exchange, the set of `offer_keyset`
-values MUST equal the set of receive keysets (the common output `id` of each
-participant's bundle, authenticated by `H_recv`) — i.e. every asset class offered
-by some participant is received by some (other) participant, and vice versa.
-Per-class amount conservation is rule 10's job, so
-the count of participants on each side is unconstrained: 1-vs-N, N-vs-M, and
-N-vs-N are all valid two-class shapes. In the common shape, one side offers
-class `X` and receives `Y`; the other side offers `Y` and receives `X`.
+- `alt_outputs`: authorises a finite set of alternative output bundles in
+  addition to the primary `data`. Each value is a `H_recv` computed identically
+  to `data`. The submitted output bundle MUST hash to `data` or any listed
+  alternative. Enables FAK-style orders where the actual fill amount varies (each
+  bundle includes a different change amount). All inputs in one participant
+  record MUST carry the identical `alt_outputs` set.
+- `allow_change`: if present, outputs MAY include entries in the offer keyset
+  (change outputs) in addition to entries in the receive keyset. Without this
+  tag, all outputs MUST use a single keyset (the receive keyset). See [Change
+  outputs](#change-outputs).
+- `min_output_amount`: minimum total receive-keyset output amount (excluding
+  change). The mint MUST reject if the actual receive output is below this floor.
+  Prevents a coordinator from filling a tiny amount to consume the authorization
+  and force a refund.
+
+Unknown tags MUST be rejected. `expiry` is decimal unix seconds without leading
+zeros. Keyset IDs use their [NUT-02][02] canonical form; the refund key is a
+BIP-340 x-only pubkey in hex.
+
+Every proof contributed by one participant MUST carry the same condition (same
+`nonce`, `data`, tags, `expiry`, `refund`). Across the exchange, the set of
+`offer_keyset` values MUST equal the set of receive keysets — i.e. every asset
+class offered by some participant is received by some (other) participant, and
+vice versa.
+
+### Change outputs
+
+When `allow_change` is present, a participant's output bundle MAY contain entries
+in both the receive keyset and the offer keyset. The receive-keyset entries are
+the participant's desired receive amount; the offer-keyset entries are change
+returned from unspent input.
+
+The mint determines the correct change amount from per-class conservation (rule
+10): `change = sum(inputs_offer) − sum(outputs_offer_to_counterparties) − fees`.
+The change outputs MUST be included in the committed bundle (`H_recv` or an
+`alt_outputs` entry) — the coordinator cannot insert its own change outputs
+because it lacks the owner's blinding factors.
+
+Change outputs do NOT add a third asset class. The exchange still has exactly two
+keysets: the offer keyset (now appearing on both input and output sides) and the
+receive keyset.
 
 ### Receive-output commitment
 
-The receive destination is the owner's ordered list of `BlindedMessage` values.
-The canonical encoding of one entry is:
+The receive destination is the owner's ordered list of `BlindedMessage` values,
+including any change outputs. The canonical encoding of one entry is:
 
 ```json
 {"amount": <uint>, "id": "<keyset_id>", "B_": "<hex_str>"}
@@ -158,7 +188,7 @@ of entries in declared order. Each `entry_canonical` is the entry serialized wit
 the [RFC 8785][rfc8785] JSON Canonicalization Scheme (JCS): UTF-8, object keys in
 lexicographic order, minimal number serialization, no insignificant whitespace.
 The length prefix is a 4-byte little-endian unsigned integer recording the
-**entry count** (not byte length; output lists are not capped at 255):
+**entry count** (not byte length):
 
 ```
 recv_canonical = uint32_le(len) || entry[0]_canonical || ... || entry[n-1]_canonical
@@ -170,9 +200,7 @@ Amounts are unsigned 64-bit integers; the mint MUST reject outputs whose amounts
 are not representable as u64.
 
 Duplicate entries, unknown fields, non-canonical encodings, and list-prefix
-matches MUST be rejected. A separate receive public key is not required: only the
-wallet that created the blinded messages knows the secrets and blinding factors
-needed to unblind the mint's signatures.
+matches MUST be rejected.
 
 ### Canonical encodings
 
@@ -182,18 +210,16 @@ needed to unblind the mint's signatures.
   exactly the field set defined in [NUT-00][00]; unknown or extra fields MUST be
   rejected.
 - **Amounts**: encoded as JSON numbers per JCS, MUST be unsigned integers in
-  `[0, 2^64)`. The mint MUST use checked, non-wrapping arithmetic for all sums
-  in validation rule 10.
-- **`PAY_TO_UNLOCK` condition**: each of the three tags (`offer_keyset`,
-  `expiry`, `refund`) MUST appear exactly once; unknown or duplicate tags MUST be
-  rejected. `expiry` is decimal unix seconds without leading zeros or fractional
-  part. Keyset IDs use their [NUT-02][02] canonical form; the refund key is a
-  BIP-340 x-only pubkey in hex.
+  `[0, 2^64)`. The mint MUST use checked, non-wrapping arithmetic for all sums.
+- **`PAY_TO_UNLOCK` condition**: the three required tags (`offer_keyset`,
+  `expiry`, `refund`) MUST each appear exactly once. Optional tags (`alt_outputs`,
+  `allow_change`, `min_output_amount`) MAY each appear at most once. Unknown tags
+  MUST be rejected. `alt_outputs` values MUST be distinct 64-char hex strings;
+  the mint MAY enforce `max_alt_outputs` (advertised in [NUT-06][06]).
 - **Participant order**: records are ordered by the lexicographically smallest
   `(keyset_id, secret)` among each participant's inputs. Proof secrets are unique
-  across the whole request, so this is a strict total order even when several
-  participants share an `offer_keyset`.
-- **Request digest**:
+  across the whole request, so this is a strict total order.
+- **Request digest** (optional, for idempotent retries):
 
 ```
 req_canonical = participant[0]_canonical || ... || participant[n-1]_canonical
@@ -203,54 +229,41 @@ request_digest = tagged_hash("Cashu/exchange/request", req_canonical)
 If the mint supports idempotent retries (advertised via `idempotent_retries` in
 [NUT-06][06] info), the request digest enables fast retry: a byte-identical
 request returns the cached response instead of failing on double-spend. Without
-this feature, clients fall back to [NUT-09][09] recovery to retrieve lost
-signatures.
-
-Every signature or hash in this NUT is over these canonical encodings.
+this feature, clients fall back to [NUT-09][09] recovery.
 
 ### Preparation
 
-A `PAY_TO_UNLOCK` proof is reusable settlement material: once minted it is
-consumed by the first `/v1/exchange` request that respects its committed terms,
-or reclaimed by its owner. There are two preparation patterns.
-
 #### Two-party direct swap
 
-Two participants agree on an exact exchange of asset `A` for asset `B` (e.g. an
-OTC trade or a direct match). Both are online. Each participant:
+Two participants agree on an exact exchange. Both are online. Each participant:
 
-1. prepares blinded receive outputs for the agreed amount of the other class and
-   computes `H_recv`;
-2. uses an ordinary [NUT-03][03] swap to convert its bearer proofs of its offered
-   class into `PAY_TO_UNLOCK` proofs committed to `H_recv`, choosing an `expiry`
-   and a fresh `refund` key it retains;
-3. verifies the [NUT-12][12] DLEQ proofs on the returned blind signatures and
-   checks that the conditioned proofs encode the agreed terms;
-4. one participant assembles both participants' conditioned proofs and public
-   receive `BlindedMessage` lists and POSTs `/v1/exchange`.
+1. prepares blinded receive outputs and computes `H_recv`;
+2. uses an ordinary [NUT-03][03] swap to convert its bearer proofs into
+   `PAY_TO_UNLOCK` proofs committed to `H_recv`;
+3. verifies the [NUT-12][12] DLEQ proofs;
+4. one participant assembles both participants' material and POSTs
+   `/v1/exchange`.
 
-If the request fails validation, no proof is spent; each participant reclaims its
-own conditioned proofs via refund after `expiry`, then retries or walks away.
+#### Coordinator-mediated swap with FAK support
 
-#### Coordinator-mediated swap
+A matching engine pairs orders. For exact-fill orders (FOK), each participant
+prepares one `H_recv` as above. For variable-fill orders (FAK), a participant
+uses `alt_outputs` + `allow_change` + `min_output_amount`:
 
-A matching engine pairs orders and a relay assembles and submits the settlement
-request. Each participant prepares its conditioned proofs as in the two-party
-flow above. A participant that wants offline capability may prepare **multiple
-lots**, each a separate `PAY_TO_UNLOCK` authorization with its own `H_recv`, its
-own inputs, and its own `expiry`; each lot becomes its own participant record in
-`/v1/exchange`. The submitter includes only the lots it actually matches; unused
-lots remain unspent and are reclaimed by their owner via refund after their own
-`expiry`. A participant that has pre-committed sufficient lots to cover any
-acceptable match may disconnect before matching; a participant that prepares
-conditioned proofs only after a match is agreed must be online at match time.
+1. Generate the receive outputs for the **maximum** fill (e.g., 100 USD).
+2. For each possible fill amount (one per price tick), generate a complete bundle:
+   receive outputs + change outputs in the offer keyset for the unspent portion.
+3. Compute `H_recv` for each bundle. Set `data` to the max-fill bundle; list the
+   rest in `alt_outputs`.
+4. Set `min_output_amount` to the minimum acceptable receive amount.
+5. Lock the full input amount in one `PAY_TO_UNLOCK` proof (one NUT-03 swap).
+6. The coordinator picks the matching bundle at match time.
 
-The relay assembles every matched participant's conditioned proofs and public
-receive descriptors into one `/v1/exchange` request and submits it.
+One proof, one swap, tick-level granularity. The coordinator can only select
+among owner-authorised bundles; it cannot alter any bundle's contents.
 
-In both patterns the mint does not learn the condition during blind preparation;
-it first sees the plaintext condition at settlement or refund, as with other
-NUT-10 conditions.
+A participant that has pre-committed sufficient bundles may disconnect before
+matching. Unused proofs are reclaimed via refund after `expiry`.
 
 ### Settlement request
 
@@ -270,75 +283,53 @@ POST https://mint.host:3338/v1/exchange
 }
 ```
 
-The `participants` array contains one record per participant (`N >= 2`). Records
-MUST appear in canonical participant order.
-
-```bash
-curl -X POST https://mint.host:3338/v1/exchange \
-  -H "Content-Type: application/json" \
-  -d '{"participants":[...]}'
-```
-
 #### Mint validation
 
-Before any mutation, the mint MUST verify all of the following:
+Before any mutation, the mint MUST verify:
 
-1. The request has two or more participant records, each containing at least one
-   input and one output. Advertised limits (`max_participants`, `max_inputs`,
-   `max_outputs`, `max_request_bytes`) MUST be respected.
+1. Two or more participant records, each with ≥1 input and ≥1 output. Advertised
+   limits respected.
 2. Every proof is authentic, unspent, unique in the request, and signed by an
    active or still-spendable keyset.
-3. Every proof carries a supported, canonical `PAY_TO_UNLOCK` condition (each of
-   the four tags appearing exactly once, no unknown tags; see [Canonical
-   encodings](#canonical-encodings)).
-4. No input proof is reused across records and every input is unique in the
-   request.
-5. Each participant's inputs are all of that participant's `offer_keyset`.
-6. Each participant's `outputs` list hashes exactly to that participant's
-   `H_recv`.
-7. Every output in a participant's `outputs` list shares the same `id`; that
-   common `id` is the participant's receive keyset (authenticated by `H_recv`).
+3. Every proof carries a canonical `PAY_TO_UNLOCK` condition: the three required
+   tags each exactly once; optional tags at most once; no unknown tags.
+4. No input proof is reused across records; every input is unique.
+5. Each input's `Proof.id == offer_keyset` (prevents keyset relabeling).
+6. Each participant's `outputs` list hashes to the condition's `data` **or** an
+   `alt_outputs` entry. (If `alt_outputs` is absent, must match `data` exactly.)
+7. If `allow_change` is absent: every output `id` is the same (the receive
+   keyset), and that keyset differs from `offer_keyset`. If `allow_change` is
+   present: every output `id` is either the receive keyset or the `offer_keyset`;
+   at least one output MUST use the receive keyset; the receive keyset MUST differ
+   from `offer_keyset`.
 8. Exactly two distinct keysets appear across all participants' `offer_keyset`
-   values and their derived receive keysets, and every participant's receive
-   keyset differs from its own `offer_keyset`. Per-class amount conservation
-   (rule 10) does not require equal participant counts per class, so any
-   two-class shape is valid:
-   1-vs-N, N-vs-M, or N-vs-N.
+   values and receive keysets. Per-class conservation (rule 10) does not require
+   equal participant counts per class, so any two-class shape is valid: 1-vs-N,
+   N-vs-M, or N-vs-N.
 9. Every blinded output is unique, valid, uses an accepted keyset, and has not
    been signed before.
-10. For each asset class `c` independently, summed over all participants with
-    checked, non-wrapping unsigned 64-bit arithmetic:
-    `sum(inputs_c) == sum(outputs_c) + input_fees_c`, where amounts are unsigned
-    64-bit integers and
+10. For each asset class `c` independently, with checked, non-wrapping u64
+    arithmetic: `sum(inputs_c) == sum(outputs_c) + input_fees_c`, where
     `input_fees_c = (sum(input_fee_ppk over inputs with id == c) + 999) // 1000`
     per [NUT-02][02]. Fees are computed and rounded **per class**, not globally.
-    No additional operation fee is defined in v1.
-11. The request is submitted before the minimum `expiry` across all
-    participants' conditions (mint clock); an expired proof is not settleable.
+11. The request is submitted before the minimum `expiry` across all participants'
+    conditions.
+12. If `min_output_amount` is present: the total receive-keyset output amount for
+    that participant MUST be ≥ `min_output_amount`. (Change outputs in the offer
+    keyset are excluded from this check.)
 
-**Processing order.** If the mint supports idempotent retries, it first
-canonicalizes the request and computes `request_digest`. If a committed response
-already exists for that digest, it is returned unchanged (idempotent retry)
-without re-running the rules below. Only otherwise are rules 1–11 applied, then
-the atomic commit. The mint MUST finish validation before any expensive signing
-or durable mutation.
+**Processing order.** If idempotent retries are supported, canonicalize and
+compute `request_digest` first. If a committed response exists, return it.
+Otherwise apply rules 1–12, then atomic commit.
 
 #### Atomic commit
 
-The mint MUST commit these effects in one database transaction:
+The mint MUST commit in one transaction:
 
-1. mark every selected input proof spent;
-2. sign every selected blinded output;
-3. persist every `BlindedMessage` and corresponding `BlindSignature` for
-   [NUT-09][09] restoration; and
-4. if idempotent retries are supported, persist a response keyed by
-   `request_digest`.
-
-If any validation, signing, or persistence step fails, none of these effects may
-commit. If idempotent retries are supported, a byte-identical retry MUST return
-the previously committed result, and an input proof that already appears in a
-committed response under a conflicting `request_digest` MUST fail without
-mutation.
+1. mark every input proof spent;
+2. sign every blinded output;
+3. persist every `BlindedMessage` / `BlindSignature` for [NUT-09][09] restoration;
+4. if idempotent retries are supported, persist response keyed by `request_digest`.
 
 #### Response
 
@@ -352,65 +343,48 @@ mutation.
 }
 ```
 
-`signatures` has one entry per participant, in canonical participant order.
-
 ### Recovery
 
-Recovery is the direct [NUT-07][07]/[NUT-09][09] path, with one note: because
-each **owner** retained its own receive `BlindedMessage` values, the owner — not
-the submitter — recovers signatures from the mint and unblinds locally. A wallet
-SHOULD retry [NUT-09][09] with bounded backoff when an input is spent but no
-response was received. Wallets seeking stronger metadata privacy SHOULD use an
-anonymity-preserving transport for recovery polling.
+Recovery is the direct [NUT-07][07]/[NUT-09][09] path. Because each **owner**
+retained its own receive `BlindedMessage` values, the owner — not the submitter —
+recovers signatures from the mint and unblinds locally. A wallet SHOULD retry
+[NUT-09][09] with bounded backoff when an input is spent but no response was
+received.
 
 ### Refund
 
-A `PAY_TO_UNLOCK` proof has two mutually exclusive spend paths selected by the
-mint clock:
+A `PAY_TO_UNLOCK` proof has two mutually exclusive spend paths:
 
-- **Before `expiry`**: only as an input to a valid `/v1/exchange` (rules above).
+- **Before `expiry`**: only as an input to `/v1/exchange`.
 - **At or after `expiry`**: only via an ordinary [NUT-03][03] swap to fresh
   outputs of the offered asset class, where each refunded input carries a
   `Proof.witness` containing a single BIP-340 Schnorr signature by the `refund`
-  private key over
+  private key over:
 
   ```
-  refund_digest = tagged_hash("Cashu/PAY_TO_UNLOCK/refund", canonical_swap_request)
+  refund_digest = tagged_hash("Cashu/PAY_TO_UNLOCK/refund", canonical_refund_request)
   ```
 
-  where `canonical_swap_request` is the [RFC 8785][rfc8785] JCS encoding of the
-  NUT-03 swap request object `{inputs, outputs}` (same canonicalization rule as
-  the settlement request). The mint verifies that the current time is at or past
-  the condition's `expiry`, that the signature is valid under the condition's
-  `refund` public key, and that the swap issues refund outputs in an **active
-  keyset of the same unit** as the condition's `offer_keyset` (not necessarily
-  the same keyset ID, since the original keyset may have been rotated and
-  [NUT-02][02] forbids new outputs from inactive keysets). Otherwise the refund
-  is rejected. The mint MUST NOT accept a refund before `expiry`, and MUST NOT
-  accept an expired proof in a `/v1/exchange` settlement.
+  where `canonical_refund_request` is the [RFC 8785][rfc8785] JCS encoding of the
+  swap request object `{inputs, outputs}`, with each input `Proof` serialized
+  **without** its `witness` field (the witness carries the signature and cannot
+  be included in its own preimage). The mint verifies: current time ≥ `expiry`;
+  signature valid under `refund` public key; swap issues outputs in an active
+  keyset of the same unit as `offer_keyset`. Otherwise rejected.
 
-The proof is therefore committed until `expiry` — settlement is the only valid
-spend — and reclaimable by the owner afterwards — refund is the only valid spend.
 The `refund` signature owner-gates the reclaim path: without it, any holder of
-the bearer proof could refund it to itself.
-
-Liveness is preserved: a `/v1/exchange` that fails validation commits nothing
-(inputs stay unspent), and the owner reclaims its conditioned proofs via refund
-once `expiry` passes. A keyset's own [activation/expiry lifecycle][02] is a
-separate, coarse issuer-level bound and does not replace the per-authorization
-`expiry`.
+the bearer proof could refund it to itself. Liveness is preserved: a failed
+`/v1/exchange` commits nothing, and the owner reclaims via refund once `expiry`
+passes.
 
 ### Fees
 
 Input fees follow [NUT-02][02] per-keyset rules, computed and rounded **per asset
-class** as defined in validation rule 10, and are included in that class's
-conservation. The receiver's committed amount therefore equals the offered amount
-minus that asset class's input fees. No additional operation fee is defined in v1;
-a mint MAY advertise one in a later revision via an explicit condition tag.
+class** as defined in rule 10. Change outputs are in the offer keyset and are
+included in that class's conservation (they reduce the fee-adjusted output to the
+counterparty, not the change recipient).
 
 ### Mint info
-
-Support MUST be advertised through [NUT-06][06]:
 
 ```json
 {
@@ -422,49 +396,42 @@ Support MUST be advertised through [NUT-06][06]:
     "max_outputs": "<uint>",
     "max_request_bytes": "<uint>",
     "idempotent_retries": "<bool>",
+    "max_alt_outputs": "<uint>",
     "max_expiry_seconds": "<uint>"
   }
 }
 ```
 
-`max_participants` bounds `N` in one atomic exchange. `max_expiry_seconds` bounds
-the lifetime of a `PAY_TO_UNLOCK` condition: the mint MUST reject any
-[NUT-03][03] swap that mints a `PAY_TO_UNLOCK` proof whose `expiry` exceeds the
-current mint clock plus `max_expiry_seconds`.
-
-A wallet MUST NOT create `PAY_TO_UNLOCK` proofs unless the mint advertises this
-NUT and suitable bounds. Specific error codes are defined in
-[error_codes.md](error_codes.md).
+`max_alt_outputs` bounds the number of alternative `H_recv` values per
+condition. `max_expiry_seconds` bounds condition lifetime at [NUT-03][03] swap
+time.
 
 ## FAQ
 
 **Why commit to blinded outputs rather than a receive public key?**
 A `BlindedMessage` already commits to amount, receive keyset, and the
 wallet-chosen blinded point `B_`. Only the wallet that knows the secret and
-blinding factor can unblind the signature and build the proof. An unblinded
-destination key would not give the same blind-issuance guarantee and would weaken
-Cashu privacy.
+blinding factor can unblind the signature and build the proof.
 
 **Can a submitter or coordinator steal the funds?**
-No. (1) It receives only the _blinded_ receive messages `B_`; without the
-blinding factors it cannot unblind the returned signatures into spendable proofs,
-so it cannot steal what is received. (2) The input proofs it relays are locked by
-`PAY_TO_UNLOCK` to the owner's exact receive outputs, so it cannot redirect the
-value to itself — it can only submit the one authorized exchange. (3) The only
-theft vector is the refund key; the owner keeps a fresh refund key per
-authorization and never shares its private half. A coordinator can therefore at
-worst delay notification or refuse to submit.
+No. (1) It receives only the _blinded_ receive messages; without the blinding
+factors it cannot unblind signatures. (2) Inputs are locked by `PAY_TO_UNLOCK`
+to owner-authorised bundles — including change outputs, which use the owner's
+blinding factors. (3) The only theft vector is the refund key; the owner keeps
+a fresh one per authorization.
+
+**How does FAK work?**
+Use `alt_outputs` + `allow_change` + `min_output_amount`. One proof authorises a
+finite set of output bundles (one per price tick). The coordinator picks the
+matching bundle. See [Coordinator-mediated swap](#coordinator-mediated-swap-with-fak-support).
 
 ## References
 
 - [NUT-02](02.md) · [NUT-03](03.md) · [NUT-06](06.md) · [NUT-07](07.md) ·
-  [NUT-09](09.md) · [NUT-10](10.md) · [NUT-11](11.md) · [NUT-12](12.md) · [NUT-21](21.md) · [NUT-22](22.md)
+  [NUT-09](09.md) · [NUT-10](10.md) · [NUT-11](11.md) · [NUT-12](12.md)
 - [Maurice Herlihy, Atomic Cross-Chain Swaps](https://arxiv.org/abs/1801.09515)
-  — leader/follower topology and timelock hierarchy (the _structure_ of an
-  adaptor-sig/HTLC swap).
 - [Mazumdar et al., Towards Faster Settlement in HTLC-based Cross-Chain
-  Swaps](https://arxiv.org/abs/2211.15804) — the American-call-option-without-premium
-  framing of the free-option locktime race this NUT removes.
+  Swaps](https://arxiv.org/abs/2211.15804)
 
 [00]: 00.md
 [02]: 02.md
@@ -475,6 +442,4 @@ worst delay notification or refuse to submit.
 [10]: 10.md
 [11]: 11.md
 [12]: 12.md
-[21]: 21.md
-[22]: 22.md
 [rfc8785]: https://www.rfc-editor.org/rfc/rfc8785.html

--- a/exchange.md
+++ b/exchange.md
@@ -24,8 +24,10 @@ asset classes. Final NUT name, number, and NUT-10 `kind` are provisional.
 A client-to-client atomic swap of Cashu tokens (for example an HTLC or
 adaptor-signature swap) requires both wallets to remain available while they
 exchange keys, commitments, signatures, mint requests, and claims. It exposes a
-free-option locktime race: after one side commits, the other can stall or abandon
-while prices move. And a party matched against several counterparties starts
+free-option locktime race: the party holding the swap secret (the leader) picks
+when to trigger settlement inside the locktime window — completing only if price
+has moved in its favor, otherwise letting the swap lapse — a free American option
+on the locked rate. And a party matched against several counterparties starts
 several independent protocols; sequential execution puts several network paths
 on the critical path.
 
@@ -46,7 +48,10 @@ This is the duty separation of a smart-contract exchange — independently enfor
 authorization, atomic asset transition — but the trust boundary is that of a
 Cashu mint, not a public blockchain.
 
-A coordinator or relay is **optional** and has no on-mint authority; see
+Two preparation patterns are supported: a **direct two-party swap** where both
+participants are online, and a **coordinator-mediated swap** where a relay
+assembles matched participants' material (see [Preparation](#preparation)). A
+coordinator or relay is **optional** and has no on-mint authority; see
 [Coordinator and relay role](#coordinator-and-relay-role).
 
 ### Trust boundary and anonymity
@@ -57,13 +62,13 @@ atomic database commit**. No transparency or accountability layer is defined
 here. Two mitigations bound the added trust:
 
 1. **A violation is transcript-checkable.** Any party holding the full transcript
-   (inputs, conditions, output commitments, signatures, expiry) can prove the
-   mint accepted an exchange that violates a condition or a conservation rule.
-   This is incidental verifiability, not a published audit log.
-2. **Anonymity makes betrayal indiscriminate.** Fresh `swap_id`, refund key,
-   proof secret, and output secret per authorization carry no stable owner
-   identity, so the mint cannot _selectively_ betray a user. It can still censor,
-   deny service, or betray an exchange wholesale — the same issuer trust NUT-11
+   (inputs, conditions, output commitments, signatures) can prove the mint
+   accepted an exchange that violates a condition or a conservation rule. This
+   is incidental verifiability, not a published audit log.
+2. **Anonymity makes betrayal indiscriminate.** Fresh per-authorization `nonce`,
+   refund key, proof secret, and output secret carry no stable owner identity,
+   so the mint cannot _selectively_ betray a user. It can still censor, deny
+   service, or betray an exchange wholesale — the same issuer trust NUT-11
    carries.
 
 ### Scope
@@ -87,14 +92,6 @@ or public-consensus enforcement.
 Independent atomic exchanges are unrelated: a failure or retry of one never
 rolls back another, since each is its own database transaction.
 
-### Offline boundary
-
-A participant must be online through the moment a specific exchange is agreed
-and it creates and commits its exact receive outputs. After handing its
-conditioned proofs and public receive descriptors to the submitter, it may
-disconnect. Settlement and output recovery (via [NUT-09][09]) require no further
-online participation.
-
 ## Protocol
 
 ### Terminology
@@ -106,8 +103,6 @@ online participation.
   receives the other.
 - **Submitter**: whoever posts the settlement request to the mint — a participant
   or a relay. It is not a custody role.
-- `swap_id`: a fresh random 32-byte value binding one exchange's conditions. All
-  participants in one exchange share the same `swap_id`.
 
 ### `PAY_TO_UNLOCK` condition
 
@@ -121,10 +116,8 @@ carrying it authorizes one exact exchange (bilateral or N-party star).
     "nonce": "<hex_str: 32 bytes>",
     "data": "<hex_str: H_recv>",
     "tags": [
-      ["swap_id", "<hex_str: 32 bytes>"],
       ["offer_keyset", "<keyset_id>"],
       ["receive_keyset", "<keyset_id>"],
-      ["expiry", "<unix_seconds_str>"],
       ["refund", "<xonly_pubkey_hex>"]
     ]
   }
@@ -134,23 +127,22 @@ carrying it authorizes one exact exchange (bilateral or N-party star).
 - `data` is `H_recv`, the commitment to this participant's complete ordered
   receive-output list (see [Receive-output commitment](#receive-output-commitment)).
 - `offer_keyset` / `receive_keyset` bind the two asset classes. They MUST differ.
-- `expiry` is a unix timestamp. Settlement must occur before it; refund is
-  available after it.
-- `refund` is a fresh x-only public key controlling the post-expiry refund path
-  (see [Expiry refund](#expiry-refund)).
+- `refund` is a fresh x-only public key whose private half the owner retains. A
+  signature under it authorizes the reclaim path (see
+  [Refund](#refund)). It is the sole owner-authorization key and cannot be
+  omitted; see [Refund](#refund) for why.
 
 The condition answers one question:
 
 > May this proof be consumed by a transaction that atomically creates exactly
 > these blinded outputs of `receive_keyset`?
 
-Every proof contributed by one participant MUST carry the same `swap_id`,
-`offer_keyset`, `receive_keyset`, `H_recv`, `expiry`, and `refund`. All
-participants' conditions MUST carry the same `swap_id`. Across the exchange, the
-multiset of offered keysets MUST equal the multiset of received keysets — i.e.
-every asset class received by some participant is offered by some other
-participant. In the common star shape, one side offers class `X` and receives
-`Y`; the other side offers `Y` and receives `X`.
+Every proof contributed by one participant MUST carry the same `offer_keyset`,
+`receive_keyset`, `H_recv`, and `refund`. Across the exchange, the multiset of
+offered keysets MUST equal the multiset of received keysets — i.e. every asset
+class received by some participant is offered by some other participant. In the
+common star shape, one side offers class `X` and receives `Y`; the other side
+offers `Y` and receives `X`.
 
 ### Receive-output commitment
 
@@ -194,33 +186,70 @@ needed to unblind the mint's signatures.
 - **Request digest**:
 
 ```
-req_canonical = swap_id || participant[0]_canonical || ... || participant[n-1]_canonical
+req_canonical = participant[0]_canonical || ... || participant[n-1]_canonical
 request_digest = tagged_hash("Cashu/exchange/request", req_canonical)
 ```
+
+The request digest is the sole idempotency and replay key: a byte-identical
+retry yields the same digest and returns the committed result; any input proof
+can be spent only once.
 
 Every signature or hash in this NUT is over these canonical encodings.
 
 ### Preparation
 
-For an exact exchange of Alice's asset `A` for Bob's asset `B`:
+A `PAY_TO_UNLOCK` proof is reusable settlement material: once minted it is
+consumed by the first `/v1/exchange` request that respects its committed terms,
+or reclaimed by its owner. There are two preparation patterns.
 
-1. The participants choose a fresh random `swap_id`.
-2. Alice prepares blinded receive outputs for the agreed amount of `B`; Bob
-   prepares blinded receive outputs for the agreed amount of `A`.
-3. Alice uses an ordinary [NUT-03][03] swap to convert her bearer `A` proofs into
-   `PAY_TO_UNLOCK` proofs committed to her `B` outputs. Bob does the
-   corresponding operation for his `B` proofs and `A` outputs.
-4. Each wallet verifies, against the mint, the [NUT-12][12] DLEQ proofs on the
-   blind signatures returned in step 3 — this confirms the mint signed each
-   conditioned proof correctly under the active keyset (it is a participant ↔
-   mint check; no third party is involved). Each wallet also checks that its
-   conditioned proofs encode the intended terms.
-5. Each wallet computes `H_recv` and hands its counterparty(ies) (or a relay) its
-   conditioned proofs and its public receive `BlindedMessage` list, then may
-   disconnect.
+#### Two-party direct swap
 
-The mint does not learn the condition during blind preparation; it first sees the
-plaintext condition at settlement or refund, as with other NUT-10 conditions.
+Two participants agree on an exact exchange of asset `A` for asset `B` (e.g. an
+OTC trade or a direct match). Both are online. Each participant:
+
+1. prepares blinded receive outputs for the agreed amount of the other class and
+   computes `H_recv`;
+2. uses an ordinary [NUT-03][03] swap to convert its bearer proofs of its offered
+   class into `PAY_TO_UNLOCK` proofs committed to `H_recv`, choosing a fresh
+   `refund` key it retains;
+3. verifies the [NUT-12][12] DLEQ proofs on the returned blind signatures and
+   checks that the conditioned proofs encode the agreed terms;
+4. one participant assembles both participants' conditioned proofs and public
+   receive `BlindedMessage` lists and POSTs `/v1/exchange`.
+
+If the request fails validation, no proof is spent; each participant refunds its
+own conditioned proofs and retries or walks away.
+
+#### Coordinator-mediated swap
+
+A matching engine pairs orders and a relay assembles and submits the settlement
+request. What a participant must know up front depends on its order type:
+
+- **Fill-or-Kill (FOK) taker — may go offline.** A FOK order has a single exact
+  fill amount, so the taker knows its receive amount at order placement. It
+  prepares its conditioned proofs then (steps 1–3 above), attaches them and its
+  public receive descriptors to the order, and disconnects. At match the relay
+  uses this pre-committed material; the taker later recovers its outputs via
+  [NUT-09][09].
+- **Makers and Fill-and-Kill (FAK) takers — must be online at match.** A resting
+  maker may be partially filled and a FAK taker's fill amount is unknown until
+  match, so neither knows its exact receive amount at preparation time. They
+  prepare conditioned proofs after a match is agreed (deriving receive amounts
+  from the matched terms) and hand them to the relay.
+
+The relay assembles every matched participant's conditioned proofs and public
+receive descriptors into one `/v1/exchange` request and submits it.
+
+> **Blinding-budget lemma.** Blind issuance requires the recipient to supply —
+> and later unblind — its own `BlindedMessage` values, so a participant can
+> disconnect only if it has pre-committed outputs for its exact fill amount. This
+> is why only exact-fill (FOK) orders are offline-capable; partially fillable
+> orders would need a pre-committed pool of lot-granularity authorizations, which
+> is out of scope for v1.
+
+In both patterns the mint does not learn the condition during blind preparation;
+it first sees the plaintext condition at settlement or refund, as with other
+NUT-10 conditions.
 
 ### Settlement request
 
@@ -230,7 +259,6 @@ POST https://mint.host:3338/v1/exchange
 
 ```json
 {
-  "swap_id": "<hex_str>",
   "participants": [
     {
       "inputs": "<Array[Proof]>",
@@ -247,7 +275,7 @@ MUST appear in canonical participant order.
 ```bash
 curl -X POST https://mint.host:3338/v1/exchange \
   -H "Content-Type: application/json" \
-  -d '{"swap_id":"...","participants":[...]}'
+  -d '{"participants":[...]}'
 ```
 
 #### Mint validation
@@ -260,8 +288,8 @@ Before any mutation, the mint MUST verify all of the following:
 2. Every proof is authentic, unspent, unique in the request, and signed by an
    active or still-spendable keyset.
 3. Every proof carries a supported, canonical `PAY_TO_UNLOCK` condition.
-4. Every condition carries the request's `swap_id`; no input is reused across
-   records; all participants share the `swap_id`.
+4. No input proof is reused across records and every input is unique in the
+   request.
 5. Each participant's inputs are all of that participant's `offer_keyset`.
 6. Each participant's `outputs` list hashes exactly to that participant's
    `H_recv`.
@@ -269,13 +297,12 @@ Before any mutation, the mint MUST verify all of the following:
    participant's `receive_keyset`.
 8. Exactly two distinct keysets appear across all participants' `offer_keyset`
    and `receive_keyset` values, and every participant's `receive_keyset` differs
-   from its own `offer_keyset`. (Per-class amount conservation is rule 11; it does
+   from its own `offer_keyset`. (Per-class amount conservation is rule 10; it does
    not require equal participant counts per class, so a one-taker/multi-maker star
    is valid.)
 9. Every blinded output is unique, valid, uses an accepted keyset, and has not
    been signed before.
-10. The request is before all conditions' `expiry` values (use the minimum).
-11. For each asset class `c` independently, summed over all participants:
+10. For each asset class `c` independently, summed over all participants:
     `sum(inputs_c) == sum(outputs_c) + input_fees_c`, where
     `input_fees_c = (sum(input_fee_ppk over inputs with id == c) + 999) // 1000`
     per [NUT-02][02]. Fees are computed and rounded **per class**, not globally.
@@ -284,7 +311,7 @@ Before any mutation, the mint MUST verify all of the following:
 **Processing order.** The mint first canonicalizes the request and computes
 `request_digest`. If a committed response already exists for that digest, it is
 returned unchanged (idempotent retry) without re-running the rules below. Only
-otherwise are rules 1–11 applied, then the atomic commit. The mint MUST finish
+otherwise are rules 1–10 applied, then the atomic commit. The mint MUST finish
 validation before any expensive signing or durable mutation.
 
 #### Atomic commit
@@ -298,9 +325,9 @@ The mint MUST commit these effects in one database transaction:
 4. persist an idempotent response keyed by `request_digest`.
 
 If any validation, signing, or persistence step fails, none of these effects may
-commit. A byte-identical retry MUST return the previously committed result.
-Reuse of a `swap_id` or input proof with a conflicting `request_digest` MUST fail
-without mutation.
+commit. A byte-identical retry MUST return the previously committed result. An
+input proof that already appears in a committed response under a conflicting
+`request_digest` MUST fail without mutation.
 
 #### Response
 
@@ -331,35 +358,47 @@ A wallet SHOULD retry [NUT-09][09] with bounded backoff when an input is spent
 but no response was received. Wallets seeking stronger metadata privacy SHOULD
 use an anonymity-preserving transport for recovery polling.
 
-### Expiry refund
+### Refund
 
-Version 1 has no pre-expiry cancellation. A `PAY_TO_UNLOCK` proof may be spent in
-exactly two ways:
+A `PAY_TO_UNLOCK` proof is spendable in exactly two ways:
 
-- **Settlement** — as an input to a valid `/v1/exchange` request, before `expiry`
-  (rules above).
-- **Refund** — after `expiry`, through an ordinary [NUT-03][03] swap to fresh
-  outputs of the offered asset class, authorized by a signature from the `refund`
-  key. The swap request MUST include, for each refunded input, a `Proof.witness`
-  with a Schnorr signature by the `refund` private key over
+- **Settlement** — as an input to a valid `/v1/exchange` request (rules above).
+- **Refund** — through an ordinary [NUT-03][03] swap to fresh outputs of the
+  offered asset class, authorized by a signature from the `refund` key. The swap
+  request MUST include, for each refunded input, a `Proof.witness` with a Schnorr
+  signature by the `refund` private key over
   `refund_digest = tagged_hash("Cashu/PAY_TO_UNLOCK/refund", canonical_swap_request)`.
-  The mint verifies the current time is at or past the condition's `expiry` and
-  that the signature is valid under the condition's `refund` public key; otherwise
-  the refund is rejected. The mint MUST NOT accept a refund before `expiry`, and
-  MUST NOT accept an expired proof in a `/v1/exchange` settlement request.
+  The mint verifies the signature under the condition's `refund` public key;
+  otherwise the refund is rejected. A refund is accepted **at any time**, so a
+  participant can abort a failed exchange or withdraw a resting order whenever it
+  chooses.
 
-Settlement before expiry and refund after expiry are mutually exclusive in time
-and serialize on proof spentness; the first valid mint transaction to commit
-wins. Because refund authorization comes from the `refund`-key signature (not
-from output locking), a coordinator or counterparty holding the conditioned
-proofs cannot refund them to itself unless it also holds the refund private key.
-A wallet MUST use a fresh refund key for each authorization and MUST NOT share
-the refund private key.
+Settlement and refund serialize on proof spentness: the first valid mint
+transaction to commit wins, and the loser's transaction is rejected without
+effect (no funds are stranded). This is the same single-spend arbitration NUT-11
+uses.
+
+**Why the `refund` key is required.** A `PAY_TO_UNLOCK` proof is bearer and is
+not spendable in a normal `/v1/swap` — that lock is precisely what prevents a
+relay or counterparty from redirecting its value. Because the proof is bearer,
+the refund path must be owner-gated: without a signature, any holder (the relay
+that assembles the request, or the counterparty) could refund it to its own
+outputs. Settlement needs no signature — the condition, `H_recv`, and per-class
+conservation authorize it structurally — so the `refund` key is the sole
+owner-authorization key and cannot be omitted. A wallet MUST use a fresh refund
+key per authorization and MUST NOT share its private half.
+
+Order validity windows, stale-price protection, and similar operational policy
+are not defined here; they are the coordinator's concern (see
+[Coordinator and relay role](#coordinator-and-relay-role)). A participant that
+wants an authorization to lapse simply refunds it. A keyset's own
+[activation/expiry lifecycle][02] bounds how long any proof — conditioned or not
+— remains settellable.
 
 ### Fees
 
 Input fees follow [NUT-02][02] per-keyset rules, computed and rounded **per asset
-class** as defined in validation rule 11, and are included in that class's
+class** as defined in validation rule 10, and are included in that class's
 conservation. The receiver's committed amount therefore equals the offered amount
 minus that asset class's input fees. No additional operation fee is defined in v1;
 a mint MAY advertise one in a later revision via an explicit condition tag.
@@ -376,8 +415,7 @@ Support MUST be advertised through [NUT-06][06]:
     "max_participants": "<uint>",
     "max_inputs": "<uint>",
     "max_outputs": "<uint>",
-    "max_request_bytes": "<uint>",
-    "max_expiry_seconds": "<uint>"
+    "max_request_bytes": "<uint>"
   }
 }
 ```
@@ -390,17 +428,33 @@ NUT and suitable bounds. Specific error codes are defined in
 
 ## Coordinator and relay role
 
-A coordinator (or relay) is an **optional** deployment convenience: it assembles
-the participants' conditioned proofs and public receive descriptors and submits
-the settlement request on their behalf. It is never required for correctness or
-recovery, and it has no special on-mint role: any holder of all the valid
-authorizations may submit a request, because custody does not depend on who
-submits (see the FAQ). Participants that want a specific party to submit simply
-hand their authorizations only to that party over their chosen off-mint
-transport.
+A coordinator (or relay) is an **optional** deployment convenience used in the
+coordinator-mediated pattern: it assembles the participants' conditioned proofs
+and public receive descriptors and submits the settlement request on their
+behalf. It is never required for correctness or recovery, and it has no special
+on-mint role: any holder of all the valid authorizations may submit a request,
+because custody does not depend on who submits (see the FAQ). Participants that
+want a specific party to submit simply hand their authorizations only to that
+party over their chosen off-mint transport.
 
-Recovery is always the direct [NUT-07][07]/[NUT-09][09] path, independent of any
-coordinator.
+Operational policy — order validity windows, stale-price handling, matching and
+batching rules, anti-spam deposits, reputation — lives entirely at the
+coordinator and is out of scope for this NUT. Recovery is always the direct
+[NUT-07][07]/[NUT-09][09] path, independent of any coordinator.
+
+## Resting-order optionality and relay discretion
+
+A resting order — whether an offline FOK taker's pre-committed proofs or an
+online maker's limit order waiting in a book — offers the market a free option:
+it is most likely to fill exactly when price has moved against it (adverse
+selection). This is the standard limit-order property of every order book, not a
+settlement-atomicity problem, and it is unrelated to the adaptor-sig locktime
+race this NUT removes. Separately, a relay has grouping and timing discretion
+over which pre-authorized proofs it assembles into a request and when it submits;
+it cannot redirect value or alter price (outputs and amounts are bound by
+`H_recv`), but it can choose match timing and pairing. Mitigations for both are
+order-book-level: batch auctions, validity windows enforced by the coordinator,
+post-only orders, and reputation. None is a theft or safety violation.
 
 ## FAQ
 
@@ -417,9 +471,9 @@ blinding factors it cannot unblind the returned signatures into spendable proofs
 so it cannot steal what is received. (2) The input proofs it relays are locked by
 `PAY_TO_UNLOCK` to the owner's exact receive outputs, so it cannot redirect the
 value to itself — it can only submit the one authorized exchange. (3) The only
-theft vector is the post-`expiry` refund key; the owner keeps a fresh refund key
-per authorization and never shares its private half. A coordinator can therefore
-at worst delay notification or refuse to submit.
+theft vector is the refund key; the owner keeps a fresh refund key per
+authorization and never shares its private half. A coordinator can therefore at
+worst delay notification or refuse to submit.
 
 **What if the response is withheld?**
 A withheld response can delay notification; it cannot redirect outputs, cannot
@@ -428,8 +482,8 @@ cannot permanently deny a committed output while the mint complies with
 [NUT-09][09]. Withholding is bounded to a notification delay.
 
 **Can the mint link exchanges to an owner?**
-Not from condition fields: fresh `swap_id`, refund key, proof secret, and output
-secret per authorization carry no stable identity. The mint sees asset classes,
+Not from condition fields: fresh per-authorization `nonce`, refund key, proof
+secret, and output secret carry no stable identity. The mint sees asset classes,
 amounts, and timing per settlement transaction. It cannot achieve
 identity-selective censorship from protocol fields alone.
 
@@ -439,9 +493,29 @@ other in a single database transaction. A typical use case is a matching engine
 settling a taker's **Fill-or-Kill** (FOK) order against several makers: the
 engine assembles one request and the mint settles all legs or none, so the taker
 is never left with a partial fill because one maker's input was stale. General
-N-way cycles (A->B->C->A) that would require a solver are
-out of scope for v1; only star shapes (one side vs one or more of the other) are
-supported.
+N-way cycles (A->B->C->A) that would require a solver are out of scope for v1;
+only star shapes (one side vs one or more of the other) are supported.
+
+**Can a participant go offline after placing an order?**
+Only for an exact-fill order. A Fill-or-Kill (FOK) taker knows its receive amount
+at order placement, so it can pre-commit its conditioned proofs and disconnect;
+the relay settles later and the taker recovers via [NUT-09][09]. A Fill-and-Kill
+(FAK) taker and a resting maker do not know their fill amount until matched, so
+they must be online at match to produce the exact receive outputs. (Blind
+issuance requires the recipient to pre-commit its exact outputs — see the
+blinding-budget lemma.)
+
+**Is a refund key really necessary?**
+Yes. See [Refund](#refund): a conditioned proof is bearer and not normal-spendable,
+so the refund path must be owner-gated by a signature or any holder could refund
+it to itself. Settlement needs no signature, so the refund key is the sole
+owner-authorization key.
+
+**Is there an expiry or validity window?**
+Not in this NUT. A proof is settellable until it is spent or refunded, and a
+participant withdraws an authorization simply by refunding it. Order validity and
+staleness are the coordinator's operational concern; a keyset's own lifecycle
+bounds how long any proof remains settellable.
 
 **Can this represent a partially fillable standing order?**
 Not in v1. A single-use proof has no mutable remaining allowance; standing orders
@@ -453,6 +527,11 @@ mint-side state) and are deferred.
 - [NUT-02](02.md) · [NUT-03](03.md) · [NUT-06](06.md) · [NUT-07](07.md) ·
   [NUT-09](09.md) · [NUT-10](10.md) · [NUT-11](11.md) · [NUT-12](12.md) · [NUT-21](21.md) · [NUT-22](22.md)
 - [Maurice Herlihy, Atomic Cross-Chain Swaps](https://arxiv.org/abs/1801.09515)
+  — leader/follower topology and timelock hierarchy (the *structure* of an
+  adaptor-sig/HTLC swap).
+- [Mazumdar et al., Towards Faster Settlement in HTLC-based Cross-Chain
+  Swaps](https://arxiv.org/abs/2211.15804) — the American-call-option-without-premium
+  framing of the free-option locktime race this NUT removes.
 
 [00]: 00.md
 [02]: 02.md

--- a/exchange.md
+++ b/exchange.md
@@ -158,13 +158,43 @@ Unknown tags MUST be rejected. `expiry` is decimal unix seconds without leading
 zeros. Keyset IDs use their [NUT-02][02] canonical form; the refund key is a
 BIP-340 x-only pubkey in hex.
 
-Every proof contributed by one participant MUST carry a `PAY_TO_UNLOCK`
-condition with the same `data` (`H_recv`), the same tags (`offer_keyset`,
-`expiry`, `refund`, and any optional tags), but a **unique `nonce` per proof**.
-The `nonce` provides per-proof anti-replay; the meaningful authorisation fields
-are shared. This allows multiple proofs (e.g., micro-denomination inputs) in one
-record without duplicate secrets. Across the exchange, the set of `offer_keyset`
-values MUST equal the set of receive keysets.
+Each input is validated under its own spending condition. Within one
+record, all `PAY_TO_UNLOCK` inputs MUST use the same `data` and the same
+tags, with a **unique `nonce` per proof** — for standard participants,
+`data` is `H_recv` with the tags `offer_keyset`, `expiry`, `refund`, and
+any optional tags; for pool-authorized participants, `data` is
+`H_manifest` with the pool tags defined by
+[NUT-Exchange-partial-fill][partial-fill]. A record MAY also contain
+endpoint-compatible non-`PAY_TO_UNLOCK` inputs (rule 3).
+The `nonce` provides per-proof anti-replay; the meaningful authorisation
+fields are shared. This allows multiple proofs (e.g., micro-denomination
+inputs) in one record without duplicate secrets.
+
+A record with no `PAY_TO_UNLOCK` inputs at all is a bare record (see
+rule 3 for the condition classes and the record predicate). A bare record has no
+`H_recv` commitment and no refund path under this NUT: its outputs are
+constrained by the global two-class rule (rule 8) and conservation
+(rule 10). Rules that read a `PAY_TO_UNLOCK` field (`H_recv`, `refund`,
+`expiry`, coordinator binding) apply only to locked records. Across the
+exchange, locked records' `offer_keyset` values and receive keysets MUST
+lie within the two classes of rule 8.
+
+`request_digest` and `coordinator_digest` bind every input proof and
+witness, every output, every pool field, and every condition-relevant
+top-level field, for locked and bare records alike. Recovery restores
+outputs only to a party that retained the corresponding blinded messages;
+conservation gives the holder of a bare input no claim on outputs another
+assembler chose.
+
+Non-normative cautions: a disclosed bearer proof — or any
+non-output-binding condition together with its witness — can fund a
+different valid request; keep such material private until direct
+submission. For a request containing at least one `PAY_TO_UNLOCK` input, any party
+able to assemble a complete valid request holds a timing option until the
+earliest `PAY_TO_UNLOCK` `expiry` in it: it can choose whether and when to
+submit. A coordinator is optional; when a
+`coordinator_pubkey` binds a locked input, the holder of that key holds
+the option.
 
 ### Change outputs
 
@@ -297,7 +327,7 @@ POST https://mint.host:3338/v1/exchange
     },
     { "...": "one record per participant; N >= 2" }
   ],
-  "coordinator_sig": "<hex_str: 128 chars; present iff any input carries coordinator_pubkey>"
+  "coordinator_sig": "<hex_str: 128 chars; present iff any canonical PAY_TO_UNLOCK input carries coordinator_pubkey>"
 }
 ```
 
@@ -309,20 +339,42 @@ Before any mutation, the mint MUST verify:
    limits respected.
 2. Every proof is authentic, unspent, unique in the request, and signed by an
    active or still-spendable keyset.
-3. Every proof carries a canonical `PAY_TO_UNLOCK` condition: the three required
-   tags each exactly once; optional tags at most once; no unknown tags.
+3. Every proof satisfies its own spending condition, restricted to
+   endpoint-compatible conditions: (a) no [NUT-10][10] condition — an
+   ordinary proof; (b) a canonical `PAY_TO_UNLOCK` condition: the three
+   required tags each exactly once, optional tags at most once, no unknown
+   tags; or (c) another supported [NUT-10][10] condition whose validation
+   depends only on the individual proof and its witness — no request
+   context of any kind.
+   Conditions that require a transaction preimage over this endpoint's
+   request (for example [NUT-11][11] `SIG_ALL`) MUST be rejected: this NUT
+   defines no such preimage. Within one record, let `L` be its
+   `PAY_TO_UNLOCK` inputs. If `L` is non-empty the record is a *locked
+   record*: every input in `L` MUST share the same `data` and tags per the
+   participant rule. A locked record whose inputs in `L` carry the pool
+   tags is a *pool record*: all of its inputs MUST be pool-authorized
+   `PAY_TO_UNLOCK` inputs, `pool_manifest` and `pool_selection` are
+   accepted only on it, and it is validated by the pool rule set
+   ([NUT-Exchange-partial-fill][partial-fill] 6p-9p) — base rules 6, 7,
+   and 12 do NOT apply to it. Any other locked record is a *standard
+   locked record*: rules 6, 7, and 12 apply to its complete `outputs`
+   list. If `L` is empty the record is a *bare record*: every
+   `PAY_TO_UNLOCK`-derived rule is skipped for it, and its outputs remain
+   subject to rules 8, 9, and 10.
 4. No input proof is reused across records; every input is unique.
-5. Each input's `Proof.id == offer_keyset` (prevents keyset relabeling).
-6. Each participant's `outputs` list hashes to the condition's `data` **or** an
+5. Each `PAY_TO_UNLOCK` input's `Proof.id == offer_keyset` (prevents keyset relabeling).
+6. Each standard locked record's `outputs` list hashes to the condition's `data` **or** an
    `alt_outputs` entry. (If `alt_outputs` is absent, must match `data` exactly.)
-7. If `allow_change` is absent: every output `id` is the same (the receive
+7. For a standard locked record — if `allow_change` is absent: every output `id` is the same (the receive
    keyset), and that keyset differs from `offer_keyset`. If `allow_change` is
    present: every output `id` is either the receive keyset or the `offer_keyset`;
    at least one output MUST use the receive keyset; the receive keyset MUST differ
    from `offer_keyset`.
-8. Exactly two distinct keysets appear across all participants' `offer_keyset`
-   values and receive keysets. Per-class conservation (rule 10) does not require
-   equal participant counts per class, so any two-class shape is valid: 1-vs-N,
+8. Exactly two distinct keysets appear across all actual input `Proof.id`
+   values and all output `id` values in the request. Bare records are counted
+   by their actual keysets and remain subject to this two-class rule and to
+   conservation (rule 10). Per-class conservation does not require equal
+   participant counts per class, so any two-class shape is valid: 1-vs-N,
    N-vs-M, or N-vs-N.
 9. Every blinded output is unique, valid, uses an accepted keyset, and has not
    been signed before.
@@ -330,17 +382,18 @@ Before any mutation, the mint MUST verify:
     arithmetic: `sum(inputs_c) == sum(outputs_c) + input_fees_c`, where
     `input_fees_c = (sum(input_fee_ppk over inputs with id == c) + 999) // 1000`
     per [NUT-02][02]. Fees are computed and rounded **per class**, not globally.
-11. The request is submitted before the minimum `expiry` across all participants'
-    conditions.
-12. If `min_output_amount` is present: the total receive-keyset output amount for
+11. The request is submitted before the minimum `expiry` across all
+    `PAY_TO_UNLOCK` inputs. This rule is skipped when the request contains
+    none.
+12. For a standard locked record — if `min_output_amount` is present: the total receive-keyset output amount for
     that participant MUST be ≥ `min_output_amount`. (Change outputs in the offer
     keyset are excluded from this check.)
-13. **Coordinator authentication.** If any input carries `coordinator_pubkey`
+13. **Coordinator authentication.** If any canonical `PAY_TO_UNLOCK` input carries `coordinator_pubkey`
     (BIP-340 x-only key, 64 lowercase hex / 32 bytes), every such input MUST
     decode to the same key `K`, and the request MUST carry `coordinator_sig` — a
     BIP-340 signature (128 lowercase hex / 64 bytes) valid under `K` over
     `coordinator_digest` ([Canonical encodings](#canonical-encodings)). Version 1
-    permits one `K` per request; if no input carries `coordinator_pubkey`,
+    permits one `K` per request; if no canonical `PAY_TO_UNLOCK` input carries `coordinator_pubkey`,
     `coordinator_sig` MUST be absent. Reject with 15015 on key disagreement or a
     missing, invalid, or unexpected signature. The signature authorizes the
     request but does not assert inputs are unspent (rules 2 and 11 remain;

--- a/exchange.md
+++ b/exchange.md
@@ -151,11 +151,13 @@ Unknown tags MUST be rejected. `expiry` is decimal unix seconds without leading
 zeros. Keyset IDs use their [NUT-02][02] canonical form; the refund key is a
 BIP-340 x-only pubkey in hex.
 
-Every proof contributed by one participant MUST carry the same condition (same
-`nonce`, `data`, tags, `expiry`, `refund`). Across the exchange, the set of
-`offer_keyset` values MUST equal the set of receive keysets — i.e. every asset
-class offered by some participant is received by some (other) participant, and
-vice versa.
+Every proof contributed by one participant MUST carry a `PAY_TO_UNLOCK`
+condition with the same `data` (`H_recv`), the same tags (`offer_keyset`,
+`expiry`, `refund`, and any optional tags), but a **unique `nonce` per proof**.
+The `nonce` provides per-proof anti-replay; the meaningful authorisation fields
+are shared. This allows multiple proofs (e.g., micro-denomination inputs) in one
+record without duplicate secrets. Across the exchange, the set of `offer_keyset`
+values MUST equal the set of receive keysets.
 
 ### Change outputs
 
@@ -164,8 +166,7 @@ in both the receive keyset and the offer keyset. The receive-keyset entries are
 the participant's desired receive amount; the offer-keyset entries are change
 returned from unspent input.
 
-The mint determines the correct change amount from per-class conservation (rule
-10): `change = sum(inputs_offer) − sum(outputs_offer_to_counterparties) − fees`.
+Change is determined by per-class conservation (rule 10) at the aggregate level.
 The change outputs MUST be included in the committed bundle (`H_recv` or an
 `alt_outputs` entry) — the coordinator cannot insert its own change outputs
 because it lacks the owner's blinding factors.
@@ -186,16 +187,18 @@ including any change outputs. The canonical encoding of one entry is:
 The commitment is a BIP-340 tagged hash over the length-prefixed concatenation
 of entries in declared order. Each `entry_canonical` is the entry serialized with
 the [RFC 8785][rfc8785] JSON Canonicalization Scheme (JCS): UTF-8, object keys in
-lexicographic order, minimal number serialization, no insignificant whitespace.
-The length prefix is a 4-byte little-endian unsigned integer recording the
-**entry count** (not byte length):
+lexicographic order, no insignificant whitespace. **Amounts are encoded as
+decimal strings** (not JSON numbers) in the canonical form to avoid IEEE-754
+precision loss above 2^53. The length prefix is a 4-byte little-endian unsigned
+integer recording the **entry count** (not byte length):
 
 ```
 recv_canonical = uint32_le(len) || entry[0]_canonical || ... || entry[n-1]_canonical
 H_recv = tagged_hash("Cashu/PAY_TO_UNLOCK/recv", recv_canonical)
 ```
 
-where `tagged_hash(tag, msg) = SHA256(SHA256(tag) || SHA256(tag) || msg)`.
+where `tagged_hash(tag, msg) = SHA256(SHA256(tag) || SHA256(tag) || msg)` and
+each `entry_canonical` is `{"amount":"<decimal_str>","id":"<keyset_id>","B_":"<hex>"}`.
 Amounts are unsigned 64-bit integers; the mint MUST reject outputs whose amounts
 are not representable as u64.
 
@@ -217,7 +220,7 @@ matches MUST be rejected.
   MUST be rejected. `alt_outputs` values MUST be distinct 64-char hex strings;
   the mint MAY enforce `max_alt_outputs` (advertised in [NUT-06][06]).
 - **Participant order**: records are ordered by the lexicographically smallest
-  `(keyset_id, secret)` among each participant's inputs. Proof secrets are unique
+  `(id, secret)` among each participant's inputs. Proof secrets are unique
   across the whole request, so this is a strict total order.
 - **Request digest** (optional, for idempotent retries):
 

--- a/exchange.md
+++ b/exchange.md
@@ -110,7 +110,6 @@ carrying it authorizes one exact exchange.
     "data": "<hex_str: H_recv>",
     "tags": [
       ["offer_keyset", "<keyset_id>"],
-      ["receive_keyset", "<keyset_id>"],
       ["expiry", "<unix_seconds_str>"],
       ["refund", "<xonly_pubkey_hex>"]
     ]
@@ -120,7 +119,7 @@ carrying it authorizes one exact exchange.
 
 - `data` is `H_recv`, the commitment to this participant's complete ordered
   receive-output list (see [Receive-output commitment](#receive-output-commitment)).
-- `offer_keyset` / `receive_keyset` bind the two asset classes. They MUST differ.
+- `offer_keyset` binds the participant's offered asset class. The receive asset class is the common `id` of all entries in the output bundle (authenticated by `H_recv`).
 - `expiry` is a unix timestamp checked against the mint clock. It is the binding
   window of the commitment: settlement is valid only before it and refund only
   after it (the two states are mutually exclusive). It MUST be set; a short window
@@ -133,13 +132,14 @@ carrying it authorizes one exact exchange.
 The condition answers one question:
 
 > May this proof be consumed by a transaction that atomically creates exactly
-> these blinded outputs of `receive_keyset`?
+> these blinded outputs?
 
 Every proof contributed by one participant MUST carry the same `offer_keyset`,
-`receive_keyset`, `H_recv`, `expiry`, and `refund`. Across the exchange, the set
-of `offer_keyset` values MUST equal the set of `receive_keyset` values — i.e.
-every asset class offered by some participant is received by some (other)
-participant, and vice versa. Per-class amount conservation is rule 10's job, so
+`H_recv`, `expiry`, and `refund`. Across the exchange, the set of `offer_keyset`
+values MUST equal the set of receive keysets (the common output `id` of each
+participant's bundle, authenticated by `H_recv`) — i.e. every asset class offered
+by some participant is received by some (other) participant, and vice versa.
+Per-class amount conservation is rule 10's job, so
 the count of participants on each side is unconstrained: 1-vs-N, N-vs-M, and
 N-vs-N are all valid two-class shapes. In the common shape, one side offers
 class `X` and receives `Y`; the other side offers `Y` and receives `X`.
@@ -184,11 +184,11 @@ needed to unblind the mint's signatures.
 - **Amounts**: encoded as JSON numbers per JCS, MUST be unsigned integers in
   `[0, 2^64)`. The mint MUST use checked, non-wrapping arithmetic for all sums
   in validation rule 10.
-- **`PAY_TO_UNLOCK` condition**: each of the four tags (`offer_keyset`,
-  `receive_keyset`, `expiry`, `refund`) MUST appear exactly once; unknown or
-  duplicate tags MUST be rejected. `expiry` is decimal unix seconds without
-  leading zeros or fractional part. Keyset IDs use their [NUT-02][02] canonical
-  form; the refund key is a BIP-340 x-only pubkey in hex.
+- **`PAY_TO_UNLOCK` condition**: each of the three tags (`offer_keyset`,
+  `expiry`, `refund`) MUST appear exactly once; unknown or duplicate tags MUST be
+  rejected. `expiry` is decimal unix seconds without leading zeros or fractional
+  part. Keyset IDs use their [NUT-02][02] canonical form; the refund key is a
+  BIP-340 x-only pubkey in hex.
 - **Participant order**: records are ordered by the lexicographically smallest
   `(keyset_id, secret)` among each participant's inputs. Proof secrets are unique
   across the whole request, so this is a strict total order even when several
@@ -294,12 +294,13 @@ Before any mutation, the mint MUST verify all of the following:
 5. Each participant's inputs are all of that participant's `offer_keyset`.
 6. Each participant's `outputs` list hashes exactly to that participant's
    `H_recv`.
-7. Every output in a participant's `outputs` list has `id` equal to that
-   participant's `receive_keyset`.
+7. Every output in a participant's `outputs` list shares the same `id`; that
+   common `id` is the participant's receive keyset (authenticated by `H_recv`).
 8. Exactly two distinct keysets appear across all participants' `offer_keyset`
-   and `receive_keyset` values, and every participant's `receive_keyset` differs
-   from its own `offer_keyset`. Per-class amount conservation (rule 10) does not
-   require equal participant counts per class, so any two-class shape is valid:
+   values and their derived receive keysets, and every participant's receive
+   keyset differs from its own `offer_keyset`. Per-class amount conservation
+   (rule 10) does not require equal participant counts per class, so any
+   two-class shape is valid:
    1-vs-N, N-vs-M, or N-vs-N.
 9. Every blinded output is unique, valid, uses an accepted keyset, and has not
    been signed before.

--- a/exchange.md
+++ b/exchange.md
@@ -1,0 +1,468 @@
+# NUT-Exchange: Atomic Multi-Asset Exchange
+
+`draft`
+
+`optional`
+
+`depends on: NUT-02, NUT-03, NUT-06, NUT-07, NUT-09, NUT-10, NUT-11, NUT-12`
+
+---
+
+This NUT defines an atomic exchange of two existing Cashu asset classes at one
+mint. Two or more participants each contribute bearer proofs of one asset class
+and commit to exact blinded receive outputs of the other class. The mint spends
+every input and signs every output in a single database transaction, or changes
+nothing.
+
+This NUT transfers **existing typed assets only**. It does not create or destroy
+asset classes. Final NUT name, number, and NUT-10 `kind` are provisional.
+
+## Premise
+
+### The problem
+
+A client-to-client atomic swap of Cashu tokens (for example an HTLC or
+adaptor-signature swap) requires both wallets to remain available while they
+exchange keys, commitments, signatures, mint requests, and claims. It exposes a
+free-option locktime race: after one side commits, the other can stall or abandon
+while prices move. And a party matched against several counterparties starts
+several independent protocols; sequential execution puts several network paths
+on the critical path.
+
+A Cashu mint already validates proof signatures, maintains spentness, and issues
+blind signatures. This NUT uses that existing authority as the atomic settlement
+layer, removing the interactive claim sequence entirely.
+
+### Model
+
+Each participant first locks its bearer proofs to an exact receive-output
+commitment via a [NUT-10][10] `PAY_TO_UNLOCK` condition. The participants'
+conditioned proofs and public receive descriptors are assembled into one
+settlement request and submitted to the mint. The mint validates every condition
+and conserves each asset class independently, then commits all input spends and
+all output signatures in one transaction — or changes nothing.
+
+This is the duty separation of a smart-contract exchange — independently enforced
+authorization, atomic asset transition — but the trust boundary is that of a
+Cashu mint, not a public blockchain.
+
+A coordinator or relay is **optional** and has no on-mint authority; see
+[Coordinator and relay role](#coordinator-and-relay-role).
+
+### Trust boundary and anonymity
+
+The mint is trusted for the same things [NUT-11][11] P2PK already trusts it
+(rejecting invalid spends, maintaining spentness, blind signing) **plus one
+atomic database commit**. No transparency or accountability layer is defined
+here. Two mitigations bound the added trust:
+
+1. **A violation is transcript-checkable.** Any party holding the full transcript
+   (inputs, conditions, output commitments, signatures, expiry) can prove the
+   mint accepted an exchange that violates a condition or a conservation rule.
+   This is incidental verifiability, not a published audit log.
+2. **Anonymity makes betrayal indiscriminate.** Fresh `swap_id`, refund key,
+   proof secret, and output secret per authorization carry no stable owner
+   identity, so the mint cannot *selectively* betray a user. It can still censor,
+   deny service, or betray an exchange wholesale — the same issuer trust NUT-11
+   carries.
+
+### Scope
+
+Version 1 supports:
+
+- one mint;
+- two or more participants in one atomic exchange (a star: one party on one side,
+  one or more on the other — e.g. one taker against one or more makers);
+- exactly two existing asset classes, one offered per side;
+- exact, owner-precommitted blinded receive outputs;
+- per-asset-class conservation; and
+- one atomic commit (all participants settle or none).
+
+Version 1 does **not** support: a coordinator as a required party; cross-mint
+settlement; general N-way cycles (A wants B, B wants C, C wants A) that would
+require a solver; partial fills of one authorization; a mutable remaining
+balance; a venue-selected price or amount range; asset creation or destruction;
+or public-consensus enforcement.
+
+Independent atomic exchanges are unrelated: a failure or retry of one never
+rolls back another, since each is its own database transaction.
+
+### Offline boundary
+
+A participant must be online through the moment a specific exchange is agreed
+and it creates and commits its exact receive outputs. After handing its
+conditioned proofs and public receive descriptors to the submitter, it may
+disconnect. Settlement and output recovery (via [NUT-09][09]) require no further
+online participation.
+
+## Protocol
+
+### Terminology
+
+- **Asset class**: a mint keyset identified by its [NUT-02][02] `id`. A keyset's
+  unit is part of the class identity. Amounts from different classes MUST NOT be
+  added or compared.
+- **Participant**: one owner in an exchange. Each offers one asset class and
+  receives the other.
+- **Submitter**: whoever posts the settlement request to the mint — a participant
+  or a relay. It is not a custody role.
+- `swap_id`: a fresh random 32-byte value binding one exchange's conditions. All
+  participants in one exchange share the same `swap_id`.
+
+### `PAY_TO_UNLOCK` condition
+
+A new [NUT-10][10] well-known secret `kind` named `PAY_TO_UNLOCK`. A proof
+carrying it authorizes one exact exchange (bilateral or N-party star).
+
+```json
+[
+  "PAY_TO_UNLOCK",
+  {
+    "nonce": "<hex_str: 32 bytes>",
+    "data": "<hex_str: H_recv>",
+    "tags": [
+      ["swap_id", "<hex_str: 32 bytes>"],
+      ["offer_keyset", "<keyset_id>"],
+      ["receive_keyset", "<keyset_id>"],
+      ["expiry", "<unix_seconds_str>"],
+      ["refund", "<xonly_pubkey_hex>"]
+    ]
+  }
+]
+```
+
+- `data` is `H_recv`, the commitment to this participant's complete ordered
+  receive-output list (see [Receive-output commitment](#receive-output-commitment)).
+- `offer_keyset` / `receive_keyset` bind the two asset classes. They MUST differ.
+- `expiry` is a unix timestamp. Settlement must occur before it; refund is
+  available after it.
+- `refund` is a fresh x-only public key controlling the post-expiry refund path
+  (see [Expiry refund](#expiry-refund)).
+
+The condition answers one question:
+
+> May this proof be consumed by a transaction that atomically creates exactly
+> these blinded outputs of `receive_keyset`?
+
+Every proof contributed by one participant MUST carry the same `swap_id`,
+`offer_keyset`, `receive_keyset`, `H_recv`, `expiry`, and `refund`. All
+participants' conditions MUST carry the same `swap_id`. Across the exchange, the
+multiset of offered keysets MUST equal the multiset of received keysets — i.e.
+every asset class received by some participant is offered by some other
+participant. In the common star shape, one side offers class `X` and receives
+`Y`; the other side offers `Y` and receives `X`.
+
+### Receive-output commitment
+
+The receive destination is the owner's ordered list of `BlindedMessage` values.
+The canonical encoding of one entry is:
+
+```json
+{"amount": <uint>, "id": "<keyset_id>", "B_": "<hex_str>"}
+```
+
+The commitment is a BIP-340 tagged hash over the length-prefixed concatenation
+of entries in declared order. Each `entry_canonical` is the entry serialized with
+the [RFC 8785][rfc8785] JSON Canonicalization Scheme (JCS): UTF-8, object keys in
+lexicographic order, minimal number serialization, no insignificant whitespace.
+The length prefix is a 4-byte little-endian unsigned integer (output lists are
+not capped at 255):
+
+```
+recv_canonical = uint32_le(len) || entry[0]_canonical || ... || entry[n-1]_canonical
+H_recv = tagged_hash("Cashu/PAY_TO_UNLOCK/recv", recv_canonical)
+```
+
+where `tagged_hash(tag, msg) = SHA256(SHA256(tag) || SHA256(tag) || msg)`.
+
+Duplicate entries, unknown fields, non-canonical encodings, and list-prefix
+matches MUST be rejected. A separate receive public key is not required: only the
+wallet that created the blinded messages knows the secrets and blinding factors
+needed to unblind the mint's signatures.
+
+### Canonical encodings
+
+- **Participant record**: the JSON object `{"inputs": [...], "outputs": [...]}`,
+  with `inputs` sorted by `(keyset_id, secret)` and `outputs` in declared order,
+  serialized via [RFC 8785][rfc8785] JCS. Each `Proof` and `BlindedMessage` uses
+  exactly the field set defined in [NUT-00][00]; unknown or extra fields MUST be
+  rejected.
+- **Participant order**: records are ordered by the lexicographically smallest
+  `(keyset_id, secret)` among each participant's inputs. Proof secrets are unique
+  across the whole request, so this is a strict total order even when several
+  participants share an `offer_keyset`.
+- **Request digest**:
+
+```
+req_canonical = swap_id || participant[0]_canonical || ... || participant[n-1]_canonical
+request_digest = tagged_hash("Cashu/exchange/request", req_canonical)
+```
+
+Every signature or hash in this NUT is over these canonical encodings.
+
+### Preparation
+
+For an exact exchange of Alice's asset `A` for Bob's asset `B`:
+
+1. The participants choose a fresh random `swap_id`.
+2. Alice prepares blinded receive outputs for the agreed amount of `B`; Bob
+   prepares blinded receive outputs for the agreed amount of `A`.
+3. Alice uses an ordinary [NUT-03][03] swap to convert her bearer `A` proofs into
+   `PAY_TO_UNLOCK` proofs committed to her `B` outputs. Bob does the
+   corresponding operation for his `B` proofs and `A` outputs.
+4. Each wallet verifies, against the mint, the [NUT-12][12] DLEQ proofs on the
+   blind signatures returned in step 3 — this confirms the mint signed each
+   conditioned proof correctly under the active keyset (it is a participant ↔
+   mint check; no third party is involved). Each wallet also checks that its
+   conditioned proofs encode the intended terms.
+5. Each wallet computes `H_recv` and hands its counterparty(ies) (or a relay) its
+   conditioned proofs and its public receive `BlindedMessage` list, then may
+   disconnect.
+
+The mint does not learn the condition during blind preparation; it first sees the
+plaintext condition at settlement or refund, as with other NUT-10 conditions.
+
+### Settlement request
+
+```http
+POST https://mint.host:3338/v1/exchange
+```
+
+```json
+{
+  "swap_id": "<hex_str>",
+  "participants": [
+    {
+      "inputs": "<Array[Proof]>",
+      "outputs": "<Array[BlindedMessage]>"
+    },
+    { "...": "one record per participant; N >= 2" }
+  ]
+}
+```
+
+The `participants` array contains one record per participant (`N >= 2`). Records
+MUST appear in canonical participant order.
+
+```bash
+curl -X POST https://mint.host:3338/v1/exchange \
+  -H "Content-Type: application/json" \
+  -d '{"swap_id":"...","participants":[...]}'
+```
+
+#### Mint validation
+
+Before any mutation, the mint MUST verify all of the following:
+
+1. The request has two or more participant records. Advertised limits
+   (`max_participants`, `max_inputs`, `max_outputs`, `max_request_bytes`) MUST be
+   respected.
+2. Every proof is authentic, unspent, unique in the request, and signed by an
+   active or still-spendable keyset.
+3. Every proof carries a supported, canonical `PAY_TO_UNLOCK` condition.
+4. Every condition carries the request's `swap_id`; no input is reused across
+   records; all participants share the `swap_id`.
+5. Each participant's inputs are all of that participant's `offer_keyset`.
+6. Each participant's `outputs` list hashes exactly to that participant's
+   `H_recv`.
+7. Every output in a participant's `outputs` list has `id` equal to that
+   participant's `receive_keyset`.
+8. Exactly two distinct keysets appear across all participants' `offer_keyset`
+   and `receive_keyset` values, and every participant's `receive_keyset` differs
+   from its own `offer_keyset`. (Per-class amount conservation is rule 11; it does
+   not require equal participant counts per class, so a one-taker/multi-maker star
+   is valid.)
+9. Every blinded output is unique, valid, uses an accepted keyset, and has not
+   been signed before.
+10. The request is before all conditions' `expiry` values (use the minimum).
+11. For each asset class `c` independently, summed over all participants:
+    `sum(inputs_c) == sum(outputs_c) + input_fees_c`, where
+    `input_fees_c = (sum(input_fee_ppk over inputs with id == c) + 999) // 1000`
+    per [NUT-02][02]. Fees are computed and rounded **per class**, not globally.
+    No additional operation fee is defined in v1.
+
+**Processing order.** The mint first canonicalizes the request and computes
+`request_digest`. If a committed response already exists for that digest, it is
+returned unchanged (idempotent retry) without re-running the rules below. Only
+otherwise are rules 1–11 applied, then the atomic commit. The mint MUST finish
+validation before any expensive signing or durable mutation.
+
+#### Atomic commit
+
+The mint MUST commit these effects in one database transaction:
+
+1. mark every selected input proof spent;
+2. sign every selected blinded output;
+3. persist every `BlindedMessage` and corresponding `BlindSignature` for
+   [NUT-09][09] restoration; and
+4. persist an idempotent response keyed by `request_digest`.
+
+If any validation, signing, or persistence step fails, none of these effects may
+commit. A byte-identical retry MUST return the previously committed result.
+Reuse of a `swap_id` or input proof with a conflicting `request_digest` MUST fail
+without mutation.
+
+#### Response
+
+```json
+{
+  "signatures": [
+    "<Array[BlindSignature] for participant[0] outputs>",
+    "...",
+    "<Array[BlindSignature] for participant[N-1] outputs>"
+  ]
+}
+```
+
+`signatures` has one entry per participant, in canonical participant order.
+
+### Recovery
+
+Recovery does not depend on the submitter. Because each owner created and
+retained its receive `BlindedMessage` values, an owner can recover directly from
+the mint:
+
+1. Check its conditioned inputs with [NUT-07][07].
+2. If they are spent, send the known blinded messages to [NUT-09][09].
+3. The mint returns the signatures it already committed; the owner unblinds
+   locally.
+
+A wallet SHOULD retry [NUT-09][09] with bounded backoff when an input is spent
+but no response was received. Wallets seeking stronger metadata privacy SHOULD
+use an anonymity-preserving transport for recovery polling.
+
+### Expiry refund
+
+Version 1 has no pre-expiry cancellation. A `PAY_TO_UNLOCK` proof may be spent in
+exactly two ways:
+
+- **Settlement** — as an input to a valid `/v1/exchange` request, before `expiry`
+  (rules above).
+- **Refund** — after `expiry`, through an ordinary [NUT-03][03] swap to fresh
+  outputs of the offered asset class, authorized by a signature from the `refund`
+  key. The swap request MUST include, for each refunded input, a `Proof.witness`
+  with a Schnorr signature by the `refund` private key over
+  `refund_digest = tagged_hash("Cashu/PAY_TO_UNLOCK/refund", canonical_swap_request)`.
+  The mint verifies the current time is at or past the condition's `expiry` and
+  that the signature is valid under the condition's `refund` public key; otherwise
+  the refund is rejected. The mint MUST NOT accept a refund before `expiry`, and
+  MUST NOT accept an expired proof in a `/v1/exchange` settlement request.
+
+Settlement before expiry and refund after expiry are mutually exclusive in time
+and serialize on proof spentness; the first valid mint transaction to commit
+wins. Because refund authorization comes from the `refund`-key signature (not
+from output locking), a coordinator or counterparty holding the conditioned
+proofs cannot refund them to itself unless it also holds the refund private key.
+A wallet MUST use a fresh refund key for each authorization and MUST NOT share
+the refund private key.
+
+### Fees
+
+Input fees follow [NUT-02][02] per-keyset rules, computed and rounded **per asset
+class** as defined in validation rule 11, and are included in that class's
+conservation. The receiver's committed amount therefore equals the offered amount
+minus that asset class's input fees. No additional operation fee is defined in v1;
+a mint MAY advertise one in a later revision via an explicit condition tag.
+
+### Mint info
+
+Support MUST be advertised through [NUT-06][06]:
+
+```json
+{
+  "exchange": {
+    "supported": true,
+    "version": 1,
+    "max_participants": "<uint>",
+    "max_inputs": "<uint>",
+    "max_outputs": "<uint>",
+    "max_request_bytes": "<uint>",
+    "max_expiry_seconds": "<uint>"
+  }
+}
+```
+
+`max_participants` bounds `N` in one atomic exchange.
+
+A wallet MUST NOT create `PAY_TO_UNLOCK` proofs unless the mint advertises this
+NUT and suitable bounds. Specific error codes are defined in
+[error_codes.md](error_codes.md).
+
+## Coordinator and relay role
+
+A coordinator (or relay) is an **optional** deployment convenience: it assembles
+the participants' conditioned proofs and public receive descriptors and submits
+the settlement request on their behalf. It is never required for correctness or
+recovery, and it has no special on-mint role: any holder of all the valid
+authorizations may submit a request, because custody does not depend on who
+submits (see the FAQ). Participants that want a specific party to submit simply
+hand their authorizations only to that party over their chosen off-mint
+transport.
+
+Recovery is always the direct [NUT-07][07]/[NUT-09][09] path, independent of any
+coordinator.
+
+## FAQ
+
+**Why commit to blinded outputs rather than a receive public key?**
+A `BlindedMessage` already commits to amount, receive keyset, and the
+wallet-chosen blinded point `B_`. Only the wallet that knows the secret and
+blinding factor can unblind the signature and build the proof. An unblinded
+destination key would not give the same blind-issuance guarantee and would weaken
+Cashu privacy.
+
+**Can a submitter or coordinator steal the funds?**
+No. (1) It receives only the *blinded* receive messages `B_`; without the
+blinding factors it cannot unblind the returned signatures into spendable proofs,
+so it cannot steal what is received. (2) The input proofs it relays are locked by
+`PAY_TO_UNLOCK` to the owner's exact receive outputs, so it cannot redirect the
+value to itself — it can only submit the one authorized exchange. (3) The only
+theft vector is the post-`expiry` refund key; the owner keeps a fresh refund key
+per authorization and never shares its private half. A coordinator can therefore
+at worst delay notification or refuse to submit.
+
+**What if the response is withheld?**
+A withheld response can delay notification; it cannot redirect outputs, cannot
+make the submitter spend the resulting proofs (it lacks the output secrets), and
+cannot permanently deny a committed output while the mint complies with
+[NUT-09][09]. Withholding is bounded to a notification delay.
+
+**Can the mint link exchanges to an owner?**
+Not from condition fields: fresh `swap_id`, refund key, proof secret, and output
+secret per authorization carry no stable identity. The mint sees asset classes,
+amounts, and timing per settlement transaction. It cannot achieve
+identity-selective censorship from protocol fields alone.
+
+**When is an N-party (star) exchange useful?**
+An N-party atomic exchange commits one party on one side and one or more on the
+other in a single database transaction. A typical use case is a matching engine
+settling a taker's **Fill-or-Kill** (FOK) order against several makers: the
+engine assembles one request and the mint settles all legs or none, so the taker
+is never left with a partial fill because one maker's input was stale. General
+N-way cycles (A->B->C->A) that would require a solver are
+out of scope for v1; only star shapes (one side vs one or more of the other) are
+supported.
+
+**Can this represent a partially fillable standing order?**
+Not in v1. A single-use proof has no mutable remaining allowance; standing orders
+need additional machinery (pre-split funding lots, successor-proof chaining, or
+mint-side state) and are deferred.
+
+## References
+
+- [NUT-02](02.md) · [NUT-03](03.md) · [NUT-06](06.md) · [NUT-07](07.md) ·
+  [NUT-09](09.md) · [NUT-10](10.md) · [NUT-11](11.md) · [NUT-12](12.md) · [NUT-21](21.md) · [NUT-22](22.md)
+- [Maurice Herlihy, Atomic Cross-Chain Swaps](https://arxiv.org/abs/1801.09515)
+
+[00]: 00.md
+[02]: 02.md
+[03]: 03.md
+[06]: 06.md
+[07]: 07.md
+[09]: 09.md
+[10]: 10.md
+[11]: 11.md
+[12]: 12.md
+[21]: 21.md
+[22]: 22.md
+[rfc8785]: https://www.rfc-editor.org/rfc/rfc8785.html

--- a/exchange.md
+++ b/exchange.md
@@ -200,9 +200,11 @@ req_canonical = participant[0]_canonical || ... || participant[n-1]_canonical
 request_digest = tagged_hash("Cashu/exchange/request", req_canonical)
 ```
 
-The request digest is the sole idempotency and replay key: a byte-identical
-retry yields the same digest and returns the committed result; any input proof
-can be spent only once.
+If the mint supports idempotent retries (advertised via `idempotent_retries` in
+[NUT-06][06] info), the request digest enables fast retry: a byte-identical
+request returns the cached response instead of failing on double-spend. Without
+this feature, clients fall back to [NUT-09][09] recovery to retrieve lost
+signatures.
 
 Every signature or hash in this NUT is over these canonical encodings.
 
@@ -314,11 +316,12 @@ Before any mutation, the mint MUST verify all of the following:
 11. The request is submitted before the minimum `expiry` across all
     participants' conditions (mint clock); an expired proof is not settleable.
 
-**Processing order.** The mint first canonicalizes the request and computes
-`request_digest`. If a committed response already exists for that digest, it is
-returned unchanged (idempotent retry) without re-running the rules below. Only
-otherwise are rules 1–11 applied, then the atomic commit. The mint MUST finish
-validation before any expensive signing or durable mutation.
+**Processing order.** If the mint supports idempotent retries, it first
+canonicalizes the request and computes `request_digest`. If a committed response
+already exists for that digest, it is returned unchanged (idempotent retry)
+without re-running the rules below. Only otherwise are rules 1–11 applied, then
+the atomic commit. The mint MUST finish validation before any expensive signing
+or durable mutation.
 
 #### Atomic commit
 
@@ -328,12 +331,14 @@ The mint MUST commit these effects in one database transaction:
 2. sign every selected blinded output;
 3. persist every `BlindedMessage` and corresponding `BlindSignature` for
    [NUT-09][09] restoration; and
-4. persist an idempotent response keyed by `request_digest`.
+4. if idempotent retries are supported, persist a response keyed by
+   `request_digest`.
 
 If any validation, signing, or persistence step fails, none of these effects may
-commit. A byte-identical retry MUST return the previously committed result. An
-input proof that already appears in a committed response under a conflicting
-`request_digest` MUST fail without mutation.
+commit. If idempotent retries are supported, a byte-identical retry MUST return
+the previously committed result, and an input proof that already appears in a
+committed response under a conflicting `request_digest` MUST fail without
+mutation.
 
 #### Response
 
@@ -416,6 +421,7 @@ Support MUST be advertised through [NUT-06][06]:
     "max_inputs": "<uint>",
     "max_outputs": "<uint>",
     "max_request_bytes": "<uint>",
+    "idempotent_retries": "<bool>",
     "max_expiry_seconds": "<uint>"
   }
 }

--- a/exchange.md
+++ b/exchange.md
@@ -1,6 +1,6 @@
 # NUT-Exchange: Atomic Multi-Asset Exchange
 
-`draft`
+`draft` (final NUT name, number, and NUT-10 `kind` are provisional)
 
 `optional`
 
@@ -14,9 +14,6 @@ and commit to exact blinded receive outputs of the other class. The mint spends
 every input and signs every output in a single database transaction, or changes
 nothing.
 
-This NUT transfers **existing typed assets only**. It does not create or destroy
-asset classes. Final NUT name, number, and NUT-10 `kind` are provisional.
-
 ## Premise
 
 ### The problem
@@ -27,13 +24,13 @@ exchange keys, commitments, signatures, mint requests, and claims. It exposes a
 free-option locktime race: the party holding the swap secret (the leader) picks
 when to trigger settlement inside the locktime window — completing only if price
 has moved in its favor, otherwise letting the swap lapse — a free American option
-on the locked rate. And a party matched against several counterparties starts
-several independent protocols; sequential execution puts several network paths
-on the critical path.
+on the locked rate. And a peer-to-peer swap cannot batch several independent
+swaps into one mint transaction: each must be settled separately.
 
 A Cashu mint already validates proof signatures, maintains spentness, and issues
 blind signatures. This NUT uses that existing authority as the atomic settlement
-layer, removing the interactive claim sequence entirely.
+layer, removing the interactive claim sequence and the locktime free option it
+creates.
 
 ### Model
 
@@ -44,15 +41,11 @@ settlement request and submitted to the mint. The mint validates every condition
 and conserves each asset class independently, then commits all input spends and
 all output signatures in one transaction — or changes nothing.
 
-This is the duty separation of a smart-contract exchange — independently enforced
-authorization, atomic asset transition — but the trust boundary is that of a
-Cashu mint, not a public blockchain.
-
 Two preparation patterns are supported: a **direct two-party swap** where both
 participants are online, and a **coordinator-mediated swap** where a relay
 assembles matched participants' material (see [Preparation](#preparation)). A
-coordinator or relay is **optional** and has no on-mint authority; see
-[Coordinator and relay role](#coordinator-and-relay-role).
+coordinator or relay is **optional** and has no on-mint authority: any holder of
+all the valid authorizations may submit a request.
 
 ### Trust boundary and anonymity
 
@@ -65,19 +58,20 @@ here. Two mitigations bound the added trust:
    (inputs, conditions, output commitments, signatures, expiry) can prove the mint
    accepted an exchange that violates a condition or a conservation rule. This
    is incidental verifiability, not a published audit log.
-2. **Anonymity makes betrayal indiscriminate.** Fresh per-authorization `nonce`,
-   refund key, proof secret, and output secret carry no stable owner identity,
-   so the mint cannot _selectively_ betray a user. It can still censor, deny
-   service, or betray an exchange wholesale — the same issuer trust NUT-11
-   carries.
+2. **Protocol fields carry no stable owner identity.** Fresh per-authorization
+   `nonce`, refund key, proof secret, and output secret prevent the mint from
+   performing _identity-selective_ betrayal from protocol fields alone. The mint
+   still sees asset classes, amounts, timing, and transport metadata, and may
+   still censor, deny service, or betray an exchange wholesale — the same issuer
+   trust NUT-11 carries.
 
 ### Scope
 
 Version 1 supports:
 
 - one mint;
-- two or more participants in one atomic exchange (a star: one party on one side,
-  one or more on the other — e.g. one taker against one or more makers);
+- two or more participants in one atomic two-class exchange (any N-vs-M shape,
+  e.g. one taker against one or more makers, or multiple makers on both sides);
 - exactly two existing asset classes, one offered per side;
 - exact, owner-precommitted blinded receive outputs;
 - per-asset-class conservation; and
@@ -86,10 +80,9 @@ Version 1 supports:
 Version 1 does **not** support: a coordinator as a required party; cross-mint
 settlement; general N-way cycles (A wants B, B wants C, C wants A) that would
 require a solver; partial fills of one authorization; a mutable remaining
-balance; a venue-selected price or amount range; asset creation or destruction;
-or public-consensus enforcement.
+balance; a venue-selected price or amount range; asset creation or destruction.
 
-Independent atomic exchanges are unrelated: a failure or retry of one never
+Separate `/v1/exchange` calls are independent: a failure or retry of one never
 rolls back another, since each is its own database transaction.
 
 ## Protocol
@@ -107,7 +100,7 @@ rolls back another, since each is its own database transaction.
 ### `PAY_TO_UNLOCK` condition
 
 A new [NUT-10][10] well-known secret `kind` named `PAY_TO_UNLOCK`. A proof
-carrying it authorizes one exact exchange (bilateral or N-party star).
+carrying it authorizes one exact exchange.
 
 ```json
 [
@@ -130,12 +123,12 @@ carrying it authorizes one exact exchange (bilateral or N-party star).
 - `offer_keyset` / `receive_keyset` bind the two asset classes. They MUST differ.
 - `expiry` is a unix timestamp checked against the mint clock. It is the binding
   window of the commitment: settlement is valid only before it and refund only
-  after it (the two states never overlap). It MUST be set; a short window
+  after it (the two states are mutually exclusive). It MUST be set; a short window
   (seconds to minutes) keeps a resting offer reliable without long lockup.
 - `refund` is a fresh x-only public key whose private half the owner retains. A
-  signature under it authorizes the reclaim path (see [Refund](#refund)), valid
-  only after `expiry`. It is the sole owner-authorization key and cannot be
-  omitted; see [Refund](#refund) for why.
+  signature under it authorizes the reclaim path, valid only after `expiry`. A
+  wallet MUST use a fresh refund key per authorization and MUST NOT share its
+  private half (see [Refund](#refund)).
 
 The condition answers one question:
 
@@ -143,11 +136,13 @@ The condition answers one question:
 > these blinded outputs of `receive_keyset`?
 
 Every proof contributed by one participant MUST carry the same `offer_keyset`,
-`receive_keyset`, `H_recv`, `expiry`, and `refund`. Across the exchange, the multiset of
-offered keysets MUST equal the multiset of received keysets — i.e. every asset
-class received by some participant is offered by some other participant. In the
-common star shape, one side offers class `X` and receives `Y`; the other side
-offers `Y` and receives `X`.
+`receive_keyset`, `H_recv`, `expiry`, and `refund`. Across the exchange, the set
+of `offer_keyset` values MUST equal the set of `receive_keyset` values — i.e.
+every asset class offered by some participant is received by some (other)
+participant, and vice versa. Per-class amount conservation is rule 10's job, so
+the count of participants on each side is unconstrained: 1-vs-N, N-vs-M, and
+N-vs-N are all valid two-class shapes. In the common shape, one side offers
+class `X` and receives `Y`; the other side offers `Y` and receives `X`.
 
 ### Receive-output commitment
 
@@ -162,8 +157,8 @@ The commitment is a BIP-340 tagged hash over the length-prefixed concatenation
 of entries in declared order. Each `entry_canonical` is the entry serialized with
 the [RFC 8785][rfc8785] JSON Canonicalization Scheme (JCS): UTF-8, object keys in
 lexicographic order, minimal number serialization, no insignificant whitespace.
-The length prefix is a 4-byte little-endian unsigned integer (output lists are
-not capped at 255):
+The length prefix is a 4-byte little-endian unsigned integer recording the
+**entry count** (not byte length; output lists are not capped at 255):
 
 ```
 recv_canonical = uint32_le(len) || entry[0]_canonical || ... || entry[n-1]_canonical
@@ -171,6 +166,8 @@ H_recv = tagged_hash("Cashu/PAY_TO_UNLOCK/recv", recv_canonical)
 ```
 
 where `tagged_hash(tag, msg) = SHA256(SHA256(tag) || SHA256(tag) || msg)`.
+Amounts are unsigned 64-bit integers; the mint MUST reject outputs whose amounts
+are not representable as u64.
 
 Duplicate entries, unknown fields, non-canonical encodings, and list-prefix
 matches MUST be rejected. A separate receive public key is not required: only the
@@ -184,6 +181,14 @@ needed to unblind the mint's signatures.
   serialized via [RFC 8785][rfc8785] JCS. Each `Proof` and `BlindedMessage` uses
   exactly the field set defined in [NUT-00][00]; unknown or extra fields MUST be
   rejected.
+- **Amounts**: encoded as JSON numbers per JCS, MUST be unsigned integers in
+  `[0, 2^64)`. The mint MUST use checked, non-wrapping arithmetic for all sums
+  in validation rule 10.
+- **`PAY_TO_UNLOCK` condition**: each of the four tags (`offer_keyset`,
+  `receive_keyset`, `expiry`, `refund`) MUST appear exactly once; unknown or
+  duplicate tags MUST be rejected. `expiry` is decimal unix seconds without
+  leading zeros or fractional part. Keyset IDs use their [NUT-02][02] canonical
+  form; the refund key is a BIP-340 x-only pubkey in hex.
 - **Participant order**: records are ordered by the lexicographically smallest
   `(keyset_id, secret)` among each participant's inputs. Proof secrets are unique
   across the whole request, so this is a strict total order even when several
@@ -228,29 +233,18 @@ own conditioned proofs via refund after `expiry`, then retries or walks away.
 #### Coordinator-mediated swap
 
 A matching engine pairs orders and a relay assembles and submits the settlement
-request. What a participant must know up front depends on its order type:
-
-- **Fill-or-Kill (FOK) taker — may go offline.** A FOK order has a single exact
-  fill amount, so the taker knows its receive amount at order placement. It
-  prepares its conditioned proofs then (steps 1–3 above), attaches them and its
-  public receive descriptors to the order, and disconnects. At match the relay
-  uses this pre-committed material; the taker later recovers its outputs via
-  [NUT-09][09].
-- **Makers and Fill-and-Kill (FAK) takers — must be online at match.** A resting
-  maker may be partially filled and a FAK taker's fill amount is unknown until
-  match, so neither knows its exact receive amount at preparation time. They
-  prepare conditioned proofs after a match is agreed (deriving receive amounts
-  from the matched terms) and hand them to the relay.
+request. Each participant prepares its conditioned proofs as in the two-party
+flow above. A participant that wants offline capability may prepare **multiple
+lots**, each a separate `PAY_TO_UNLOCK` authorization with its own `H_recv`, its
+own inputs, and its own `expiry`; each lot becomes its own participant record in
+`/v1/exchange`. The submitter includes only the lots it actually matches; unused
+lots remain unspent and are reclaimed by their owner via refund after their own
+`expiry`. A participant that has pre-committed sufficient lots to cover any
+acceptable match may disconnect before matching; a participant that prepares
+conditioned proofs only after a match is agreed must be online at match time.
 
 The relay assembles every matched participant's conditioned proofs and public
 receive descriptors into one `/v1/exchange` request and submits it.
-
-> **Blinding-budget lemma.** Blind issuance requires the recipient to supply —
-> and later unblind — its own `BlindedMessage` values, so a participant can
-> disconnect only if it has pre-committed outputs for its exact fill amount. This
-> is why only exact-fill (FOK) orders are offline-capable; partially fillable
-> orders would need a pre-committed pool of lot-granularity authorizations, which
-> is out of scope for v1.
 
 In both patterns the mint does not learn the condition during blind preparation;
 it first sees the plaintext condition at settlement or refund, as with other
@@ -287,12 +281,14 @@ curl -X POST https://mint.host:3338/v1/exchange \
 
 Before any mutation, the mint MUST verify all of the following:
 
-1. The request has two or more participant records. Advertised limits
-   (`max_participants`, `max_inputs`, `max_outputs`, `max_request_bytes`) MUST be
-   respected.
+1. The request has two or more participant records, each containing at least one
+   input and one output. Advertised limits (`max_participants`, `max_inputs`,
+   `max_outputs`, `max_request_bytes`) MUST be respected.
 2. Every proof is authentic, unspent, unique in the request, and signed by an
    active or still-spendable keyset.
-3. Every proof carries a supported, canonical `PAY_TO_UNLOCK` condition.
+3. Every proof carries a supported, canonical `PAY_TO_UNLOCK` condition (each of
+   the four tags appearing exactly once, no unknown tags; see [Canonical
+   encodings](#canonical-encodings)).
 4. No input proof is reused across records and every input is unique in the
    request.
 5. Each participant's inputs are all of that participant's `offer_keyset`.
@@ -302,18 +298,20 @@ Before any mutation, the mint MUST verify all of the following:
    participant's `receive_keyset`.
 8. Exactly two distinct keysets appear across all participants' `offer_keyset`
    and `receive_keyset` values, and every participant's `receive_keyset` differs
-   from its own `offer_keyset`. (Per-class amount conservation is rule 10; it does
-   not require equal participant counts per class, so a one-taker/multi-maker star
-   is valid.)
+   from its own `offer_keyset`. Per-class amount conservation (rule 10) does not
+   require equal participant counts per class, so any two-class shape is valid:
+   1-vs-N, N-vs-M, or N-vs-N.
 9. Every blinded output is unique, valid, uses an accepted keyset, and has not
    been signed before.
-10. For each asset class `c` independently, summed over all participants:
-    `sum(inputs_c) == sum(outputs_c) + input_fees_c`, where
+10. For each asset class `c` independently, summed over all participants with
+    checked, non-wrapping unsigned 64-bit arithmetic:
+    `sum(inputs_c) == sum(outputs_c) + input_fees_c`, where amounts are unsigned
+    64-bit integers and
     `input_fees_c = (sum(input_fee_ppk over inputs with id == c) + 999) // 1000`
     per [NUT-02][02]. Fees are computed and rounded **per class**, not globally.
     No additional operation fee is defined in v1.
 11. The request is submitted before the minimum `expiry` across all
-    participants' conditions (mint clock); an expired proof is not settellable.
+    participants' conditions (mint clock); an expired proof is not settleable.
 
 **Processing order.** The mint first canonicalizes the request and computes
 `request_digest`. If a committed response already exists for that digest, it is
@@ -352,55 +350,43 @@ input proof that already appears in a committed response under a conflicting
 
 ### Recovery
 
-Recovery does not depend on the submitter. Because each owner created and
-retained its receive `BlindedMessage` values, an owner can recover directly from
-the mint:
-
-1. Check its conditioned inputs with [NUT-07][07].
-2. If they are spent, send the known blinded messages to [NUT-09][09].
-3. The mint returns the signatures it already committed; the owner unblinds
-   locally.
-
-A wallet SHOULD retry [NUT-09][09] with bounded backoff when an input is spent
-but no response was received. Wallets seeking stronger metadata privacy SHOULD
-use an anonymity-preserving transport for recovery polling.
+Recovery is the direct [NUT-07][07]/[NUT-09][09] path, with one note: because
+each **owner** retained its own receive `BlindedMessage` values, the owner — not
+the submitter — recovers signatures from the mint and unblinds locally. A wallet
+SHOULD retry [NUT-09][09] with bounded backoff when an input is spent but no
+response was received. Wallets seeking stronger metadata privacy SHOULD use an
+anonymity-preserving transport for recovery polling.
 
 ### Refund
 
-A `PAY_TO_UNLOCK` proof is spendable in exactly two ways, gated by the mint
-clock so the two states never overlap:
+A `PAY_TO_UNLOCK` proof has two mutually exclusive spend paths selected by the
+mint clock:
 
-- **Settlement** — as an input to a valid `/v1/exchange` request submitted
-  **before** the condition's `expiry` (rules above).
-- **Refund** — through an ordinary [NUT-03][03] swap to fresh outputs of the
-  offered asset class, authorized by a signature from the `refund` key and
-  accepted only **after** `expiry`. The swap request MUST include, for each
-  refunded input, a `Proof.witness` with a Schnorr signature by the `refund`
+- **Before `expiry`**: only as an input to a valid `/v1/exchange` (rules above).
+- **At or after `expiry`**: only via an ordinary [NUT-03][03] swap to fresh
+  outputs of the offered asset class, where each refunded input carries a
+  `Proof.witness` containing a single BIP-340 Schnorr signature by the `refund`
   private key over
-  `refund_digest = tagged_hash("Cashu/PAY_TO_UNLOCK/refund", canonical_swap_request)`.
-  The mint verifies the current time is at or past the condition's `expiry` and
-  that the signature is valid under the condition's `refund` public key;
-  otherwise the refund is rejected. The mint MUST NOT accept a refund before
-  `expiry`, and MUST NOT accept an expired proof in a `/v1/exchange` settlement.
 
-The non-overlap is what makes a conditioned proof a *commitment*: once minted,
-the owner cannot retract it before `expiry`, so a counterparty can rely on the
-offer standing for the whole window. If refund were allowed at any time the
-owner would hold a free cancellation option — retracting whenever price turned
-against it — which is exactly the free-option locktime race this NUT removes.
-Binding-until-`expiry` eliminates that option; only the standard resting
-limit-order adverse selection (inherent to any order book) remains. A maker
-wanting flexibility chooses a short `expiry`.
+  ```
+  refund_digest = tagged_hash("Cashu/PAY_TO_UNLOCK/refund", canonical_swap_request)
+  ```
 
-**Why the `refund` key is required.** A `PAY_TO_UNLOCK` proof is bearer and is
-not spendable in a normal `/v1/swap` — that lock is precisely what prevents a
-relay or counterparty from redirecting its value. Because the proof is bearer,
-the refund path must be owner-gated: without a signature, any holder (the relay
-that assembles the request, or the counterparty) could refund it to its own
-outputs. Settlement needs no signature — the condition, `H_recv`, and per-class
-conservation authorize it structurally — so the `refund` key is the sole
-owner-authorization key and cannot be omitted. A wallet MUST use a fresh refund
-key per authorization and MUST NOT share its private half.
+  where `canonical_swap_request` is the [RFC 8785][rfc8785] JCS encoding of the
+  NUT-03 swap request object `{inputs, outputs}` (same canonicalization rule as
+  the settlement request). The mint verifies that the current time is at or past
+  the condition's `expiry`, that the signature is valid under the condition's
+  `refund` public key, and that the swap issues refund outputs in an **active
+  keyset of the same unit** as the condition's `offer_keyset` (not necessarily
+  the same keyset ID, since the original keyset may have been rotated and
+  [NUT-02][02] forbids new outputs from inactive keysets). Otherwise the refund
+  is rejected. The mint MUST NOT accept a refund before `expiry`, and MUST NOT
+  accept an expired proof in a `/v1/exchange` settlement.
+
+The proof is therefore committed until `expiry` — settlement is the only valid
+spend — and reclaimable by the owner afterwards — refund is the only valid spend.
+The `refund` signature owner-gates the reclaim path: without it, any holder of
+the bearer proof could refund it to itself.
 
 Liveness is preserved: a `/v1/exchange` that fails validation commits nothing
 (inputs stay unspent), and the owner reclaims its conditioned proofs via refund
@@ -434,41 +420,14 @@ Support MUST be advertised through [NUT-06][06]:
 }
 ```
 
-`max_participants` bounds `N` in one atomic exchange.
+`max_participants` bounds `N` in one atomic exchange. `max_expiry_seconds` bounds
+the lifetime of a `PAY_TO_UNLOCK` condition: the mint MUST reject any
+[NUT-03][03] swap that mints a `PAY_TO_UNLOCK` proof whose `expiry` exceeds the
+current mint clock plus `max_expiry_seconds`.
 
 A wallet MUST NOT create `PAY_TO_UNLOCK` proofs unless the mint advertises this
 NUT and suitable bounds. Specific error codes are defined in
 [error_codes.md](error_codes.md).
-
-## Coordinator and relay role
-
-A coordinator (or relay) is an **optional** deployment convenience used in the
-coordinator-mediated pattern: it assembles the participants' conditioned proofs
-and public receive descriptors and submits the settlement request on their
-behalf. It is never required for correctness or recovery, and it has no special
-on-mint role: any holder of all the valid authorizations may submit a request,
-because custody does not depend on who submits (see the FAQ). Participants that
-want a specific party to submit simply hand their authorizations only to that
-party over their chosen off-mint transport.
-
-Operational policy — order validity windows, stale-price handling, matching and
-batching rules, anti-spam deposits, reputation — lives entirely at the
-coordinator and is out of scope for this NUT. Recovery is always the direct
-[NUT-07][07]/[NUT-09][09] path, independent of any coordinator.
-
-## Resting-order optionality and relay discretion
-
-A resting order — whether an offline FOK taker's pre-committed proofs or an
-online maker's limit order waiting in a book — offers the market a free option:
-it is most likely to fill exactly when price has moved against it (adverse
-selection). This is the standard limit-order property of every order book, not a
-settlement-atomicity problem, and it is unrelated to the adaptor-sig locktime
-race this NUT removes. Separately, a relay has grouping and timing discretion
-over which pre-authorized proofs it assembles into a request and when it submits;
-it cannot redirect value or alter price (outputs and amounts are bound by
-`H_recv`), but it can choose match timing and pairing. Mitigations for both are
-order-book-level: batch auctions, validity windows enforced by the coordinator,
-post-only orders, and reputation. None is a theft or safety violation.
 
 ## FAQ
 
@@ -488,56 +447,6 @@ value to itself — it can only submit the one authorized exchange. (3) The only
 theft vector is the refund key; the owner keeps a fresh refund key per
 authorization and never shares its private half. A coordinator can therefore at
 worst delay notification or refuse to submit.
-
-**What if the response is withheld?**
-A withheld response can delay notification; it cannot redirect outputs, cannot
-make the submitter spend the resulting proofs (it lacks the output secrets), and
-cannot permanently deny a committed output while the mint complies with
-[NUT-09][09]. Withholding is bounded to a notification delay.
-
-**Can the mint link exchanges to an owner?**
-Not from condition fields: fresh per-authorization `nonce`, refund key, proof
-secret, and output secret carry no stable identity. The mint sees asset classes,
-amounts, and timing per settlement transaction. It cannot achieve
-identity-selective censorship from protocol fields alone.
-
-**When is an N-party (star) exchange useful?**
-An N-party atomic exchange commits one party on one side and one or more on the
-other in a single database transaction. A typical use case is a matching engine
-settling a taker's **Fill-or-Kill** (FOK) order against several makers: the
-engine assembles one request and the mint settles all legs or none, so the taker
-is never left with a partial fill because one maker's input was stale. General
-N-way cycles (A->B->C->A) that would require a solver are out of scope for v1;
-only star shapes (one side vs one or more of the other) are supported.
-
-**Can a participant go offline after placing an order?**
-Only for an exact-fill order. A Fill-or-Kill (FOK) taker knows its receive amount
-at order placement, so it can pre-commit its conditioned proofs and disconnect;
-the relay settles later and the taker recovers via [NUT-09][09]. A Fill-and-Kill
-(FAK) taker and a resting maker do not know their fill amount until matched, so
-they must be online at match to produce the exact receive outputs. (Blind
-issuance requires the recipient to pre-commit its exact outputs — see the
-blinding-budget lemma.)
-
-**Is a refund key really necessary?**
-Yes. See [Refund](#refund): a conditioned proof is bearer and not normal-spendable,
-so the refund path must be owner-gated by a signature or any holder could refund
-it to itself. Settlement needs no signature, so the refund key is the sole
-owner-authorization key.
-
-**Why is `expiry` required?**
-It is what makes a conditioned proof a commitment rather than a revocable offer.
-Settlement is valid only before `expiry` and refund only after, so the owner
-cannot retract during the window and a counterparty can rely on the offer
-standing. If refund were allowed at any time, the owner could retract whenever
-price turned against it — recreating the free-option locktime race this NUT
-removes. Choose a short `expiry` for flexibility; reclaim unconditionally after
-it.
-
-**Can this represent a partially fillable standing order?**
-Not in v1. A single-use proof has no mutable remaining allowance; standing orders
-need additional machinery (pre-split funding lots, successor-proof chaining, or
-mint-side state) and are deferred.
 
 ## References
 

--- a/exchange.md
+++ b/exchange.md
@@ -62,7 +62,7 @@ atomic database commit**. No transparency or accountability layer is defined
 here. Two mitigations bound the added trust:
 
 1. **A violation is transcript-checkable.** Any party holding the full transcript
-   (inputs, conditions, output commitments, signatures) can prove the mint
+   (inputs, conditions, output commitments, signatures, expiry) can prove the mint
    accepted an exchange that violates a condition or a conservation rule. This
    is incidental verifiability, not a published audit log.
 2. **Anonymity makes betrayal indiscriminate.** Fresh per-authorization `nonce`,
@@ -118,6 +118,7 @@ carrying it authorizes one exact exchange (bilateral or N-party star).
     "tags": [
       ["offer_keyset", "<keyset_id>"],
       ["receive_keyset", "<keyset_id>"],
+      ["expiry", "<unix_seconds_str>"],
       ["refund", "<xonly_pubkey_hex>"]
     ]
   }
@@ -127,9 +128,13 @@ carrying it authorizes one exact exchange (bilateral or N-party star).
 - `data` is `H_recv`, the commitment to this participant's complete ordered
   receive-output list (see [Receive-output commitment](#receive-output-commitment)).
 - `offer_keyset` / `receive_keyset` bind the two asset classes. They MUST differ.
+- `expiry` is a unix timestamp checked against the mint clock. It is the binding
+  window of the commitment: settlement is valid only before it and refund only
+  after it (the two states never overlap). It MUST be set; a short window
+  (seconds to minutes) keeps a resting offer reliable without long lockup.
 - `refund` is a fresh x-only public key whose private half the owner retains. A
-  signature under it authorizes the reclaim path (see
-  [Refund](#refund)). It is the sole owner-authorization key and cannot be
+  signature under it authorizes the reclaim path (see [Refund](#refund)), valid
+  only after `expiry`. It is the sole owner-authorization key and cannot be
   omitted; see [Refund](#refund) for why.
 
 The condition answers one question:
@@ -138,7 +143,7 @@ The condition answers one question:
 > these blinded outputs of `receive_keyset`?
 
 Every proof contributed by one participant MUST carry the same `offer_keyset`,
-`receive_keyset`, `H_recv`, and `refund`. Across the exchange, the multiset of
+`receive_keyset`, `H_recv`, `expiry`, and `refund`. Across the exchange, the multiset of
 offered keysets MUST equal the multiset of received keysets — i.e. every asset
 class received by some participant is offered by some other participant. In the
 common star shape, one side offers class `X` and receives `Y`; the other side
@@ -210,15 +215,15 @@ OTC trade or a direct match). Both are online. Each participant:
 1. prepares blinded receive outputs for the agreed amount of the other class and
    computes `H_recv`;
 2. uses an ordinary [NUT-03][03] swap to convert its bearer proofs of its offered
-   class into `PAY_TO_UNLOCK` proofs committed to `H_recv`, choosing a fresh
-   `refund` key it retains;
+   class into `PAY_TO_UNLOCK` proofs committed to `H_recv`, choosing an `expiry`
+   and a fresh `refund` key it retains;
 3. verifies the [NUT-12][12] DLEQ proofs on the returned blind signatures and
    checks that the conditioned proofs encode the agreed terms;
 4. one participant assembles both participants' conditioned proofs and public
    receive `BlindedMessage` lists and POSTs `/v1/exchange`.
 
-If the request fails validation, no proof is spent; each participant refunds its
-own conditioned proofs and retries or walks away.
+If the request fails validation, no proof is spent; each participant reclaims its
+own conditioned proofs via refund after `expiry`, then retries or walks away.
 
 #### Coordinator-mediated swap
 
@@ -307,11 +312,13 @@ Before any mutation, the mint MUST verify all of the following:
     `input_fees_c = (sum(input_fee_ppk over inputs with id == c) + 999) // 1000`
     per [NUT-02][02]. Fees are computed and rounded **per class**, not globally.
     No additional operation fee is defined in v1.
+11. The request is submitted before the minimum `expiry` across all
+    participants' conditions (mint clock); an expired proof is not settellable.
 
 **Processing order.** The mint first canonicalizes the request and computes
 `request_digest`. If a committed response already exists for that digest, it is
 returned unchanged (idempotent retry) without re-running the rules below. Only
-otherwise are rules 1–10 applied, then the atomic commit. The mint MUST finish
+otherwise are rules 1–11 applied, then the atomic commit. The mint MUST finish
 validation before any expensive signing or durable mutation.
 
 #### Atomic commit
@@ -360,23 +367,30 @@ use an anonymity-preserving transport for recovery polling.
 
 ### Refund
 
-A `PAY_TO_UNLOCK` proof is spendable in exactly two ways:
+A `PAY_TO_UNLOCK` proof is spendable in exactly two ways, gated by the mint
+clock so the two states never overlap:
 
-- **Settlement** — as an input to a valid `/v1/exchange` request (rules above).
+- **Settlement** — as an input to a valid `/v1/exchange` request submitted
+  **before** the condition's `expiry` (rules above).
 - **Refund** — through an ordinary [NUT-03][03] swap to fresh outputs of the
-  offered asset class, authorized by a signature from the `refund` key. The swap
-  request MUST include, for each refunded input, a `Proof.witness` with a Schnorr
-  signature by the `refund` private key over
+  offered asset class, authorized by a signature from the `refund` key and
+  accepted only **after** `expiry`. The swap request MUST include, for each
+  refunded input, a `Proof.witness` with a Schnorr signature by the `refund`
+  private key over
   `refund_digest = tagged_hash("Cashu/PAY_TO_UNLOCK/refund", canonical_swap_request)`.
-  The mint verifies the signature under the condition's `refund` public key;
-  otherwise the refund is rejected. A refund is accepted **at any time**, so a
-  participant can abort a failed exchange or withdraw a resting order whenever it
-  chooses.
+  The mint verifies the current time is at or past the condition's `expiry` and
+  that the signature is valid under the condition's `refund` public key;
+  otherwise the refund is rejected. The mint MUST NOT accept a refund before
+  `expiry`, and MUST NOT accept an expired proof in a `/v1/exchange` settlement.
 
-Settlement and refund serialize on proof spentness: the first valid mint
-transaction to commit wins, and the loser's transaction is rejected without
-effect (no funds are stranded). This is the same single-spend arbitration NUT-11
-uses.
+The non-overlap is what makes a conditioned proof a *commitment*: once minted,
+the owner cannot retract it before `expiry`, so a counterparty can rely on the
+offer standing for the whole window. If refund were allowed at any time the
+owner would hold a free cancellation option — retracting whenever price turned
+against it — which is exactly the free-option locktime race this NUT removes.
+Binding-until-`expiry` eliminates that option; only the standard resting
+limit-order adverse selection (inherent to any order book) remains. A maker
+wanting flexibility chooses a short `expiry`.
 
 **Why the `refund` key is required.** A `PAY_TO_UNLOCK` proof is bearer and is
 not spendable in a normal `/v1/swap` — that lock is precisely what prevents a
@@ -388,12 +402,11 @@ conservation authorize it structurally — so the `refund` key is the sole
 owner-authorization key and cannot be omitted. A wallet MUST use a fresh refund
 key per authorization and MUST NOT share its private half.
 
-Order validity windows, stale-price protection, and similar operational policy
-are not defined here; they are the coordinator's concern (see
-[Coordinator and relay role](#coordinator-and-relay-role)). A participant that
-wants an authorization to lapse simply refunds it. A keyset's own
-[activation/expiry lifecycle][02] bounds how long any proof — conditioned or not
-— remains settellable.
+Liveness is preserved: a `/v1/exchange` that fails validation commits nothing
+(inputs stay unspent), and the owner reclaims its conditioned proofs via refund
+once `expiry` passes. A keyset's own [activation/expiry lifecycle][02] is a
+separate, coarse issuer-level bound and does not replace the per-authorization
+`expiry`.
 
 ### Fees
 
@@ -415,7 +428,8 @@ Support MUST be advertised through [NUT-06][06]:
     "max_participants": "<uint>",
     "max_inputs": "<uint>",
     "max_outputs": "<uint>",
-    "max_request_bytes": "<uint>"
+    "max_request_bytes": "<uint>",
+    "max_expiry_seconds": "<uint>"
   }
 }
 ```
@@ -511,11 +525,14 @@ so the refund path must be owner-gated by a signature or any holder could refund
 it to itself. Settlement needs no signature, so the refund key is the sole
 owner-authorization key.
 
-**Is there an expiry or validity window?**
-Not in this NUT. A proof is settellable until it is spent or refunded, and a
-participant withdraws an authorization simply by refunding it. Order validity and
-staleness are the coordinator's operational concern; a keyset's own lifecycle
-bounds how long any proof remains settellable.
+**Why is `expiry` required?**
+It is what makes a conditioned proof a commitment rather than a revocable offer.
+Settlement is valid only before `expiry` and refund only after, so the owner
+cannot retract during the window and a counterparty can rely on the offer
+standing. If refund were allowed at any time, the owner could retract whenever
+price turned against it — recreating the free-option locktime race this NUT
+removes. Choose a short `expiry` for flexibility; reclaim unconditionally after
+it.
 
 **Can this represent a partially fillable standing order?**
 Not in v1. A single-use proof has no mutable remaining allowance; standing orders

--- a/exchange.md
+++ b/exchange.md
@@ -208,17 +208,18 @@ matches MUST be rejected.
 ### Canonical encodings
 
 - **Participant record**: the JSON object `{"inputs": [...], "outputs": [...]}`,
-  with `inputs` sorted by `(keyset_id, secret)` and `outputs` in declared order,
-  serialized via [RFC 8785][rfc8785] JCS. Each `Proof` and `BlindedMessage` uses
-  exactly the field set defined in [NUT-00][00]; unknown or extra fields MUST be
-  rejected.
-- **Amounts**: encoded as JSON numbers per JCS, MUST be unsigned integers in
-  `[0, 2^64)`. The mint MUST use checked, non-wrapping arithmetic for all sums.
+  with `inputs` sorted by `(id, secret)` and `outputs` in declared order,
+  serialized via [RFC 8785][rfc8785] JCS. **All `amount` fields (`Proof.amount`
+  and `BlindedMessage.amount`) are encoded as decimal strings** (not JSON numbers)
+  in the canonical form, to avoid IEEE-754 precision loss above 2^53. Amounts
+  MUST be unsigned integers in `[0, 2^64)` with no leading zeros. The mint MUST
+  use checked, non-wrapping arithmetic for all sums.
 - **`PAY_TO_UNLOCK` condition**: the three required tags (`offer_keyset`,
   `expiry`, `refund`) MUST each appear exactly once. Optional tags (`alt_outputs`,
   `allow_change`, `min_output_amount`) MAY each appear at most once. Unknown tags
   MUST be rejected. `alt_outputs` values MUST be distinct 64-char hex strings;
-  the mint MAY enforce `max_alt_outputs` (advertised in [NUT-06][06]).
+  the mint MUST reject if `alt_outputs` count exceeds advertised `max_alt_outputs`.
+  `min_output_amount` is a minimal unsigned decimal string (no leading zeros).
 - **Participant order**: records are ordered by the lexicographically smallest
   `(id, secret)` among each participant's inputs. Proof secrets are unique
   across the whole request, so this is a strict total order.
@@ -371,9 +372,11 @@ A `PAY_TO_UNLOCK` proof has two mutually exclusive spend paths:
   where `canonical_refund_request` is the [RFC 8785][rfc8785] JCS encoding of the
   swap request object `{inputs, outputs}`, with each input `Proof` serialized
   **without** its `witness` field (the witness carries the signature and cannot
-  be included in its own preimage). The mint verifies: current time ≥ `expiry`;
-  signature valid under `refund` public key; swap issues outputs in an active
-  keyset of the same unit as `offer_keyset`. Otherwise rejected.
+  be included in its own preimage). **All `amount` fields are encoded as decimal
+  strings** (same rule as participant canonicalization). The mint verifies:
+  current time ≥ `expiry`; signature valid under `refund` public key; swap issues
+  outputs in an active keyset of the same unit as `offer_keyset`. Otherwise
+  rejected.
 
 The `refund` signature owner-gates the reclaim path: without it, any holder of
 the bearer proof could refund it to itself. Liveness is preserved: a failed

--- a/exchange.md
+++ b/exchange.md
@@ -114,6 +114,7 @@ chosen from a finite set of owner-authorised output bundles.
       ["offer_keyset", "<keyset_id>"],
       ["expiry", "<unix_seconds_str>"],
       ["refund", "<xonly_pubkey_hex>"],
+      ["coordinator_pubkey", "<xonly_pubkey_hex>"],
       ["alt_outputs", "<H_recv_alt_1>", "<H_recv_alt_2>", "..."],
       ["allow_change"],
       ["min_output_amount", "<uint_str>"]
@@ -146,6 +147,12 @@ chosen from a finite set of owner-authorised output bundles.
   change). The mint MUST reject if the actual receive output is below this floor.
   Prevents a coordinator from filling a tiny amount to consume the authorization
   and force a refund.
+- `coordinator_pubkey`: optional BIP-340 x-only public key (64 lowercase hex
+  chars / 32 bytes) binding these proofs to one coordinator. If present on any
+  input, the settlement requires `coordinator_sig` (see Mint validation);
+  permitted in standard and pool mode. It prevents the same authorization being
+  submitted to two coordinators — only the bound key can authorize a distinct
+  settlement.
 
 Unknown tags MUST be rejected. `expiry` is decimal unix seconds without leading
 zeros. Keyset IDs use their [NUT-02][02] canonical form; the refund key is a
@@ -216,7 +223,8 @@ matches MUST be rejected.
   use checked, non-wrapping arithmetic for all sums.
 - **`PAY_TO_UNLOCK` condition**: the three required tags (`offer_keyset`,
   `expiry`, `refund`) MUST each appear exactly once. Optional tags (`alt_outputs`,
-  `allow_change`, `min_output_amount`) MAY each appear at most once. Unknown tags
+  `allow_change`, `min_output_amount`, `coordinator_pubkey`) MAY each appear at
+  most once. Unknown tags
   MUST be rejected. `alt_outputs` values MUST be distinct 64-char hex strings;
   the mint MUST reject if `alt_outputs` count exceeds advertised `max_alt_outputs`.
   `min_output_amount` is a minimal unsigned decimal string (no leading zeros).
@@ -228,7 +236,12 @@ matches MUST be rejected.
 ```
 req_canonical = participant[0]_canonical || ... || participant[n-1]_canonical
 request_digest = tagged_hash("Cashu/exchange/request", req_canonical)
+coordinator_digest = tagged_hash("Cashu/PAY_TO_UNLOCK/coordinator", req_canonical)
 ```
+
+`coordinator_sig` signs `coordinator_digest` and is excluded from `req_canonical`,
+which already binds each proof secret (hence `coordinator_pubkey` and the spent
+identifier `Y`), the outputs, and any pool manifest/selection.
 
 If the mint supports idempotent retries (advertised via `idempotent_retries` in
 [NUT-06][06] info), the request digest enables fast retry: a byte-identical
@@ -283,7 +296,8 @@ POST https://mint.host:3338/v1/exchange
       "outputs": "<Array[BlindedMessage]>"
     },
     { "...": "one record per participant; N >= 2" }
-  ]
+  ],
+  "coordinator_sig": "<hex_str: 128 chars; present iff any input carries coordinator_pubkey>"
 }
 ```
 
@@ -321,10 +335,22 @@ Before any mutation, the mint MUST verify:
 12. If `min_output_amount` is present: the total receive-keyset output amount for
     that participant MUST be ≥ `min_output_amount`. (Change outputs in the offer
     keyset are excluded from this check.)
+13. **Coordinator authentication.** If any input carries `coordinator_pubkey`
+    (BIP-340 x-only key, 64 lowercase hex / 32 bytes), every such input MUST
+    decode to the same key `K`, and the request MUST carry `coordinator_sig` — a
+    BIP-340 signature (128 lowercase hex / 64 bytes) valid under `K` over
+    `coordinator_digest` ([Canonical encodings](#canonical-encodings)). Version 1
+    permits one `K` per request; if no input carries `coordinator_pubkey`,
+    `coordinator_sig` MUST be absent. Reject with 15015 on key disagreement or a
+    missing, invalid, or unexpected signature. The signature authorizes the
+    request but does not assert inputs are unspent (rules 2 and 11 remain;
+    [NUT-07][07] is advisory). Binding proofs to `K` prevents a _different_
+    coordinator key from authorizing a distinct settlement.
 
-**Processing order.** If idempotent retries are supported, canonicalize and
-compute `request_digest` first. If a committed response exists, return it.
-Otherwise apply rules 1–12, then atomic commit.
+**Processing order.** Verify coordinator authentication (rule 13) before any
+idempotency-cache lookup. If idempotent retries are supported, canonicalize and
+compute `request_digest` (excluding `coordinator_sig`) first; if a committed
+response exists, return it. Otherwise apply rules 1–13, then atomic commit.
 
 #### Atomic commit
 


### PR DESCRIPTION
Adds an optional NUT for an atomic exchange of two existing Cashu asset classes at one mint. Participants lock bearer proofs to exact blinded receive outputs via a new NUT-10 `PAY_TO_UNLOCK` condition; the mint validates the conditions, conserves each asset class independently, and commits all input spends and output signatures in one database transaction — or nothing.

**Context.** This branched out of ongoing work on prediction markets with Cashu (see #337). The key observation: we do not need HTLC-based atomic swaps — genuinely troublesome, as anyone who has dealt with Lightning knows — like we usually reach for in Bitcoin, when both assets are managed by a single mint, because Cashu has a different trust model. A Cashu mint already validates proofs, tracks spentness, and issues blind signatures, so it can serve directly as the atomic settlement layer. This removes the interactive claim sequence, the both-wallets-online requirement, and the free-option locktime race of a client-to-client swap.

Custody is enforced by blind signatures plus the condition binding (any submitter/relay cannot steal or redirect); recovery via NUT-09; post-expiry refund authorized by a signed `refund` key. Trust floor matches NUT-11 P2PK plus one atomic commit; no transparency layer.

Draft for discussion — final NUT number/name, endpoint, and fee policy are open.
