### PR TITLE
NUT-22: add in-band WebSocket authentication

### DIFF
--- a/22.md
+++ b/22.md
@@ -4,6 +4,8 @@
 
 `depends on: NUT-21, NUT-12`
 
+`uses: NUT-17`
+
 ---
 
 This NUT defines a blind authentication scheme that allows mint operators to limit the use of their mint to a set of authorized users while still providing privacy within that anonymity set.
@@ -196,6 +198,46 @@ and make the request as we usually would.
 
 `AuthProofs` are single-use. The wallet MUST delete the `AuthProof` after a successful request, and SHOULD delete it even if request results in an error. If the wallet runs out of `AuthProofs`, it can [mint new ones](#minting-blind-authentication-tokens) using its clear authentication token (CAT).
 
+### WebSocket authentication
+
+The `Blind-auth` header cannot be set by the browser [WebSocket API][websocket-api], so browser wallets cannot authenticate a protected [NUT-17][17] `/v1/ws` endpoint with a header. For this case the mint accepts the BAT in-band as a JSON-RPC command after the connection is established.
+
+The `WsRequestMethod` enum of [NUT-17][17] is extended with an `authenticate` command whose `params` are:
+
+```json
+{
+  "token": <string>
+}
+```
+
+`token` is a BAT (the serialized `authA...` string). As in the header case, it MUST NOT contain the `dleq` proof. The mint verifies and spends the BAT as [above](#using-blind-authentication-tokens) and replies with a `WsResponse` of status `OK`. A single BAT authenticates the whole connection for its lifetime; later commands on the same connection do not consume additional BATs.
+
+Until a valid `authenticate` command is received on a connection that requires it, the mint MUST reject `subscribe` / `unsubscribe` with error `31001`, MUST NOT send notifications, and SHOULD close the connection after a short timeout. A failed `authenticate` returns error `31002` and does not spend the BAT. A valid `Blind-auth` header at upgrade time authenticates the connection as usual and makes the command unnecessary.
+
+If the wallet sends a `subscribe` / `unsubscribe` before authenticating, the mint responds with a `WsResponse` error `31001`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": 31001,
+    "message": "Endpoint requires blind auth"
+  },
+  "id": 1
+}
+```
+
+The wallet then authenticates by sending the `authenticate` command:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "method": "authenticate",
+  "params": { "token": "authAeyJpZCI6ICIwMDBlNDc5NjczODQ5YmY2Ii..." }
+}
+```
+
 ## Mint
 
 ### DLEQs
@@ -256,5 +298,7 @@ See [Error Codes][errors]:
 [04]: 04.md
 [05]: 05.md
 [06]: 06.md
+[17]: 17.md
 [21]: 21.md
 [errors]: error_codes.md
+[websocket-api]: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket


### PR DESCRIPTION
[Here is the rendered document](https://github.com/crodas/nuts/blob/5380624fc5da812f517b867ccd52158c3954a0fc/22.md#websocket-authentication)


Browsers cannot set the Blind-auth header on the WebSocket API, so a browser wallet has no way to authenticate a protected NUT-17 /v1/ws endpoint at upgrade time. Accept the BAT in-band instead: extend the NUT-17 WsRequestMethod enum with an authenticate command that carries the serialized BAT, spend it once, and authenticate the connection for its lifetime. Define the reject/timeout behavior and error codes for unauthenticated connections.

- [ ] cdk: https://github.com/cashubtc/cdk/pull/2280
- [ ] cashu-ts: https://github.com/cashubtc/cashu-ts/pull/1032 
- [ ] nutshell:  