### PR TITLE
NUT-04: clarify expiry as a payment deadline

### DIFF
--- a/04.md
+++ b/04.md
@@ -72,7 +72,7 @@ Where:
 - `quote` is the quote ID in [UUIDv7](https://www.rfc-editor.org/rfc/rfc9562) format
 - `request` is the payment request for the quote
 - `unit` corresponds to the value provided in the request
-- `expiry` is the Unix timestamp until which the quote is valid (`null` if it does not expire)
+- `expiry` is the Unix timestamp until which the `request` can be paid (`null` if it does not expire)
 - `method` is the payment method of the quote
 - `amount_paid` is the total amount that has been paid to the mint for this quote, denominated in `unit`
 - `amount_issued` is the total amount of ecash that has been issued for this quote, denominated in `unit`
@@ -81,6 +81,8 @@ Where:
 Mints **MUST** include `amount_paid`, `amount_issued`, and `updated_at` in all mint quote responses. `amount_paid` and `amount_issued` **MUST** be non-negative integers, and `amount_issued` **MUST NOT** exceed `amount_paid`.
 
 The amount currently mintable for a quote is `amount_paid - amount_issued`. Mints **MUST NOT** issue ecash whose total output amount exceeds `amount_paid - amount_issued`. If a wallet mints less than the currently mintable amount, `amount_issued` only increases by the amount that was issued.
+
+`expiry` is a deadline for payment, not for issuance. Mints **MUST NOT** refuse to issue a quote's currently mintable amount solely because `expiry` has passed. Mints **MAY** credit payments received after `expiry` (for example, a late on-chain payment).
 
 Mints **MUST** update `updated_at` whenever `amount_paid` or `amount_issued` changes. Mints **MUST** ensure that `updated_at` monotonically increases for each quote, even if multiple updates occur within the same timestamp resolution. Wallets that receive multiple responses for the same quote **MUST NOT** replace locally stored quote data with a response whose `updated_at` is lower than the latest processed value for that quote. Wallets **MUST NOT** decrease locally stored `amount_paid` or `amount_issued` values based on stale responses.
 


### PR DESCRIPTION
# Implementations

- [x] Cashu-TS: https://github.com/cashubtc/cashu-ts/pull/969
- [x] CDK: Already compliant
- [x] Nutshell: https://github.com/cashubtc/nutshell/pull/1122

## Summary

NUT-23 defines `expiry` as the timestamp until which the `request` can be paid. The generic wording in NUT-04 ("until which the quote is valid") reads as an issuance deadline instead, and implementations have diverged: CDK issues a quote's remaining mintable balance after expiry, while Nutshell rejects issuance once expiry has passed, which can leave a paid quote unmintable.

This aligns the NUT-04 wording with NUT-23 and adds a normative clarification: `expiry` is a deadline for payment, not for issuance. Mints MUST NOT refuse to issue the currently mintable amount (`amount_paid - amount_issued`) solely because `expiry` has passed, and MAY credit payments received after `expiry` (relevant for on-chain and bolt12, where late payment is possible).