### PR TITLE
NUT-08: require amount 0 on blank change outputs

### DIFF
--- a/08.md
+++ b/08.md
@@ -112,7 +112,7 @@ curl -X POST https://mint.host:3338/v1/melt/bolt11 -d \
 }'
 ```
 
-Everything here is the same as in [NUT-05][05] except for `outputs`. The `amount` field in the `BlindedMessage`s here are ignored by `Bob` so they can be set to any arbitrary value by `Alice` (they should be set to a value, like `1` so potential JSON validations do not error).
+Everything here is the same as in [NUT-05][05] except for `outputs`. The `amount` field in the `BlindedMessage`s here are ignored by `Bob` so they can be set to any arbitrary value by `Alice`; implementations conventionally set them to `0`.
 
 If the mint has made a successful payment, it will respond the following.
 

--- a/08.md
+++ b/08.md
@@ -104,7 +104,7 @@ curl -X POST https://mint.host:3338/v1/melt/bolt11 -d \
   ],
   "outputs": [
     {
-      "amount": 1,
+      "amount": 0,
       "id": "009a1f293253e41e",
       "B_": "03327fc4fa333909b70f08759e217ce5c94e6bf1fc2382562f3c560c5580fa69f4"
     }
@@ -112,7 +112,7 @@ curl -X POST https://mint.host:3338/v1/melt/bolt11 -d \
 }'
 ```
 
-Everything here is the same as in [NUT-05][05] except for `outputs`. The `amount` field in the `BlindedMessage`s here are ignored by `Bob` so they can be set to any arbitrary value by `Alice`; implementations conventionally set them to `0`.
+Everything here is the same as in [NUT-05][05] except for `outputs`. `Alice` **MUST** set the `amount` of each blank output to `0`, and `Bob` **MUST** ignore it, imprinting the amount himself.
 
 If the mint has made a successful payment, it will respond the following.
 


### PR DESCRIPTION
The amount of a blank output is ignored by the mint, and NUT-08 currently suggests setting it to `1`. Current implementations (cdk, cashu-ts) send `0`, as this is a stronger "blank" signal than `1`, so this makes `0` a requirement for wallets and updates the example to match.

Mints must still ignore the field, so wallets that send `1` today keep working.

## Implementations

- [x] Cashu-TS: Already compliant
- [x] CDK: Already compliant
- [x] Nutshell: https://github.com/cashubtc/nutshell/pull/1118
