### PR TITLE
NUT-06: require signed mint info

### DIFF
--- a/06.md
+++ b/06.md
@@ -19,7 +19,8 @@ With the mint's response being of the form `GetInfoResponse`:
 ```json
 {
   "name": "Bob's Cashu mint",
-  "pubkey": "0283bf290884eed3a7ca2663fc0260de2e2064d6b355ea13f98dec004b7a7ead99",
+  "pubkey": "02d53b2972b5fcfda2861d937a40bd4dd4170718276e35ac82a84fa60c3a365046",
+  "signature": "efed7369effde640baee2f089681a57fd559e45ebf5bbf9a1f2200bb4137291453b617d7955f0e47426be39f21c4253e92bac8ada04f730021a3e313465334d9",
   "version": "Nutshell/0.15.0",
   "description": "The short mint description",
   "description_long": "A description that can be a long piece of text.",
@@ -87,8 +88,11 @@ With the mint's response being of the form `GetInfoResponse`:
 }
 ```
 
+For reproducibility, the example uses the mint seed `NUT-06 example mint seed` and zero-filled auxiliary randomness for BIP-340 signing.
+
 - (optional) `name` is the name of the mint and should be recognizable.
-- (optional) `pubkey` is the hex pubkey of the mint.
+- (mandatory) `pubkey` is the mint's identity public key as a lowercase hex-encoded, 33-byte compressed secp256k1 public key.
+- (mandatory) `signature` is the lowercase hex encoding of the mint's 64-byte BIP-340 Schnorr signature on the response payload, constructed as specified below.
 - (optional) `version` is the implementation name and the version of the software running on this mint separated with a slash "/".
 - (optional) `description` is a short description of the mint that can be shown in the wallet next to the mint's name.
 - (optional) `description_long` is a long description that can be shown in an additional field.
@@ -99,6 +103,30 @@ With the mint's response being of the form `GetInfoResponse`:
 - (optional) `time` is the current time set on the server. The value is passed as a Unix timestamp integer.
 - (optional) `tos_url` is the URL pointing to the Terms of Service of the mint.
 - (optional) `nuts` indicates each NUT specification that the mint supports and its settings. The settings are defined in each NUT separately.
+
+## Mint identity key
+
+The mint identity key is deterministically derived from the mint seed. Given the exact `seed` string used by the mint:
+
+1. Encode `seed` as UTF-8.
+2. Compute `secret_key = SHA256(seed)`.
+3. Interpret `secret_key` as a 32-byte big-endian integer. It **MUST** be a valid secp256k1 secret key in the range `1..n-1`, where `n` is the order of the secp256k1 curve.
+4. Compute `pubkey = secret_key * G` and serialize it in 33-byte compressed SEC1 format.
+
+The mint **MUST** return this public key in `GetInfoResponse.pubkey`.
+
+## Signature
+
+The mint **MUST** sign every `GetInfoResponse` with the identity key corresponding to `pubkey`. To construct and sign the message:
+
+1. Start with the complete `GetInfoResponse` JSON object.
+2. Remove the top-level `signature` and `time` members. The `time` member is excluded so that an otherwise unchanged response has a stable signed payload.
+3. Canonicalize the resulting JSON object using the JSON Canonicalization Scheme (JCS) defined in [RFC 8785]. Encode the canonical JSON as UTF-8.
+4. Compute the SHA-256 hash of those bytes.
+5. Sign the 32-byte hash using [BIP-340] Schnorr over secp256k1.
+6. Encode the resulting 64-byte signature as lowercase hexadecimal and return it in `GetInfoResponse.signature`.
+
+Wallets **MUST** reject the response if `pubkey` or `signature` is missing or malformed, or if BIP-340 verification fails. For BIP-340 verification, wallets use the 32-byte x-coordinate of the compressed `pubkey`.
 
 With curl:
 
@@ -119,3 +147,5 @@ curl -X GET https://mint.host:3338/v1/info
 [10]: 10.md
 [11]: 11.md
 [12]: 12.md
