### PR TITLE
NUT-23: add per-quote description hashes

### DIFF
--- a/23.md
+++ b/23.md
@@ -16,9 +16,16 @@ For the `bolt11` method, the wallet includes the following specific `PostMintQuo
 {
   "amount": <int>,
   "unit": <str_enum[UNIT]>,
-  "description": <str> // Optional
+  "description": <str>, // Optional
+  "description_hash": <bool> // Optional, default false
 }
 ```
+
+If `description_hash` is `true`, `description` **MUST** be present. The mint **MUST** return a BOLT11 invoice containing an `h` tag equal to the SHA-256 hash of the UTF-8 encoded `description` and **MUST NOT** include a `d` tag. This allows the invoice to commit to exact data that is provided to the payer out of band.
+
+If `description_hash` is `false` or omitted, the existing `description` behavior is unchanged: a mint that supports descriptions includes the value in the invoice's `d` tag.
+
+Wallets **SHOULD** request a description hash only when the mint advertises support. A mint that cannot produce the requested description hash **MUST** reject the quote request.
 
 The mint responds with a `PostMintQuoteBolt11Response`:
 
@@ -122,7 +129,7 @@ Response:
 
 ## Mint Settings
 
-A `description` option **MUST** be set to indicate whether the `bolt11` payment method backend supports providing an invoice description.
+A `description` option **MUST** be set to indicate whether the `bolt11` payment method backend supports providing a plaintext invoice description. A `description_hash` option **MUST** be set to indicate whether it supports committing to the supplied description with an invoice description hash.
 
 ### Example `MintMethodSetting`
 
@@ -133,7 +140,8 @@ A `description` option **MUST** be set to indicate whether the `bolt11` payment 
   "min_amount": 0,
   "max_amount": 10000,
   "options": {
-    "description": true
+    "description": true,
+    "description_hash": true
   }
 }
 ```


### PR DESCRIPTION
## Summary

- add an optional per-quote `description_hash` boolean to BOLT11 mint quote requests
- define the exact `h = SHA256(UTF8(description))` behavior
- preserve the current plaintext `d` behavior when the option is omitted or false
- advertise support independently as `options.description_hash`

## Motivation

Some protocols provide the invoice description out of band and require the BOLT11 invoice to commit to its exact bytes. NIP-57 zap requests are one example. A mint-wide setting would regress ordinary Cashu deposit memos, so the choice needs to be made independently for each quote.

Reference implementation: cashubtc/nutshell#1105
Client integration: candypoets/lnuts#1
