### PR TITLE
NUT-07: define UNSPENT for a Y the mint has no record of

### DIFF
--- a/07.md
+++ b/07.md
@@ -12,7 +12,7 @@ With the token state check, wallets can ask the mint whether a specific proof is
 
 A proof can be in one of the following states
 
-- A proof is `UNSPENT` if it has not been spent yet
+- A proof is `UNSPENT` if it has not been spent yet, or if the mint has no record of it (an unissued secret is indistinguishable from an unspent `Proof`).
 - A proof is `PENDING` if it is being processed in a transaction (in an ongoing payment). A `PENDING` proof cannot be used in another transaction until it is `live` again.
 - A proof is `SPENT` if it has been redeemed and its secret is in the list of spent secrets of the mint.
 


### PR DESCRIPTION
NUT-07 defines `UNSPENT` as a proof that "has not been spent yet", which reads as a statement about a proof the mint knows exists. It cannot know that.

A mint records a `BlindedMessage`'s `B_` when it signs it, and a `Proof`'s `Y` when it is spent, and cannot link the two. For a proof that was issued and never spent it therefore holds no `Y` at all, so a `Y` it has never seen is indistinguishable from one belonging to an unspent proof. No third answer is available to a correctly blinded mint: being able to give one would mean it had linked `Y` to `B_`.

Both reference implementations already behave this way, arrived at independently and with no rule to follow:

- nutshell, `cashu/mint/db/read.py:64-66`: collects the spent and pending sets, and defaults everything else to `UNSPENT`
- CDK, `crates/cdk/src/mint/check_spendable.rs:65`: `state.unwrap_or(State::Unspent)` over an `Option<State>` from the store

This asks for no change from either. It writes down what the state already means, so that wallets checking state over derived secrets have something to cite.