+[RFC 8785]: https://www.rfc-editor.org/rfc/rfc8785
+[BIP-340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki

--- a/06.md
+++ b/06.md
@@ -20,7 +20,7 @@ With the mint's response being of the form `GetInfoResponse`:
 {
   "name": "Bob's Cashu mint",
   "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
-  "signature": "d1ae4c576e3ffa667df795b06655a5400e590653ae1f60f2a256c01e794a70328fee6fc8f4139c86458d12c0d4f04781581a5890a9ee83b9f7c72c78a641add0",
+  "signature": "256c3fc7773edf908d8d86bf0b1efe5cecbca0e152dfcc4e3d9cb9e5d3e643daa67f62aeb23c640783d46538a601d7907afed9b7db19f7dbdaccfc6dc8d8a227",
   "version": "Nutshell/0.15.0",
   "description": "The short mint description",
   "description_long": "A description that can be a long piece of text.",
@@ -100,7 +100,7 @@ For reproducibility, the example uses the UTF-8 encoding of `NUT-06 example mint
 - (optional) `motd` is the message of the day that the wallet must display to the user. It should only be used to display important announcements to users, such as scheduled maintenances.
 - (optional) `icon_url` is the URL pointing to an image to be used as an icon for the mint. Recommended to be squared in shape.
 - (optional) `urls` is the list of endpoint URLs where the mint is reachable from.
-- (optional) `time` is the current time set on the server. The value is passed as a Unix timestamp integer.
+- (mandatory) `time` is the mint's current time as a Unix timestamp integer. It is included in the signed payload and **MUST** be within 3600 seconds of the verifier's current time.
 - (optional) `tos_url` is the URL pointing to the Terms of Service of the mint.
 - (optional) `nuts` indicates each NUT specification that the mint supports and its settings. The settings are defined in each NUT separately.
 
@@ -122,13 +122,13 @@ The mint **MUST** return this public key in `GetInfoResponse.pubkey`.
 The mint **MUST** sign every `GetInfoResponse` with the identity key corresponding to `pubkey`. To construct and sign the message:
 
 1. Start with the complete `GetInfoResponse` JSON object.
-2. Remove the top-level `signature` and `time` members. The `time` member is excluded so that an otherwise unchanged response has a stable signed payload.
+2. Remove the top-level `signature` member. The `time` member remains in the object and is therefore included in the signed payload.
 3. Canonicalize the resulting JSON object using the JSON Canonicalization Scheme (JCS) defined in [RFC 8785]. Encode the canonical JSON as UTF-8.
 4. Compute the SHA-256 hash of those bytes.
 5. Sign the 32-byte hash using [BIP-340] Schnorr over secp256k1.
 6. Encode the resulting 64-byte signature as lowercase hexadecimal and return it in `GetInfoResponse.signature`.
 
-Wallets **MUST** reject the response if `pubkey` or `signature` is missing or malformed, or if BIP-340 verification fails. For BIP-340 verification, wallets use the 32-byte x-coordinate of the compressed `pubkey`.
+Wallets **MUST** reject the response if `pubkey`, `signature`, or `time` is missing or malformed, if BIP-340 verification fails, or if `time` differs from the wallet's current Unix time by more than 3600 seconds. A difference of exactly 3600 seconds is valid. For BIP-340 verification, wallets use the 32-byte x-coordinate of the compressed `pubkey`.
 
 With curl:
 

--- a/06.md
+++ b/06.md
@@ -19,8 +19,8 @@ With the mint's response being of the form `GetInfoResponse`:
 ```json
 {
   "name": "Bob's Cashu mint",
-  "pubkey": "02d53b2972b5fcfda2861d937a40bd4dd4170718276e35ac82a84fa60c3a365046",
-  "signature": "efed7369effde640baee2f089681a57fd559e45ebf5bbf9a1f2200bb4137291453b617d7955f0e47426be39f21c4253e92bac8ada04f730021a3e313465334d9",
+  "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
+  "signature": "d1ae4c576e3ffa667df795b06655a5400e590653ae1f60f2a256c01e794a70328fee6fc8f4139c86458d12c0d4f04781581a5890a9ee83b9f7c72c78a641add0",
   "version": "Nutshell/0.15.0",
   "description": "The short mint description",
   "description_long": "A description that can be a long piece of text.",
@@ -88,7 +88,7 @@ With the mint's response being of the form `GetInfoResponse`:
 }
 ```
 
-For reproducibility, the example uses the mint seed `NUT-06 example mint seed` and zero-filled auxiliary randomness for BIP-340 signing.
+For reproducibility, the example uses the UTF-8 encoding of `NUT-06 example mint seed` as the mint seed and zero-filled auxiliary randomness for BIP-340 signing.
 
 - (optional) `name` is the name of the mint and should be recognizable.
 - (mandatory) `pubkey` is the mint's identity public key as a lowercase hex-encoded, 33-byte compressed secp256k1 public key.
@@ -106,12 +106,14 @@ For reproducibility, the example uses the mint seed `NUT-06 example mint seed` a
 
 ## Mint identity key
 
-The mint identity key is deterministically derived from the mint seed. Given the exact `seed` string used by the mint:
+The mint identity key is deterministically derived from the mint seed. Given the exact `seed` bytes used by the mint:
 
-1. Encode `seed` as UTF-8.
-2. Compute `secret_key = SHA256(seed)`.
-3. Interpret `secret_key` as a 32-byte big-endian integer. It **MUST** be a valid secp256k1 secret key in the range `1..n-1`, where `n` is the order of the secp256k1 curve.
+1. Set the one-byte counter `ctr` to `0x00`.
+2. Compute `secret_key = HMAC-SHA256(key=seed, data=MINT_IDENTITY_DOMAIN_SEPARATOR || ctr)`, where `MINT_IDENTITY_DOMAIN_SEPARATOR = b"Cashu_Mint_Identity_v1"` and `||` denotes byte concatenation.
+3. Interpret `secret_key` as a 32-byte big-endian integer. If it is not in the range `1..n-1`, where `n` is the order of the secp256k1 curve, increment `ctr` and retry (up to 256 attempts).
 4. Compute `pubkey = secret_key * G` and serialize it in 33-byte compressed SEC1 format.
+
+Derivation **MUST** fail if no valid secret key is found after 256 attempts.
 
 The mint **MUST** return this public key in `GetInfoResponse.pubkey`.
 

--- a/06.md
+++ b/06.md
@@ -30,7 +30,7 @@ With the mint's response being of the form `GetInfoResponse`:
 {
   "name": "Bob's Cashu mint",
   "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
-  "signature": "6495ee5d693994f9a7e821e5baaf87791c50eb98bae9b2047bdb18cfbed4d92298816032c97aa6382ce6b4226efc8401d1ef7e2d8731bbb658bb6c44acc86df5",
+  "signature": "e91f667871ff922f7430aee729bc0252ff893ec2b05ef2b0f98376f7f5119b152029b363f89c35ffa2d8e3395c889c5caa2484c8b716cc18881dad7b6ef9a739",
   "challenge": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
   "version": "Nutshell/0.15.0",
   "description": "The short mint description",
@@ -135,12 +135,14 @@ The mint **MUST** sign every `GetInfoResponse` with the identity key correspondi
 
 1. Start with the complete `GetInfoResponse` JSON object.
 2. Remove the top-level `signature` member. The `time` member and, if present, the `challenge` member remain in the object and are therefore included in the signed payload.
-3. Canonicalize the resulting JSON object using the JSON Canonicalization Scheme (JCS) defined in [RFC 8785]. Encode the canonical JSON as UTF-8.
-4. Compute the SHA-256 hash of those bytes.
-5. Sign the 32-byte hash using [BIP-340] Schnorr over secp256k1.
+3. Canonicalize the resulting JSON object using the JSON Canonicalization Scheme (JCS) defined in [RFC 8785]. Encode the canonical JSON as UTF-8 to obtain `bytes`.
+4. Compute `message_hash = tagged_hash("Cashu_MintInfo_v1", bytes)`.
+5. Sign the 32-byte `message_hash` using [BIP-340] Schnorr over secp256k1.
 6. Encode the resulting 64-byte signature as lowercase hexadecimal and return it in `GetInfoResponse.signature`.
 
-Wallets **MUST** reject the response if `pubkey`, `signature`, or `time` is missing or malformed, if BIP-340 verification fails, or if `time` differs from the wallet's current Unix time by more than 3600 seconds. A difference of exactly 3600 seconds is valid. For BIP-340 verification, wallets use the 32-byte x-coordinate of the compressed `pubkey`.
+The `tagged_hash` function uses the [BIP-340] construction `SHA256(SHA256(tag) || SHA256(tag) || message)`, where `tag` is encoded as UTF-8, each inner SHA-256 result is its raw 32-byte digest, and `||` denotes byte concatenation. For this tag, `SHA256("Cashu_MintInfo_v1") = 916a34ebf6f2244d64490e8eb2b5e7af19cdc45aa6176160186fc6543aa20d9b`.
+
+Wallets **MUST** reject the response if `pubkey`, `signature`, or `time` is missing or malformed, if BIP-340 verification fails, or if `time` differs from the wallet's current Unix time by more than 3600 seconds. A difference of exactly 3600 seconds is valid. For BIP-340 verification, wallets recompute `message_hash` as specified above and use the 32-byte x-coordinate of the compressed `pubkey`.
 
 If the wallet sent a challenge, it **MUST** also reject the response if `challenge` is missing, malformed, or does not exactly match the challenge sent in the corresponding request. If the wallet did not send a challenge, no challenge is required for verification.
 

--- a/06.md
+++ b/06.md
@@ -8,20 +8,20 @@ This endpoint returns information about the mint that a wallet can show to the u
 
 ## Request
 
-Wallets **MAY** include a `challenge` query parameter in `GET /v1/info` requests. If provided, the challenge **MUST** be 32 bytes generated using a cryptographically secure random number generator, encoded as a 64-character lowercase hexadecimal string (`[0-9a-f]{64}`). Wallets using challenges **MUST** generate a fresh challenge for each request and retain it until the response has been verified.
+Wallets **MAY** include a `request_nonce` query parameter in `GET /v1/info` requests. This wallet-generated freshness nonce binds the signed response to the corresponding request. If provided, the request nonce **MUST** be 32 bytes generated using a cryptographically secure random number generator, encoded as a 64-character lowercase hexadecimal string (`[0-9a-f]{64}`). Wallets using request nonces **MUST** generate a fresh request nonce for each request and retain it until the response has been verified.
 
-If a `challenge` parameter is provided, the mint **MUST** check the length of its URL-decoded value before hex decoding it or constructing and signing the `GetInfoResponse`. A value longer than 64 characters (the hex encoding of 32 bytes) **MUST** be rejected with HTTP status code `400`, using the error response format in [NUT-00][00]. The mint **MUST NOT** truncate oversized challenges. This limit bounds challenge processing and response size. Other malformed values **MUST** also be rejected with HTTP status code `400` using the same error response format.
+If a `request_nonce` parameter is provided, the mint **MUST** check the length of its URL-decoded value before hex decoding it or constructing and signing the `GetInfoResponse`. A value longer than 64 characters (the hex encoding of 32 bytes) **MUST** be rejected with HTTP status code `400`, using the error response format in [NUT-00][00]. The mint **MUST NOT** truncate oversized request nonces. This limit bounds request nonce processing and response size. Other malformed values **MUST** also be rejected with HTTP status code `400` using the same error response format.
 
-For a valid challenge, the mint **MUST** copy it unchanged into `GetInfoResponse.challenge` and include it in the signed payload. The mint processes challenges without storing them or checking whether they have been used before. Challenge freshness is the wallet's responsibility.
+For a valid request nonce, the mint **MUST** copy it unchanged into `GetInfoResponse.request_nonce` and include it in the signed payload. The mint processes request nonces without storing them or checking whether they have been used before. Request nonce freshness is the wallet's responsibility.
 
-If no `challenge` parameter is provided, the mint **MUST** return a signed `GetInfoResponse` without a `challenge` member. This preserves compatibility with wallets that request `GET /v1/info` without a challenge.
+If no `request_nonce` parameter is provided, the mint **MUST** return a signed `GetInfoResponse` without a `request_nonce` member. This preserves compatibility with wallets that request `GET /v1/info` without a request nonce.
 
 ## Example
 
 **Request** of `Alice`:
 
 ```http
-GET https://mint.host:3338/v1/info?challenge=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+GET https://mint.host:3338/v1/info?request_nonce=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
 ```
 
 With the mint's response being of the form `GetInfoResponse`:
@@ -30,8 +30,8 @@ With the mint's response being of the form `GetInfoResponse`:
 {
   "name": "Bob's Cashu mint",
   "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
-  "signature": "e91f667871ff922f7430aee729bc0252ff893ec2b05ef2b0f98376f7f5119b152029b363f89c35ffa2d8e3395c889c5caa2484c8b716cc18881dad7b6ef9a739",
-  "challenge": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "signature": "a7e3a3bd6a1c4d6be9311f26c54617e51da8d8bc22fdbe78a61c6c824dec06845bd4d7fc9ee0db8e94837029913b9fbd034afd1f0a668d1e9f032af20c213004",
+  "request_nonce": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
   "version": "Nutshell/0.15.0",
   "description": "The short mint description",
   "description_long": "A description that can be a long piece of text.",
@@ -99,12 +99,12 @@ With the mint's response being of the form `GetInfoResponse`:
 }
 ```
 
-For reproducibility, the example uses the UTF-8 encoding of `NUT-06 example mint seed` as the mint seed, zero-filled auxiliary randomness for BIP-340 signing, and a fixed challenge consisting of the bytes `0x00` through `0x1f`. When verifying this example, use `1725304480` as the wallet's current Unix time. Actual requests that include a challenge use fresh random challenges as specified above.
+For reproducibility, the example uses the UTF-8 encoding of `NUT-06 example mint seed` as the mint seed, zero-filled auxiliary randomness for BIP-340 signing, and a fixed request nonce consisting of the bytes `0x00` through `0x1f`. When verifying this example, use `1725304480` as the wallet's current Unix time. Actual requests that include a request nonce use fresh random request nonces as specified above.
 
 - (optional) `name` is the name of the mint and should be recognizable.
 - (mandatory) `pubkey` is the mint's identity public key as a lowercase hex-encoded, 33-byte compressed secp256k1 public key.
 - (mandatory) `signature` is the lowercase hex encoding of the mint's 64-byte BIP-340 Schnorr signature on the response payload, constructed as specified below.
-- (optional) `challenge` is the 64-character lowercase hexadecimal challenge from the request. It **MUST** be present and exactly match the request's challenge when one was provided, and **MUST** be omitted otherwise. When present, it is included in the signed payload.
+- (optional) `request_nonce` is the 64-character lowercase hexadecimal nonce supplied by the wallet. It **MUST** be present and exactly match the request's `request_nonce` when one was provided, and **MUST** be omitted otherwise. When present, it is included in the signed payload.
 - (optional) `version` is the implementation name and the version of the software running on this mint separated with a slash "/".
 - (optional) `description` is a short description of the mint that can be shown in the wallet next to the mint's name.
 - (optional) `description_long` is a long description that can be shown in an additional field.
@@ -134,7 +134,7 @@ The mint **MUST** return this public key in `GetInfoResponse.pubkey`.
 The mint **MUST** sign every `GetInfoResponse` with the identity key corresponding to `pubkey`. To construct and sign the message:
 
 1. Start with the complete `GetInfoResponse` JSON object.
-2. Remove the top-level `signature` member. The `time` member and, if present, the `challenge` member remain in the object and are therefore included in the signed payload.
+2. Remove the top-level `signature` member. The `time` member and, if present, the `request_nonce` member remain in the object and are therefore included in the signed payload.
 3. Canonicalize the resulting JSON object using the JSON Canonicalization Scheme (JCS) defined in [RFC 8785]. Encode the canonical JSON as UTF-8 to obtain `bytes`.
 4. Compute `message_hash = tagged_hash("Cashu_MintInfo_v1", bytes)`.
 5. Sign the 32-byte `message_hash` using [BIP-340] Schnorr over secp256k1.
@@ -144,24 +144,24 @@ The `tagged_hash` function uses the [BIP-340] construction `SHA256(SHA256(tag) |
 
 Wallets **MUST** reject the response if `pubkey`, `signature`, or `time` is missing or malformed, if BIP-340 verification fails, or if `time` differs from the wallet's current Unix time by more than 3600 seconds. A difference of exactly 3600 seconds is valid. For BIP-340 verification, wallets recompute `message_hash` as specified above and use the 32-byte x-coordinate of the compressed `pubkey`.
 
-If the wallet sent a challenge, it **MUST** also reject the response if `challenge` is missing, malformed, or does not exactly match the challenge sent in the corresponding request. If the wallet did not send a challenge, no challenge is required for verification.
+If the wallet sent a request nonce, it **MUST** also reject the response if `request_nonce` is missing, malformed, or does not exactly match the request nonce sent in the corresponding request. If the wallet did not send a request nonce, no request nonce is required for verification.
 
-With curl, without a challenge:
+With curl, without a request nonce:
 
 ```bash
 curl -X GET https://mint.host:3338/v1/info
 ```
 
-With a challenge:
+With a request nonce:
 
 ```bash
-challenge=$(openssl rand -hex 32)
-curl -X GET "https://mint.host:3338/v1/info?challenge=${challenge}"
+request_nonce=$(openssl rand -hex 32)
+curl -X GET "https://mint.host:3338/v1/info?request_nonce=${request_nonce}"
 ```
 
 ## Test vectors
 
-[Test vectors](tests/06-tests.md) cover identity key derivation and signed responses with and without challenges.
+[Test vectors](tests/06-tests.md) cover identity key derivation and signed responses with and without request nonces.
 
 [00]: 00.md
 [01]: 01.md

--- a/06.md
+++ b/06.md
@@ -10,7 +10,9 @@ This endpoint returns information about the mint that a wallet can show to the u
 
 Wallets **MAY** include a `challenge` query parameter in `GET /v1/info` requests. If provided, the challenge **MUST** be 32 bytes generated using a cryptographically secure random number generator, encoded as a 64-character lowercase hexadecimal string (`[0-9a-f]{64}`). Wallets using challenges **MUST** generate a fresh challenge for each request and retain it until the response has been verified.
 
-If a `challenge` parameter is provided, the mint **MUST** reject a malformed value with HTTP status code `400`, using the error response format in [NUT-00][00]. For a valid challenge, the mint **MUST** copy it unchanged into `GetInfoResponse.challenge` and include it in the signed payload. The mint processes challenges without storing them or checking whether they have been used before. Challenge freshness is the wallet's responsibility.
+If a `challenge` parameter is provided, the mint **MUST** check the length of its URL-decoded value before hex decoding it or constructing and signing the `GetInfoResponse`. A value longer than 64 characters (the hex encoding of 32 bytes) **MUST** be rejected with HTTP status code `400`, using the error response format in [NUT-00][00]. The mint **MUST NOT** truncate oversized challenges. This limit bounds challenge processing and response size. Other malformed values **MUST** also be rejected with HTTP status code `400` using the same error response format.
+
+For a valid challenge, the mint **MUST** copy it unchanged into `GetInfoResponse.challenge` and include it in the signed payload. The mint processes challenges without storing them or checking whether they have been used before. Challenge freshness is the wallet's responsibility.
 
 If no `challenge` parameter is provided, the mint **MUST** return a signed `GetInfoResponse` without a `challenge` member. This preserves compatibility with wallets that request `GET /v1/info` without a challenge.
 

--- a/06.md
+++ b/06.md
@@ -8,9 +8,11 @@ This endpoint returns information about the mint that a wallet can show to the u
 
 ## Request
 
-Wallets **MUST** include exactly one `challenge` query parameter in each `GET /v1/info` request. The challenge **MUST** be 32 bytes generated using a cryptographically secure random number generator, encoded as a 64-character lowercase hexadecimal string (`[0-9a-f]{64}`). Wallets **MUST** generate a fresh challenge for each request and retain it until the response has been verified.
+Wallets **MAY** include a `challenge` query parameter in `GET /v1/info` requests. If provided, the challenge **MUST** be 32 bytes generated using a cryptographically secure random number generator, encoded as a 64-character lowercase hexadecimal string (`[0-9a-f]{64}`). Wallets using challenges **MUST** generate a fresh challenge for each request and retain it until the response has been verified.
 
-The mint **MUST** reject requests with a missing, repeated, or malformed `challenge` parameter with HTTP status code `400`, using the error response format in [NUT-00][00]. For a valid request, the mint **MUST** copy the challenge unchanged into `GetInfoResponse.challenge` and include it in the signed payload. Wallets **MUST** verify that the returned challenge exactly matches the challenge sent in the corresponding request.
+If a `challenge` parameter is provided, the mint **MUST** reject a malformed value with HTTP status code `400`, using the error response format in [NUT-00][00]. For a valid challenge, the mint **MUST** copy it unchanged into `GetInfoResponse.challenge` and include it in the signed payload. The mint processes challenges without storing them or checking whether they have been used before. Challenge freshness is the wallet's responsibility.
+
+If no `challenge` parameter is provided, the mint **MUST** return a signed `GetInfoResponse` without a `challenge` member. This preserves compatibility with wallets that request `GET /v1/info` without a challenge.
 
 ## Example
 
@@ -95,12 +97,12 @@ With the mint's response being of the form `GetInfoResponse`:
 }
 ```
 
-For reproducibility, the example uses the UTF-8 encoding of `NUT-06 example mint seed` as the mint seed, zero-filled auxiliary randomness for BIP-340 signing, and a fixed challenge consisting of the bytes `0x00` through `0x1f`. When verifying this example, use `1725304480` as the wallet's current Unix time. Actual requests use fresh random challenges as specified above.
+For reproducibility, the example uses the UTF-8 encoding of `NUT-06 example mint seed` as the mint seed, zero-filled auxiliary randomness for BIP-340 signing, and a fixed challenge consisting of the bytes `0x00` through `0x1f`. When verifying this example, use `1725304480` as the wallet's current Unix time. Actual requests that include a challenge use fresh random challenges as specified above.
 
 - (optional) `name` is the name of the mint and should be recognizable.
 - (mandatory) `pubkey` is the mint's identity public key as a lowercase hex-encoded, 33-byte compressed secp256k1 public key.
 - (mandatory) `signature` is the lowercase hex encoding of the mint's 64-byte BIP-340 Schnorr signature on the response payload, constructed as specified below.
-- (mandatory) `challenge` is the 64-character lowercase hexadecimal challenge from the request. It is included in the signed payload and **MUST** exactly match the challenge sent by the wallet.
+- (optional) `challenge` is the 64-character lowercase hexadecimal challenge from the request. It **MUST** be present and exactly match the request's challenge when one was provided, and **MUST** be omitted otherwise. When present, it is included in the signed payload.
 - (optional) `version` is the implementation name and the version of the software running on this mint separated with a slash "/".
 - (optional) `description` is a short description of the mint that can be shown in the wallet next to the mint's name.
 - (optional) `description_long` is a long description that can be shown in an additional field.
@@ -130,15 +132,23 @@ The mint **MUST** return this public key in `GetInfoResponse.pubkey`.
 The mint **MUST** sign every `GetInfoResponse` with the identity key corresponding to `pubkey`. To construct and sign the message:
 
 1. Start with the complete `GetInfoResponse` JSON object.
-2. Remove the top-level `signature` member. The `challenge` and `time` members remain in the object and are therefore included in the signed payload.
+2. Remove the top-level `signature` member. The `time` member and, if present, the `challenge` member remain in the object and are therefore included in the signed payload.
 3. Canonicalize the resulting JSON object using the JSON Canonicalization Scheme (JCS) defined in [RFC 8785]. Encode the canonical JSON as UTF-8.
 4. Compute the SHA-256 hash of those bytes.
 5. Sign the 32-byte hash using [BIP-340] Schnorr over secp256k1.
 6. Encode the resulting 64-byte signature as lowercase hexadecimal and return it in `GetInfoResponse.signature`.
 
-Wallets **MUST** reject the response if `pubkey`, `signature`, `challenge`, or `time` is missing or malformed, if `challenge` does not exactly match the challenge sent in the corresponding request, if BIP-340 verification fails, or if `time` differs from the wallet's current Unix time by more than 3600 seconds. A difference of exactly 3600 seconds is valid. For BIP-340 verification, wallets use the 32-byte x-coordinate of the compressed `pubkey`.
+Wallets **MUST** reject the response if `pubkey`, `signature`, or `time` is missing or malformed, if BIP-340 verification fails, or if `time` differs from the wallet's current Unix time by more than 3600 seconds. A difference of exactly 3600 seconds is valid. For BIP-340 verification, wallets use the 32-byte x-coordinate of the compressed `pubkey`.
 
-With curl:
+If the wallet sent a challenge, it **MUST** also reject the response if `challenge` is missing, malformed, or does not exactly match the challenge sent in the corresponding request. If the wallet did not send a challenge, no challenge is required for verification.
+
+With curl, without a challenge:
+
+```bash
+curl -X GET https://mint.host:3338/v1/info
+```
+
+With a challenge:
 
 ```bash
 challenge=$(openssl rand -hex 32)
@@ -147,7 +157,7 @@ curl -X GET "https://mint.host:3338/v1/info?challenge=${challenge}"
 
 ## Test vectors
 
-[Test vectors](tests/06-tests.md) cover identity key derivation, signed challenges, and response verification.
+[Test vectors](tests/06-tests.md) cover identity key derivation and signed responses with and without challenges.
 
 [00]: 00.md
 [01]: 01.md

--- a/06.md
+++ b/06.md
@@ -6,12 +6,18 @@
 
 This endpoint returns information about the mint that a wallet can show to the user and use to make decisions on how to interact with the mint.
 
+## Request
+
+Wallets **MUST** include exactly one `challenge` query parameter in each `GET /v1/info` request. The challenge **MUST** be 32 bytes generated using a cryptographically secure random number generator, encoded as a 64-character lowercase hexadecimal string (`[0-9a-f]{64}`). Wallets **MUST** generate a fresh challenge for each request and retain it until the response has been verified.
+
+The mint **MUST** reject requests with a missing, repeated, or malformed `challenge` parameter with HTTP status code `400`, using the error response format in [NUT-00][00]. For a valid request, the mint **MUST** copy the challenge unchanged into `GetInfoResponse.challenge` and include it in the signed payload. Wallets **MUST** verify that the returned challenge exactly matches the challenge sent in the corresponding request.
+
 ## Example
 
 **Request** of `Alice`:
 
 ```http
-GET https://mint.host:3338/v1/info
+GET https://mint.host:3338/v1/info?challenge=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
 ```
 
 With the mint's response being of the form `GetInfoResponse`:
@@ -20,7 +26,8 @@ With the mint's response being of the form `GetInfoResponse`:
 {
   "name": "Bob's Cashu mint",
   "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
-  "signature": "256c3fc7773edf908d8d86bf0b1efe5cecbca0e152dfcc4e3d9cb9e5d3e643daa67f62aeb23c640783d46538a601d7907afed9b7db19f7dbdaccfc6dc8d8a227",
+  "signature": "6495ee5d693994f9a7e821e5baaf87791c50eb98bae9b2047bdb18cfbed4d92298816032c97aa6382ce6b4226efc8401d1ef7e2d8731bbb658bb6c44acc86df5",
+  "challenge": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
   "version": "Nutshell/0.15.0",
   "description": "The short mint description",
   "description_long": "A description that can be a long piece of text.",
@@ -88,11 +95,12 @@ With the mint's response being of the form `GetInfoResponse`:
 }
 ```
 
-For reproducibility, the example uses the UTF-8 encoding of `NUT-06 example mint seed` as the mint seed and zero-filled auxiliary randomness for BIP-340 signing.
+For reproducibility, the example uses the UTF-8 encoding of `NUT-06 example mint seed` as the mint seed, zero-filled auxiliary randomness for BIP-340 signing, and a fixed challenge consisting of the bytes `0x00` through `0x1f`. When verifying this example, use `1725304480` as the wallet's current Unix time. Actual requests use fresh random challenges as specified above.
 
 - (optional) `name` is the name of the mint and should be recognizable.
 - (mandatory) `pubkey` is the mint's identity public key as a lowercase hex-encoded, 33-byte compressed secp256k1 public key.
 - (mandatory) `signature` is the lowercase hex encoding of the mint's 64-byte BIP-340 Schnorr signature on the response payload, constructed as specified below.
+- (mandatory) `challenge` is the 64-character lowercase hexadecimal challenge from the request. It is included in the signed payload and **MUST** exactly match the challenge sent by the wallet.
 - (optional) `version` is the implementation name and the version of the software running on this mint separated with a slash "/".
 - (optional) `description` is a short description of the mint that can be shown in the wallet next to the mint's name.
 - (optional) `description_long` is a long description that can be shown in an additional field.
@@ -122,19 +130,24 @@ The mint **MUST** return this public key in `GetInfoResponse.pubkey`.
 The mint **MUST** sign every `GetInfoResponse` with the identity key corresponding to `pubkey`. To construct and sign the message:
 
 1. Start with the complete `GetInfoResponse` JSON object.
-2. Remove the top-level `signature` member. The `time` member remains in the object and is therefore included in the signed payload.
+2. Remove the top-level `signature` member. The `challenge` and `time` members remain in the object and are therefore included in the signed payload.
 3. Canonicalize the resulting JSON object using the JSON Canonicalization Scheme (JCS) defined in [RFC 8785]. Encode the canonical JSON as UTF-8.
 4. Compute the SHA-256 hash of those bytes.
 5. Sign the 32-byte hash using [BIP-340] Schnorr over secp256k1.
 6. Encode the resulting 64-byte signature as lowercase hexadecimal and return it in `GetInfoResponse.signature`.
 
-Wallets **MUST** reject the response if `pubkey`, `signature`, or `time` is missing or malformed, if BIP-340 verification fails, or if `time` differs from the wallet's current Unix time by more than 3600 seconds. A difference of exactly 3600 seconds is valid. For BIP-340 verification, wallets use the 32-byte x-coordinate of the compressed `pubkey`.
+Wallets **MUST** reject the response if `pubkey`, `signature`, `challenge`, or `time` is missing or malformed, if `challenge` does not exactly match the challenge sent in the corresponding request, if BIP-340 verification fails, or if `time` differs from the wallet's current Unix time by more than 3600 seconds. A difference of exactly 3600 seconds is valid. For BIP-340 verification, wallets use the 32-byte x-coordinate of the compressed `pubkey`.
 
 With curl:
 
 ```bash
-curl -X GET https://mint.host:3338/v1/info
+challenge=$(openssl rand -hex 32)
+curl -X GET "https://mint.host:3338/v1/info?challenge=${challenge}"
 ```
+
+## Test vectors
+
+[Test vectors](tests/06-tests.md) cover identity key derivation, signed challenges, and response verification.
 
 [00]: 00.md
 [01]: 01.md

--- a/tests/06-tests.md
+++ b/tests/06-tests.md
@@ -118,19 +118,23 @@ The following cases start from the minimal signed response without a challenge, 
 
 ## Request validation cases
 
-`C` denotes the example challenge above. All lengths below refer to the decoded query parameter value. A valid format alone does not demonstrate that a challenge was generated randomly; generating a fresh random challenge is the wallet's responsibility.
+`C` denotes the example challenge above. All lengths below refer to the URL-decoded query parameter value. Values longer than 64 characters are rejected before hex decoding or constructing and signing a response, without truncation. A valid format alone does not demonstrate that a challenge was generated randomly; generating a fresh random challenge is the wallet's responsibility.
 
-| Query                                                                  | Expected result                                     |
-| ---------------------------------------------------------------------- | --------------------------------------------------- |
-| `?challenge=C` with `C` substituted                                    | Valid request                                       |
-| No query parameter                                                     | Valid request; response omits `challenge`           |
-| `?challenge=`                                                          | HTTP `400`                                          |
-| Challenge is `C` with its final two characters removed (62 characters) | HTTP `400`                                          |
-| Challenge is `C` with `00` appended (66 characters)                    | HTTP `400`                                          |
-| Challenge is `C` with its final character removed (63 characters)      | HTTP `400`                                          |
-| Challenge is the uppercase encoding of `C`                             | HTTP `400`                                          |
-| Challenge is `C` with its first character replaced by `g`              | HTTP `400`                                          |
-| Two separate requests with `?challenge=C`, with `C` substituted        | Both valid; the mint does not track challenge reuse |
+| Query                                                                                                       | Expected result                                     |
+| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `?challenge=C` with `C` substituted                                                                         | Valid request                                       |
+| No query parameter                                                                                          | Valid request; response omits `challenge`           |
+| `?challenge=`                                                                                               | HTTP `400`                                          |
+| Challenge is `C` with its final two characters removed (62 characters)                                      | HTTP `400`                                          |
+| Challenge is `C` with `0` appended (65 characters)                                                          | HTTP `400`; exceeds the length limit                |
+| Challenge is `C` with `00` appended (66 characters)                                                         | HTTP `400`                                          |
+| Challenge is `0` repeated 4096 times (4096 characters)                                                      | HTTP `400`; exceeds the length limit                |
+| Challenge is `C` with every character percent-encoded (64 characters after URL decoding)                    | Valid request; response echoes `C`                  |
+| Challenge is `C` with `0` appended, with every character percent-encoded (65 characters after URL decoding) | HTTP `400`; exceeds the length limit                |
+| Challenge is `C` with its final character removed (63 characters)                                           | HTTP `400`                                          |
+| Challenge is the uppercase encoding of `C`                                                                  | HTTP `400`                                          |
+| Challenge is `C` with its first character replaced by `g`                                                   | HTTP `400`                                          |
+| Two separate requests with `?challenge=C`, with `C` substituted                                             | Both valid; the mint does not track challenge reuse |
 
 ## Full NUT-06 example
 

--- a/tests/06-tests.md
+++ b/tests/06-tests.md
@@ -1,6 +1,6 @@
 # NUT-06 Test Vectors
 
-These vectors use fixed challenges and timestamps for reproducibility. Wallets that include challenges generate fresh random challenges for actual requests as specified in [NUT-06](../06.md).
+These vectors use fixed request nonces and timestamps for reproducibility. Wallets that include request nonces generate fresh random request nonces for actual requests as specified in [NUT-06](../06.md).
 
 ## Identity key derivation
 
@@ -22,12 +22,12 @@ All signatures below use this identity key and the specified zero-filled BIP-340
 
 The message hash is `tagged_hash("Cashu_MintInfo_v1", bytes)`, where `bytes` is the canonical UTF-8 JSON after removing only `signature`. The UTF-8 tag hashes to `916a34ebf6f2244d64490e8eb2b5e7af19cdc45aa6176160186fc6543aa20d9b`. Decode this hex value into the raw 32-byte `tag_hash`; the message hash is `SHA256(tag_hash || tag_hash || bytes)`.
 
-## Minimal signed response with a challenge
+## Minimal signed response with a request nonce
 
 Request:
 
 ```http
-GET https://mint.host:3338/v1/info?challenge=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+GET https://mint.host:3338/v1/info?request_nonce=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
 ```
 
 Response:
@@ -35,8 +35,8 @@ Response:
 ```json
 {
   "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
-  "signature": "e22072aff2d70f9cb210ae5bb9a1d3fe44349cbde03fcd26a73e0c10e30bb3b801046db0b096d02f25c8cf76dd24ffd6c1906c3cbc98193c7d2d8d6978c95f0a",
-  "challenge": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "signature": "a2d6aefa3acbe4acf297225a4997153022be9439c8c83d7fc9e561f54baacade98a559ba28f444e2f9a543e4425d8d1c5fb0b20bfa647498509f244d9b4d9cff",
+  "request_nonce": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
   "time": 1725304480
 }
 ```
@@ -44,18 +44,18 @@ Response:
 After removing only `signature`, the canonical UTF-8 JSON is the following single line, without a trailing newline:
 
 ```text
-{"challenge":"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f","pubkey":"0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da","time":1725304480}
+{"pubkey":"0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da","request_nonce":"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f","time":1725304480}
 ```
 
 The tagged message hash signed by the mint is:
 
 ```text
-374353ff76b340d0010379009839f8b29152808ec393409cfb79abf4b19e65bc
+6d1b435163023cbbc5045d83d90718b4439be44b0b7648c87a920d40ee8aee6a
 ```
 
-With the request challenge above and the wallet's current Unix time set to `1725304480`, both signature verification and response validation succeed.
+With the request nonce above and the wallet's current Unix time set to `1725304480`, both signature verification and response validation succeed.
 
-## Minimal signed response without a challenge
+## Minimal signed response without a request nonce
 
 Request:
 
@@ -63,7 +63,7 @@ Request:
 GET https://mint.host:3338/v1/info
 ```
 
-The mint omits `challenge` and signs the response using the same identity key and auxiliary randomness:
+The mint omits `request_nonce` and signs the response using the same identity key and auxiliary randomness:
 
 ```json
 {
@@ -85,69 +85,69 @@ The tagged message hash signed by the mint is:
 f50b2ddcbb72c59c25a17019d310ab5e73d2506f508522fa521fbd336aa9159c
 ```
 
-With no request challenge and the wallet's current Unix time set to `1725304480`, both signature verification and response validation succeed.
+With no request nonce and the wallet's current Unix time set to `1725304480`, both signature verification and response validation succeed.
 
 ## Response verification cases
 
-Each row starts from the minimal signed response with a challenge, its request challenge, and the wallet time `1725304480`. Apply only the indicated change; keep the original signature. `C` denotes the example challenge, and `Z` denotes 64 zero characters, a different valid challenge.
+Each row starts from the minimal signed response with a request nonce, its request nonce, and the wallet time `1725304480`. Apply only the indicated change; keep the original signature. `C` denotes the example request nonce, and `Z` denotes 64 zero characters, a different valid request nonce.
 
-| Change                                                           | Expected result | Reason                                                                |
-| ---------------------------------------------------------------- | --------------- | --------------------------------------------------------------------- |
-| None                                                             | Accept          | Valid signature, matching challenge, and current timestamp            |
-| Reorder JSON members or change whitespace                        | Accept          | Canonical signed payload is unchanged                                 |
-| Request challenge is `Z`; response still contains `C`            | Reject          | Challenge mismatch, even though the signature remains valid           |
-| Response challenge is `Z`; request still contains `C`            | Reject          | Challenge mismatch and invalid signature                              |
-| Both request and response challenges are `Z`                     | Reject          | Challenge matches, but the signature does not cover the new challenge |
-| Remove `challenge`                                               | Reject          | Challenge was requested but is missing                                |
-| Uppercase the response challenge                                 | Reject          | Malformed challenge                                                   |
-| Set response challenge to JSON number `0`                        | Reject          | Malformed challenge                                                   |
-| Remove `pubkey`, `signature`, or `time`, testing each separately | Reject          | Missing required field                                                |
-| Set `time` to JSON string `"1725304480"`                         | Reject          | Malformed timestamp                                                   |
-| Set `time` to `1725304481`                                       | Reject          | Timestamp is within the allowed window, but the signature is invalid  |
-| Add `"name": "Another mint"`                                     | Reject          | Every response member except `signature` is signed                    |
-| Change the first signature byte from `0xe2` to `0xe3`            | Reject          | Invalid signature                                                     |
-| Wallet time is `1725300880`                                      | Accept          | Mint time is exactly 3600 seconds ahead                               |
-| Wallet time is `1725308080`                                      | Accept          | Mint time is exactly 3600 seconds behind                              |
-| Wallet time is `1725300879`                                      | Reject          | Mint time is 3601 seconds ahead                                       |
-| Wallet time is `1725308081`                                      | Reject          | Mint time is 3601 seconds behind                                      |
+| Change                                                           | Expected result | Reason                                                                        |
+| ---------------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------- |
+| None                                                             | Accept          | Valid signature, matching request nonce, and current timestamp                |
+| Reorder JSON members or change whitespace                        | Accept          | Canonical signed payload is unchanged                                         |
+| Request nonce is `Z`; response still contains `C`                | Reject          | Request nonce mismatch, even though the signature remains valid               |
+| Response nonce is `Z`; request still contains `C`                | Reject          | Request nonce mismatch and invalid signature                                  |
+| Both request and response nonces are `Z`                         | Reject          | Request nonce matches, but the signature does not cover the new request nonce |
+| Remove `request_nonce`                                           | Reject          | Request nonce was requested but is missing                                    |
+| Uppercase the response nonce                                     | Reject          | Malformed request nonce                                                       |
+| Set response nonce to JSON number `0`                            | Reject          | Malformed request nonce                                                       |
+| Remove `pubkey`, `signature`, or `time`, testing each separately | Reject          | Missing required field                                                        |
+| Set `time` to JSON string `"1725304480"`                         | Reject          | Malformed timestamp                                                           |
+| Set `time` to `1725304481`                                       | Reject          | Timestamp is within the allowed window, but the signature is invalid          |
+| Add `"name": "Another mint"`                                     | Reject          | Every response member except `signature` is signed                            |
+| Change the first signature byte from `0xa2` to `0xa3`            | Reject          | Invalid signature                                                             |
+| Wallet time is `1725300880`                                      | Accept          | Mint time is exactly 3600 seconds ahead                                       |
+| Wallet time is `1725308080`                                      | Accept          | Mint time is exactly 3600 seconds behind                                      |
+| Wallet time is `1725300879`                                      | Reject          | Mint time is 3601 seconds ahead                                               |
+| Wallet time is `1725308081`                                      | Reject          | Mint time is 3601 seconds behind                                              |
 
-The following cases start from the minimal signed response without a challenge, a request without a challenge, and the wallet time `1725304480`. Apply only the indicated change; keep the original signature unless specified otherwise.
+The following cases start from the minimal signed response without a request nonce, a request without a request nonce, and the wallet time `1725304480`. Apply only the indicated change; keep the original signature unless specified otherwise.
 
-| Change                                                                                        | Expected result | Reason                                                                          |
-| --------------------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------- |
-| None                                                                                          | Accept          | Valid signed response to a request without a challenge                          |
-| Request challenge is `C`                                                                      | Reject          | Challenge was requested but is missing, even though the signature remains valid |
-| Replace the signature with the minimal response's signature from the example with a challenge | Reject          | That signature covers a payload containing `challenge`                          |
-| Add `"challenge": C` and set the request challenge to `C`                                     | Reject          | Challenge matches, but the signature does not cover the added member            |
+| Change                                                                                            | Expected result | Reason                                                                              |
+| ------------------------------------------------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------- |
+| None                                                                                              | Accept          | Valid signed response to a request without a request nonce                          |
+| Request nonce is `C`                                                                              | Reject          | Request nonce was requested but is missing, even though the signature remains valid |
+| Replace the signature with the minimal response's signature from the example with a request nonce | Reject          | That signature covers a payload containing `request_nonce`                          |
+| Add `"request_nonce": C` and set the request nonce to `C`                                         | Reject          | Request nonce matches, but the signature does not cover the added member            |
 
 ## Request validation cases
 
-`C` denotes the example challenge above. All lengths below refer to the URL-decoded query parameter value. Values longer than 64 characters are rejected before hex decoding or constructing and signing a response, without truncation. A valid format alone does not demonstrate that a challenge was generated randomly; generating a fresh random challenge is the wallet's responsibility.
+`C` denotes the example request nonce above. All lengths below refer to the URL-decoded query parameter value. Values longer than 64 characters are rejected before hex decoding or constructing and signing a response, without truncation. A valid format alone does not demonstrate that a request nonce was generated randomly; generating a fresh random request nonce is the wallet's responsibility.
 
-| Query                                                                                                       | Expected result                                     |
-| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `?challenge=C` with `C` substituted                                                                         | Valid request                                       |
-| No query parameter                                                                                          | Valid request; response omits `challenge`           |
-| `?challenge=`                                                                                               | HTTP `400`                                          |
-| Challenge is `C` with its final two characters removed (62 characters)                                      | HTTP `400`                                          |
-| Challenge is `C` with `0` appended (65 characters)                                                          | HTTP `400`; exceeds the length limit                |
-| Challenge is `C` with `00` appended (66 characters)                                                         | HTTP `400`                                          |
-| Challenge is `0` repeated 4096 times (4096 characters)                                                      | HTTP `400`; exceeds the length limit                |
-| Challenge is `C` with every character percent-encoded (64 characters after URL decoding)                    | Valid request; response echoes `C`                  |
-| Challenge is `C` with `0` appended, with every character percent-encoded (65 characters after URL decoding) | HTTP `400`; exceeds the length limit                |
-| Challenge is `C` with its final character removed (63 characters)                                           | HTTP `400`                                          |
-| Challenge is the uppercase encoding of `C`                                                                  | HTTP `400`                                          |
-| Challenge is `C` with its first character replaced by `g`                                                   | HTTP `400`                                          |
-| Two separate requests with `?challenge=C`, with `C` substituted                                             | Both valid; the mint does not track challenge reuse |
+| Query                                                                                                           | Expected result                                         |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `?request_nonce=C` with `C` substituted                                                                         | Valid request                                           |
+| No query parameter                                                                                              | Valid request; response omits `request_nonce`           |
+| `?request_nonce=`                                                                                               | HTTP `400`                                              |
+| Request nonce is `C` with its final two characters removed (62 characters)                                      | HTTP `400`                                              |
+| Request nonce is `C` with `0` appended (65 characters)                                                          | HTTP `400`; exceeds the length limit                    |
+| Request nonce is `C` with `00` appended (66 characters)                                                         | HTTP `400`                                              |
+| Request nonce is `0` repeated 4096 times (4096 characters)                                                      | HTTP `400`; exceeds the length limit                    |
+| Request nonce is `C` with every character percent-encoded (64 characters after URL decoding)                    | Valid request; response echoes `C`                      |
+| Request nonce is `C` with `0` appended, with every character percent-encoded (65 characters after URL decoding) | HTTP `400`; exceeds the length limit                    |
+| Request nonce is `C` with its final character removed (63 characters)                                           | HTTP `400`                                              |
+| Request nonce is the uppercase encoding of `C`                                                                  | HTTP `400`                                              |
+| Request nonce is `C` with its first character replaced by `g`                                                   | HTTP `400`                                              |
+| Two separate requests with `?request_nonce=C`, with `C` substituted                                             | Both valid; the mint does not track request nonce reuse |
 
 ## Full NUT-06 example
 
-The complete response in the [NUT-06 example](../06.md#example) uses the same seed, challenge, timestamp, and auxiliary randomness. After removing only `signature` and canonicalizing the remaining object, the expected tagged message hash and signature are:
+The complete response in the [NUT-06 example](../06.md#example) uses the same seed, request nonce, timestamp, and auxiliary randomness. After removing only `signature` and canonicalizing the remaining object, the expected tagged message hash and signature are:
 
 ```json
 {
-  "message_hash": "3c08960dfc7c5f62e489271ed44cf82240b3fe48a13968179683461444855db6",
-  "signature": "e91f667871ff922f7430aee729bc0252ff893ec2b05ef2b0f98376f7f5119b152029b363f89c35ffa2d8e3395c889c5caa2484c8b716cc18881dad7b6ef9a739"
+  "message_hash": "980585d03284414d98f1c21d32e9f6985a9fca94c69f6f56a7e3d40c89304b87",
+  "signature": "a7e3a3bd6a1c4d6be9311f26c54617e51da8d8bc22fdbe78a61c6c824dec06845bd4d7fc9ee0db8e94837029913b9fbd034afd1f0a668d1e9f032af20c213004"
 }
 ```
 
@@ -157,8 +157,8 @@ The following signatures were made over plain `SHA256(bytes)` using the same ide
 
 ```json
 {
-  "minimal_with_challenge": "77cc645a451e744ef2d0d05ef09166cae27e9baf38afd5ab1301739d5444e144db224b0f29bfa0941ec3d228a74c50a5287bb6664333e4261d641f806bc4a672",
-  "minimal_without_challenge": "446f52ec13fea5410092eb2d26c28cd9c56b141fa9feb3c60c3845766038905ba44480bc24b0e202278634d724c07560d9f8528ee64db016e48016cb03c409a0",
-  "full_example": "6495ee5d693994f9a7e821e5baaf87791c50eb98bae9b2047bdb18cfbed4d92298816032c97aa6382ce6b4226efc8401d1ef7e2d8731bbb658bb6c44acc86df5"
+  "minimal_with_request_nonce": "6264f69d79bae5696b59080817e41612ac26f9539e1ae42900648d0b4ce48cb4cc1532eebd110a5a4c66cf130a11bc326c39c29ce969eeb32728e196c9605350",
+  "minimal_without_request_nonce": "446f52ec13fea5410092eb2d26c28cd9c56b141fa9feb3c60c3845766038905ba44480bc24b0e202278634d724c07560d9f8528ee64db016e48016cb03c409a0",
+  "full_example": "d14914e8d51baa3860c47145dc35c0d6c187b2df565e833a2ccbde2a45c6b7e19d42a9fc4d4f5209adee2cf407bb5b168be75149679412ef23bcdc0e7d177955"
 }
 ```

--- a/tests/06-tests.md
+++ b/tests/06-tests.md
@@ -18,6 +18,10 @@ The seed is the UTF-8 encoding of `NUT-06 example mint seed`. With the domain se
 
 All signatures below use this identity key and the specified zero-filled BIP-340 auxiliary randomness. Verification uses the 32-byte x-coordinate of the compressed public key.
 
+## Signature message hash
+
+The message hash is `tagged_hash("Cashu_MintInfo_v1", bytes)`, where `bytes` is the canonical UTF-8 JSON after removing only `signature`. The UTF-8 tag hashes to `916a34ebf6f2244d64490e8eb2b5e7af19cdc45aa6176160186fc6543aa20d9b`. Decode this hex value into the raw 32-byte `tag_hash`; the message hash is `SHA256(tag_hash || tag_hash || bytes)`.
+
 ## Minimal signed response with a challenge
 
 Request:
@@ -31,7 +35,7 @@ Response:
 ```json
 {
   "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
-  "signature": "77cc645a451e744ef2d0d05ef09166cae27e9baf38afd5ab1301739d5444e144db224b0f29bfa0941ec3d228a74c50a5287bb6664333e4261d641f806bc4a672",
+  "signature": "e22072aff2d70f9cb210ae5bb9a1d3fe44349cbde03fcd26a73e0c10e30bb3b801046db0b096d02f25c8cf76dd24ffd6c1906c3cbc98193c7d2d8d6978c95f0a",
   "challenge": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
   "time": 1725304480
 }
@@ -43,10 +47,10 @@ After removing only `signature`, the canonical UTF-8 JSON is the following singl
 {"challenge":"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f","pubkey":"0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da","time":1725304480}
 ```
 
-The SHA-256 hash signed by the mint is:
+The tagged message hash signed by the mint is:
 
 ```text
-a586404ca44b8dbffbd732a1dc881905411d7558c40bb7c63855ffc9a0b1e913
+374353ff76b340d0010379009839f8b29152808ec393409cfb79abf4b19e65bc
 ```
 
 With the request challenge above and the wallet's current Unix time set to `1725304480`, both signature verification and response validation succeed.
@@ -64,7 +68,7 @@ The mint omits `challenge` and signs the response using the same identity key an
 ```json
 {
   "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
-  "signature": "446f52ec13fea5410092eb2d26c28cd9c56b141fa9feb3c60c3845766038905ba44480bc24b0e202278634d724c07560d9f8528ee64db016e48016cb03c409a0",
+  "signature": "1d48ab4a18f5680f9cbc28481c1c9921615cd0fbb8a8f3a015ec47ddf4720b69f7e870d8195c65b30445ce35b0d3035819ccc3adbea741873cf1e44cb9a48998",
   "time": 1725304480
 }
 ```
@@ -75,10 +79,10 @@ After removing only `signature`, the canonical UTF-8 JSON is the following singl
 {"pubkey":"0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da","time":1725304480}
 ```
 
-The SHA-256 hash signed by the mint is:
+The tagged message hash signed by the mint is:
 
 ```text
-10f9a05585b71ce112269d10a16acbe1f81835958be3fcfc1d8b63cbbef0bb55
+f50b2ddcbb72c59c25a17019d310ab5e73d2506f508522fa521fbd336aa9159c
 ```
 
 With no request challenge and the wallet's current Unix time set to `1725304480`, both signature verification and response validation succeed.
@@ -101,7 +105,7 @@ Each row starts from the minimal signed response with a challenge, its request c
 | Set `time` to JSON string `"1725304480"`                         | Reject          | Malformed timestamp                                                   |
 | Set `time` to `1725304481`                                       | Reject          | Timestamp is within the allowed window, but the signature is invalid  |
 | Add `"name": "Another mint"`                                     | Reject          | Every response member except `signature` is signed                    |
-| Change the first signature byte from `0x77` to `0x76`            | Reject          | Invalid signature                                                     |
+| Change the first signature byte from `0xe2` to `0xe3`            | Reject          | Invalid signature                                                     |
 | Wallet time is `1725300880`                                      | Accept          | Mint time is exactly 3600 seconds ahead                               |
 | Wallet time is `1725308080`                                      | Accept          | Mint time is exactly 3600 seconds behind                              |
 | Wallet time is `1725300879`                                      | Reject          | Mint time is 3601 seconds ahead                                       |
@@ -138,11 +142,23 @@ The following cases start from the minimal signed response without a challenge, 
 
 ## Full NUT-06 example
 
-The complete response in the [NUT-06 example](../06.md#example) uses the same seed, challenge, timestamp, and auxiliary randomness. After removing only `signature` and canonicalizing the remaining object, the expected hash and signature are:
+The complete response in the [NUT-06 example](../06.md#example) uses the same seed, challenge, timestamp, and auxiliary randomness. After removing only `signature` and canonicalizing the remaining object, the expected tagged message hash and signature are:
 
 ```json
 {
-  "sha256": "5c318faedf41fb96835b18c775abf2f24bb5712310585aaf8a8d101ff2533344",
-  "signature": "6495ee5d693994f9a7e821e5baaf87791c50eb98bae9b2047bdb18cfbed4d92298816032c97aa6382ce6b4226efc8401d1ef7e2d8731bbb658bb6c44acc86df5"
+  "message_hash": "3c08960dfc7c5f62e489271ed44cf82240b3fe48a13968179683461444855db6",
+  "signature": "e91f667871ff922f7430aee729bc0252ff893ec2b05ef2b0f98376f7f5119b152029b363f89c35ffa2d8e3395c889c5caa2484c8b716cc18881dad7b6ef9a739"
+}
+```
+
+## Untagged signatures (invalid)
+
+The following signatures were made over plain `SHA256(bytes)` using the same identity key and auxiliary randomness. Substituting each signature into its corresponding response above **MUST** fail verification against the tagged message hash:
+
+```json
+{
+  "minimal_with_challenge": "77cc645a451e744ef2d0d05ef09166cae27e9baf38afd5ab1301739d5444e144db224b0f29bfa0941ec3d228a74c50a5287bb6664333e4261d641f806bc4a672",
+  "minimal_without_challenge": "446f52ec13fea5410092eb2d26c28cd9c56b141fa9feb3c60c3845766038905ba44480bc24b0e202278634d724c07560d9f8528ee64db016e48016cb03c409a0",
+  "full_example": "6495ee5d693994f9a7e821e5baaf87791c50eb98bae9b2047bdb18cfbed4d92298816032c97aa6382ce6b4226efc8401d1ef7e2d8731bbb658bb6c44acc86df5"
 }
 ```

--- a/tests/06-tests.md
+++ b/tests/06-tests.md
@@ -1,0 +1,103 @@
+# NUT-06 Test Vectors
+
+These vectors use fixed challenges and timestamps for reproducibility. Wallets generate fresh random challenges for actual requests as specified in [NUT-06](../06.md).
+
+## Identity key derivation
+
+The seed is the UTF-8 encoding of `NUT-06 example mint seed`. With the domain separator `Cashu_Mint_Identity_v1` and the one-byte counter `0x00`, HMAC-SHA256 produces a valid secret key on the first attempt:
+
+```json
+{
+  "seed_hex": "4e55542d3036206578616d706c65206d696e742073656564",
+  "counter": 0,
+  "secret_key": "3842a716975d6611d7ae4b36e28068c963e6d8ddb2b70d031d46a79d1df24c3c",
+  "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
+  "aux_rand": "0000000000000000000000000000000000000000000000000000000000000000"
+}
+```
+
+Both signatures below use this identity key and the specified zero-filled BIP-340 auxiliary randomness. Verification uses the 32-byte x-coordinate of the compressed public key.
+
+## Minimal signed response
+
+Request:
+
+```http
+GET https://mint.host:3338/v1/info?challenge=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+```
+
+Response:
+
+```json
+{
+  "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
+  "signature": "77cc645a451e744ef2d0d05ef09166cae27e9baf38afd5ab1301739d5444e144db224b0f29bfa0941ec3d228a74c50a5287bb6664333e4261d641f806bc4a672",
+  "challenge": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "time": 1725304480
+}
+```
+
+After removing only `signature`, the canonical UTF-8 JSON is the following single line, without a trailing newline:
+
+```text
+{"challenge":"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f","pubkey":"0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da","time":1725304480}
+```
+
+The SHA-256 hash signed by the mint is:
+
+```text
+a586404ca44b8dbffbd732a1dc881905411d7558c40bb7c63855ffc9a0b1e913
+```
+
+With the request challenge above and the wallet's current Unix time set to `1725304480`, both signature verification and response validation succeed.
+
+## Response verification cases
+
+Each row starts from the minimal signed response, its request challenge, and the wallet time `1725304480`. Apply only the indicated change; keep the original signature. `C` denotes the example challenge, and `Z` denotes 64 zero characters, a different valid challenge.
+
+| Change                                                           | Expected result | Reason                                                                |
+| ---------------------------------------------------------------- | --------------- | --------------------------------------------------------------------- |
+| None                                                             | Accept          | Valid signature, matching challenge, and current timestamp            |
+| Reorder JSON members or change whitespace                        | Accept          | Canonical signed payload is unchanged                                 |
+| Request challenge is `Z`; response still contains `C`            | Reject          | Challenge mismatch, even though the signature remains valid           |
+| Response challenge is `Z`; request still contains `C`            | Reject          | Challenge mismatch and invalid signature                              |
+| Both request and response challenges are `Z`                     | Reject          | Challenge matches, but the signature does not cover the new challenge |
+| Remove `challenge`                                               | Reject          | Missing required challenge                                            |
+| Uppercase the response challenge                                 | Reject          | Malformed challenge                                                   |
+| Set response challenge to JSON number `0`                        | Reject          | Malformed challenge                                                   |
+| Remove `pubkey`, `signature`, or `time`, testing each separately | Reject          | Missing required field                                                |
+| Set `time` to JSON string `"1725304480"`                         | Reject          | Malformed timestamp                                                   |
+| Set `time` to `1725304481`                                       | Reject          | Timestamp is within the allowed window, but the signature is invalid  |
+| Add `"name": "Another mint"`                                     | Reject          | Every response member except `signature` is signed                    |
+| Change the first signature byte from `0x77` to `0x76`            | Reject          | Invalid signature                                                     |
+| Wallet time is `1725300880`                                      | Accept          | Mint time is exactly 3600 seconds ahead                               |
+| Wallet time is `1725308080`                                      | Accept          | Mint time is exactly 3600 seconds behind                              |
+| Wallet time is `1725300879`                                      | Reject          | Mint time is 3601 seconds ahead                                       |
+| Wallet time is `1725308081`                                      | Reject          | Mint time is 3601 seconds behind                                      |
+
+## Request validation cases
+
+`C` denotes the example challenge above. All lengths below refer to the decoded query parameter value. A valid format alone does not demonstrate that a challenge was generated randomly; generating a fresh random challenge is the wallet's responsibility.
+
+| Query                                                                  | Expected result |
+| ---------------------------------------------------------------------- | --------------- |
+| `?challenge=C` with `C` substituted                                    | Valid request   |
+| No query parameter                                                     | HTTP `400`      |
+| `?challenge=`                                                          | HTTP `400`      |
+| Challenge is `C` with its final two characters removed (62 characters) | HTTP `400`      |
+| Challenge is `C` with `00` appended (66 characters)                    | HTTP `400`      |
+| Challenge is `C` with its final character removed (63 characters)      | HTTP `400`      |
+| Challenge is the uppercase encoding of `C`                             | HTTP `400`      |
+| Challenge is `C` with its first character replaced by `g`              | HTTP `400`      |
+| `?challenge=C&challenge=C` with `C` substituted                        | HTTP `400`      |
+
+## Full NUT-06 example
+
+The complete response in the [NUT-06 example](../06.md#example) uses the same seed, challenge, timestamp, and auxiliary randomness. After removing only `signature` and canonicalizing the remaining object, the expected hash and signature are:
+
+```json
+{
+  "sha256": "5c318faedf41fb96835b18c775abf2f24bb5712310585aaf8a8d101ff2533344",
+  "signature": "6495ee5d693994f9a7e821e5baaf87791c50eb98bae9b2047bdb18cfbed4d92298816032c97aa6382ce6b4226efc8401d1ef7e2d8731bbb658bb6c44acc86df5"
+}
+```

--- a/tests/06-tests.md
+++ b/tests/06-tests.md
@@ -1,6 +1,6 @@
 # NUT-06 Test Vectors
 
-These vectors use fixed challenges and timestamps for reproducibility. Wallets generate fresh random challenges for actual requests as specified in [NUT-06](../06.md).
+These vectors use fixed challenges and timestamps for reproducibility. Wallets that include challenges generate fresh random challenges for actual requests as specified in [NUT-06](../06.md).
 
 ## Identity key derivation
 
@@ -16,9 +16,9 @@ The seed is the UTF-8 encoding of `NUT-06 example mint seed`. With the domain se
 }
 ```
 
-Both signatures below use this identity key and the specified zero-filled BIP-340 auxiliary randomness. Verification uses the 32-byte x-coordinate of the compressed public key.
+All signatures below use this identity key and the specified zero-filled BIP-340 auxiliary randomness. Verification uses the 32-byte x-coordinate of the compressed public key.
 
-## Minimal signed response
+## Minimal signed response with a challenge
 
 Request:
 
@@ -51,9 +51,41 @@ a586404ca44b8dbffbd732a1dc881905411d7558c40bb7c63855ffc9a0b1e913
 
 With the request challenge above and the wallet's current Unix time set to `1725304480`, both signature verification and response validation succeed.
 
+## Minimal signed response without a challenge
+
+Request:
+
+```http
+GET https://mint.host:3338/v1/info
+```
+
+The mint omits `challenge` and signs the response using the same identity key and auxiliary randomness:
+
+```json
+{
+  "pubkey": "0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da",
+  "signature": "446f52ec13fea5410092eb2d26c28cd9c56b141fa9feb3c60c3845766038905ba44480bc24b0e202278634d724c07560d9f8528ee64db016e48016cb03c409a0",
+  "time": 1725304480
+}
+```
+
+After removing only `signature`, the canonical UTF-8 JSON is the following single line, without a trailing newline:
+
+```text
+{"pubkey":"0338596797cef0627f653cd6568387361b00314add55d9f1ea9c94f46ae421e3da","time":1725304480}
+```
+
+The SHA-256 hash signed by the mint is:
+
+```text
+10f9a05585b71ce112269d10a16acbe1f81835958be3fcfc1d8b63cbbef0bb55
+```
+
+With no request challenge and the wallet's current Unix time set to `1725304480`, both signature verification and response validation succeed.
+
 ## Response verification cases
 
-Each row starts from the minimal signed response, its request challenge, and the wallet time `1725304480`. Apply only the indicated change; keep the original signature. `C` denotes the example challenge, and `Z` denotes 64 zero characters, a different valid challenge.
+Each row starts from the minimal signed response with a challenge, its request challenge, and the wallet time `1725304480`. Apply only the indicated change; keep the original signature. `C` denotes the example challenge, and `Z` denotes 64 zero characters, a different valid challenge.
 
 | Change                                                           | Expected result | Reason                                                                |
 | ---------------------------------------------------------------- | --------------- | --------------------------------------------------------------------- |
@@ -62,7 +94,7 @@ Each row starts from the minimal signed response, its request challenge, and the
 | Request challenge is `Z`; response still contains `C`            | Reject          | Challenge mismatch, even though the signature remains valid           |
 | Response challenge is `Z`; request still contains `C`            | Reject          | Challenge mismatch and invalid signature                              |
 | Both request and response challenges are `Z`                     | Reject          | Challenge matches, but the signature does not cover the new challenge |
-| Remove `challenge`                                               | Reject          | Missing required challenge                                            |
+| Remove `challenge`                                               | Reject          | Challenge was requested but is missing                                |
 | Uppercase the response challenge                                 | Reject          | Malformed challenge                                                   |
 | Set response challenge to JSON number `0`                        | Reject          | Malformed challenge                                                   |
 | Remove `pubkey`, `signature`, or `time`, testing each separately | Reject          | Missing required field                                                |
@@ -75,21 +107,30 @@ Each row starts from the minimal signed response, its request challenge, and the
 | Wallet time is `1725300879`                                      | Reject          | Mint time is 3601 seconds ahead                                       |
 | Wallet time is `1725308081`                                      | Reject          | Mint time is 3601 seconds behind                                      |
 
+The following cases start from the minimal signed response without a challenge, a request without a challenge, and the wallet time `1725304480`. Apply only the indicated change; keep the original signature unless specified otherwise.
+
+| Change                                                                                        | Expected result | Reason                                                                          |
+| --------------------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------- |
+| None                                                                                          | Accept          | Valid signed response to a request without a challenge                          |
+| Request challenge is `C`                                                                      | Reject          | Challenge was requested but is missing, even though the signature remains valid |
+| Replace the signature with the minimal response's signature from the example with a challenge | Reject          | That signature covers a payload containing `challenge`                          |
+| Add `"challenge": C` and set the request challenge to `C`                                     | Reject          | Challenge matches, but the signature does not cover the added member            |
+
 ## Request validation cases
 
 `C` denotes the example challenge above. All lengths below refer to the decoded query parameter value. A valid format alone does not demonstrate that a challenge was generated randomly; generating a fresh random challenge is the wallet's responsibility.
 
-| Query                                                                  | Expected result |
-| ---------------------------------------------------------------------- | --------------- |
-| `?challenge=C` with `C` substituted                                    | Valid request   |
-| No query parameter                                                     | HTTP `400`      |
-| `?challenge=`                                                          | HTTP `400`      |
-| Challenge is `C` with its final two characters removed (62 characters) | HTTP `400`      |
-| Challenge is `C` with `00` appended (66 characters)                    | HTTP `400`      |
-| Challenge is `C` with its final character removed (63 characters)      | HTTP `400`      |
-| Challenge is the uppercase encoding of `C`                             | HTTP `400`      |
-| Challenge is `C` with its first character replaced by `g`              | HTTP `400`      |
-| `?challenge=C&challenge=C` with `C` substituted                        | HTTP `400`      |
+| Query                                                                  | Expected result                                     |
+| ---------------------------------------------------------------------- | --------------------------------------------------- |
+| `?challenge=C` with `C` substituted                                    | Valid request                                       |
+| No query parameter                                                     | Valid request; response omits `challenge`           |
+| `?challenge=`                                                          | HTTP `400`                                          |
+| Challenge is `C` with its final two characters removed (62 characters) | HTTP `400`                                          |
+| Challenge is `C` with `00` appended (66 characters)                    | HTTP `400`                                          |
+| Challenge is `C` with its final character removed (63 characters)      | HTTP `400`                                          |
+| Challenge is the uppercase encoding of `C`                             | HTTP `400`                                          |
+| Challenge is `C` with its first character replaced by `g`              | HTTP `400`                                          |
+| Two separate requests with `?challenge=C`, with `C` substituted        | Both valid; the mint does not track challenge reuse |
 
 ## Full NUT-06 example
 


### PR DESCRIPTION
# Implementations

- [ ] Nutshell: https://github.com/cashubtc/nutshell/pull/1125
- [x] Cashu-TS: https://github.com/cashubtc/cashu-ts/pull/990
- [ ] CDK: TBC: https://github.com/cashubtc/cdk/pull/2424

## Summary

- standardize derivation of the mint identity key from the mint seed
- make the mint identity public key mandatory
- require a BIP-340 Schnorr signature over the RFC 8785 canonicalized info response, excluding `time` and `signature`
- require wallets to reject missing, malformed, or invalid signatures
- add a reproducible, cryptographically verified example

## Validation

- `npx prettier@3.9.1 --check 06.md`
- verified that the example public key derives from the documented seed and that its signature validates against the specified payload