### PR TITLE
NUT-06: advertise the mint's maximum request array length

### DIFF
--- a/06.md
+++ b/06.md
@@ -45,7 +45,7 @@ With the mint's response being of the form `GetInfoResponse`:
   ],
   "time": 1725304480,
   "tos_url": "https://mint.host/tos",
-  "max_request_length": 1000,
+  "max_array_length": 1000,
   "nuts": {
     "4": {
       "methods": [
@@ -99,7 +99,7 @@ With the mint's response being of the form `GetInfoResponse`:
 - (optional) `urls` is the list of endpoint URLs where the mint is reachable from.
 - (optional) `time` is the current time set on the server. The value is passed as a Unix timestamp integer.
 - (optional) `tos_url` is the URL pointing to the Terms of Service of the mint.
-- (optional) `max_request_length` is the maximum length the mint accepts for any array in a request, such as `inputs`, `outputs` or `Ys`. Wallets **SHOULD** split larger requests into batches no bigger than this.
+- (optional) `max_array_length` is the maximum length the mint accepts for any array in a request, such as `inputs`, `outputs` or `Ys`. Wallets **SHOULD** split larger requests into batches no bigger than this.
 - (optional) `nuts` indicates each NUT specification that the mint supports and its settings. The settings are defined in each NUT separately.
 
 With curl:

--- a/06.md
+++ b/06.md
@@ -45,6 +45,7 @@ With the mint's response being of the form `GetInfoResponse`:
   ],
   "time": 1725304480,
   "tos_url": "https://mint.host/tos",
+  "max_request_length": 1000,
   "nuts": {
     "4": {
       "methods": [
@@ -98,6 +99,7 @@ With the mint's response being of the form `GetInfoResponse`:
 - (optional) `urls` is the list of endpoint URLs where the mint is reachable from.
 - (optional) `time` is the current time set on the server. The value is passed as a Unix timestamp integer.
 - (optional) `tos_url` is the URL pointing to the Terms of Service of the mint.
+- (optional) `max_request_length` is the maximum length the mint accepts for any array in a request, such as `inputs`, `outputs` or `Ys`. Wallets **SHOULD** split larger requests into batches no bigger than this.
 - (optional) `nuts` indicates each NUT specification that the mint supports and its settings. The settings are defined in each NUT separately.
 
 With curl:


### PR DESCRIPTION
# Implementations

- [x] CDK — cashubtc/cdk#2352
- [x] Cashu-TS — cashubtc/cashu-ts#965
- [x] Nutshell — cashubtc/nutshell#1115

## Summary

Mints cap the length of the arrays a wallet sends, and nothing advertises the limit, so a wallet finds it by getting an error partway through a request it has already built.

Both reference implementations already enforce a cap, defaulting to 1000:

- nutshell: `mint_max_request_length` (`cashu/core/settings.py:170`), applied to `PostCheckStateRequest.Ys` and `PostRestoreRequest.outputs`
- CDK: `max_inputs` and `max_outputs` (`crates/cdk/src/mint/builder.rs:123-124`), checked in `check_state` and `restore`

This adds an optional top-level `max_array_length` to `GetInfoResponse` so wallets can size their batches up front. CDK would advertise the lower of its two limits.

One number rather than separate input and output limits: a wallet respecting a single figure never trips either cap, and a mint with asymmetric limits only under-advertises one, which costs finer chunking and nothing else. It also avoids the spec having to take a position on whether a `Y` passed to `/v1/checkstate` is an "input".

Recovery is where this absence is felt most, since a scan chunks `/v1/restore` and `/v1/checkstate` across thousands of counters, but the field is deliberately generic: it applies to any array in a request, so swap and melt inputs are covered by the same number.

No cross-references were added to the individual NUTs, since the arrays in question appear in five of them and NUT-06 is mandatory. But this can be done if desired.

