### PR TITLE
Mint Quote Lookup by Public Key spec fixes

### DIFF
--- a/xx.md
+++ b/xx.md
@@ -38,6 +38,8 @@ For each `pubkey`, the corresponding `pubkey_signatures` entry signs the SHA-256
 
 The mint **MUST** reject the request unless every signature is valid.
 
+The mint **MUST** limit the number of public keys accepted in a single request, and **MUST** reject a request that exceeds the limit with error code `11017`. Every signature has to be verified before the mint can tell whether the caller is entitled to any quote, so this limit is what bounds the work an unauthenticated caller can ask the mint to perform.
+
 ## Response
 
 The mint responds with a `PostMintQuotesByPubkeyResponse`:
@@ -59,10 +61,16 @@ The settings for this NUT are part of the mint info response ([NUT-06][06]):
 ```json
 {
   "XX": {
-    "supported": <bool>
+    "supported": <bool>,
+    "max_pubkeys": <int>
   }
 }
 ```
+
+Fields:
+
+- `supported` (required): whether the mint serves this endpoint.
+- `max_pubkeys` (optional): maximum number of public keys accepted in a single request. If omitted, the limit is implementation-defined and wallets **MUST** handle error code `11017` gracefully.
 
 [04]: 04.md
 [06]: 06.md

--- a/xx.md
+++ b/xx.md
@@ -10,10 +10,10 @@ This NUT adds an endpoint for wallets to get all NUT-20 locked mint quotes assoc
 
 ## Request
 
-To query quotes assigned to a public key, the wallet makes a `POST /v1/mint/quote/{method}/pubkey` request.
+To query quotes assigned to a public key, the wallet makes a `POST /v1/mint/quote/pubkey` request.
 
 ```http
-POST https://mint.host:3338/v1/mint/quote/bolt11/pubkey
+POST https://mint.host:3338/v1/mint/quote/pubkey
 ```
 
 The wallet includes the following `PostMintQuotesByPubkeyRequest` data:
@@ -49,6 +49,8 @@ The mint responds with a `PostMintQuotesByPubkeyResponse`:
 ```
 
 Where `MintQuoteResponse` is the quote response type defined in [NUT-04][04].
+
+The response contains the quotes locked to `pubkeys` across every payment method. Each `MintQuoteResponse` carries the `method` field defined in [NUT-04][04], so a wallet can tell the methods apart without naming one in the request.
 
 ## Settings
 


### PR DESCRIPTION
Two amendments to #341, one commit each — commit messages carry the full reasoning.
 
Drop `{method}` from the path. The endpoint answers "what does this key own," and a NUT-20 key locks quotes of any payment method — so the segment forces one request per method and buys nothing. The signature doesn't cover it, and every `MintQuoteResponse` already carries a method field (NUT-04), so a mixed-method response is unambiguous without it.
 
Bound the pubkey count. The mint must verify every signature before it can tell whether the caller is entitled to anything, so request length decides how much work an anonymous caller can demand. Adds a MUST to limit it, error `11017` on overflow, and an optional `max_pubkeys` in the NUT-06 settings — the same shape NUT-29 already uses for `max_batch_size`.