### PR TITLE
NUT-07: define UNSPENT as the absence of a pending or spent record

### DIFF
--- a/07.md
+++ b/07.md
@@ -12,9 +12,9 @@ With the token state check, wallets can ask the mint whether a specific proof is
 
 A proof can be in one of the following states
 
-- A proof is `UNSPENT` if it has not been spent yet
 - A proof is `PENDING` if it is being processed in a transaction (in an ongoing payment). A `PENDING` proof cannot be used in another transaction until it is `live` again.
 - A proof is `SPENT` if it has been redeemed and its secret is in the list of spent secrets of the mint.
+- A proof is `UNSPENT` if the mint has no record of it being pending or spent
 
 **Note:** Before deleting spent proofs from their database, wallets can check if the proof is `SPENT` to make sure that they don't accidentally delete an unspent proof. Beware that this behavior can make it easier for the mint to correlate the sender to the receiver.
 


### PR DESCRIPTION
Rewords the tautologous `UNSPENT` definition to match how a mint actually computes it, and moves it after `PENDING` and `SPENT` so it reads as the fall-through state.

"Has not been spent yet" reads as a positive claim about a proof the mint knows exists. A blinded mint cannot make that claim: it records `B_` at signing and `Y` at spend, and cannot link the two, so an issued-but-unspent proof and a `Y` it has never seen look identical. `UNSPENT` is simply the result of a lookup miss against the pending and spent sets.

Both reference implementations already do this:

- nutshell, `cashu/mint/db/read.py:64-66`: collects the spent and pending sets, defaults everything else to `UNSPENT`
- CDK, `crates/cdk/src/mint/check_spendable.rs:65`: `state.unwrap_or(State::Unspent)`

No new state or case is added; this is the same definition stated the way implementations evaluate it.