### PR TITLE
NUT-05: Clarify melt retries and the state transitions

### DIFF
--- a/05.md
+++ b/05.md
@@ -122,7 +122,7 @@ When the mint accepts an execution request for a quote in the `"UNPAID"` state, 
 
 A wallet **MAY** retry a quote in the `"UNPAID"` state by sending another execution request for the same quote. The mint **MUST NOT** reject an otherwise valid execution request solely because a previous payment attempt failed. A retry is a new payment attempt, so the mint **MUST** validate its inputs, outputs, and method-specific fields as it would for an initial attempt.
 
-The mint **MUST NOT** start another payment attempt while the quote is `"PENDING"` or after it is `"PAID"`. A quote in the `"UNPAID"` state **MUST** remain `"UNPAID"` unless the wallet sends another execution request that the mint accepts. Checking the quote state can reconcile an existing payment attempt but **MUST NOT** start a new one.
+The mint **MUST NOT** initiate a second payment for a quote in response to another execution request while the quote is `"PENDING"` or after it is `"PAID"`. This does not restrict payment-backend operations, such as route probing or retrying routes, that are part of the current payment attempt. A quote in the `"UNPAID"` state **MUST** remain `"UNPAID"` unless the wallet sends another execution request that the mint accepts. Checking the quote state can reconcile an existing payment attempt but **MUST NOT** start a new one.
 
 #### Synchronous Processing
 

--- a/05.md
+++ b/05.md
@@ -27,7 +27,7 @@ The melting process follows these steps for all payment methods:
 
 ### Synchronous vs Asynchronous Processing
 
-**Synchronous (Default):** Unless the payment method requires asynchronous execution, the melt request blocks until payment completion. This ensures immediate finality but may result in long request times for slow payment methods.
+**Synchronous (Default):** Unless the payment method requires asynchronous execution, the melt request blocks until the payment attempt completes. This returns the result of the attempt immediately but may result in long request times for slow payment methods.
 
 **Asynchronous:** A method-specific NUT can require asynchronous execution for a payment method. For other methods, the wallet can request asynchronous execution with `prefer_async: true` in the melt request body if it is supported by the mint. In both cases, the request returns immediately after validation with a `"PENDING"` state. The wallet must then monitor the payment progress through polling or websocket notifications.
 
@@ -81,9 +81,9 @@ Where
 
 `state` is an enum string field with possible values `"UNPAID"`, `"PENDING"`, `"PAID"`:
 
-- `"UNPAID"` means that the request has not been paid yet.
-- `"PENDING"` means that the request is currently being paid.
-- `"PAID"` means that the request has been paid successfully.
+- `"UNPAID"` means that the request has not been paid and no payment attempt is in progress. This is the initial state and the state after a failed payment attempt.
+- `"PENDING"` means that a payment attempt is in progress or its result is not yet known.
+- `"PAID"` means that the request has been paid successfully. This is the only terminal payment state.
 
 ### Check Melt Quote State
 
@@ -116,6 +116,14 @@ The wallet includes the following common data in its request:
 
 where `quote` is the melt quote ID, `inputs` are the proofs with a total amount sufficient to cover the requested amount plus any fees, and `prefer_async` requests asynchronous processing when set to `true`.
 
+#### Payment Attempts and Retries
+
+When the mint accepts an execution request for a quote in the `"UNPAID"` state, it sets the quote to `"PENDING"` while the payment attempt is in progress. If the payment succeeds, the mint **MUST** set the quote to `"PAID"`. If the payment is known to have failed, the mint **MUST** release the reserved inputs and set the quote back to `"UNPAID"`. If the payment result is uncertain, the mint **MUST** keep the quote and its inputs `"PENDING"` until the result is known.
+
+A wallet **MAY** retry a quote in the `"UNPAID"` state by sending another execution request for the same quote. The mint **MUST NOT** reject an otherwise valid execution request solely because a previous payment attempt failed. A retry is a new payment attempt, so the mint **MUST** validate its inputs, outputs, and method-specific fields as it would for an initial attempt.
+
+The mint **MUST NOT** start another payment attempt while the quote is `"PENDING"` or after it is `"PAID"`. A quote in the `"UNPAID"` state **MUST** remain `"UNPAID"` unless the wallet sends another execution request that the mint accepts. Checking the quote state can reconcile an existing payment attempt but **MUST NOT** start a new one.
+
 #### Synchronous Processing
 
 > [!IMPORTANT]
@@ -134,11 +142,11 @@ When asynchronous processing is used:
 3. The payment processing begins in the background
 4. The wallet can poll the quote state endpoint or subscribe to websocket notifications to monitor payment progress
 
-If the method-specific NUT does not require asynchronous execution and the mint does not support asynchronous processing for the method, the mint ignores `prefer_async` and processes the request synchronously. The response follows the standard synchronous flow with final payment state.
+If the method-specific NUT does not require asynchronous execution and the mint does not support asynchronous processing for the method, the mint ignores `prefer_async` and processes the request synchronously. The response follows the standard synchronous flow with the resulting quote state.
 
 #### Synchronous Response
 
-For synchronous processing, the mint responds with a structure that indicates the final payment state and includes any method-specific proof of payment when successful.
+For synchronous processing, the mint responds with a structure that indicates the resulting quote state and includes any method-specific proof of payment when successful.
 
 #### Asynchronous Response
 

--- a/05.md
+++ b/05.md
@@ -27,7 +27,7 @@ The melting process follows these steps for all payment methods:
 
 ### Synchronous vs Asynchronous Processing
 
-**Synchronous (Default):** Unless the payment method requires asynchronous execution, the melt request blocks until the payment attempt completes. This returns the result of the attempt immediately but may result in long request times for slow payment methods.
+**Synchronous (Default):** Unless the payment method requires asynchronous execution, the melt request blocks until the payment attempt succeeds or fails. This may result in long request times for slow payment methods.
 
 **Asynchronous:** A method-specific NUT can require asynchronous execution for a payment method. For other methods, the wallet can request asynchronous execution with `prefer_async: true` in the melt request body if it is supported by the mint. In both cases, the request returns immediately after validation with a `"PENDING"` state. The wallet must then monitor the payment progress through polling or websocket notifications.
 

--- a/23.md
+++ b/23.md
@@ -174,6 +174,8 @@ The mint responds with a `PostMeltQuoteBolt11Response`:
 
 Where `fee_reserve` is the additional fee reserve required for the Lightning payment. The mint expects the wallet to include `Proofs` of _at least_ `total_amount = amount + fee_reserve + fee` where `fee` is calculated from the keyset's `input_fee_ppk` as described in [NUT-02][02].
 
+Melt quote state transitions and payment retries follow [NUT-05][05].
+
 ### Melting Tokens
 
 For the `bolt11` method, the wallet can include an optional `outputs` field in the melt request to receive change for overpaid Lightning fees (see [NUT-08][08]):

--- a/25.md
+++ b/25.md
@@ -182,11 +182,7 @@ The mint responds with a `PostMeltQuoteBolt12Response`:
 
 Where `fee_reserve` is the additional fee reserve required for the Lightning payment. The mint expects the wallet to include `Proofs` of _at least_ `total_amount = amount + fee_reserve + fee` where `fee` is calculated from the keyset's `input_fee_ppk` as described in [NUT-02][02].
 
-`state` is an enum string field with possible values `"UNPAID"`, `"PENDING"`, `"PAID"`:
-
-- `"UNPAID"` means that the request has not been paid yet.
-- `"PENDING"` means that the request is currently being paid.
-- `"PAID"` means that the request has been paid successfully.
+Melt quote states, their transitions, and payment retries follow [NUT-05][05].
 
 ### Melting Tokens
 

--- a/30.md
+++ b/30.md
@@ -236,7 +236,7 @@ For the `onchain` method, the wallet includes the following specific `PostMeltOn
 }
 ```
 
-Where `fee_index` is the selected fee of the quote's `fee_options`. The mint **MUST** reject a melt request with a `fee_index` that was not returned in the quote. Once `selected_fee_index` is set, the mint **MUST NOT** execute the quote again with a different `fee_index` value. A retry after a failed attempt therefore **MUST** use the same `fee_index`.
+Where `fee_index` is the selected fee of the quote's `fee_options`. The mint **MUST** reject a melt request with a `fee_index` that was not returned in the quote. Once `selected_fee_index` is set for a quote, the mint **MUST NOT** execute that quote with a different `fee_index` value. A retry of the same quote after a failed attempt therefore **MUST** use the same `fee_index`.
 
 If the `outputs` field is included and the mint does not claim the full `selected_fee_reserve` as the actual fee, the mint will respond with a `change` field containing blind signatures for the unclaimed amount (see [NUT-08][08]). The `change` field is omitted if there are no blind signatures to return. Note that because onchain transactions may be batched or have unpredictable costs, the mint is entitled to claim the full `selected_fee_reserve` as the actual fee.
 

--- a/30.md
+++ b/30.md
@@ -213,10 +213,10 @@ Each item in `fee_options` represents one available fee reserve and confirmation
 
 For each fee option with `fee_index`, `fee_reserve` is the maximum onchain transaction fee the mint may charge for that option, and `estimated_blocks` is the estimated number of blocks until confirmation. `selected_fee_index` is `null` before the quote is executed and is set by the mint to the selected fee option once the wallet executes the quote. The mint expects the wallet to include `Proofs` of _at least_ `total_amount = amount + selected_fee_reserve + input_fee` where `selected_fee_reserve` is the `fee_reserve` from the selected `fee_index` item and `input_fee` is calculated from the keyset's `input_fee_ppk` as described in [NUT-02][02]. If the mint does not claim the full `selected_fee_reserve` as the actual fee, the mint returns the unclaimed amount as `change` to the wallet as described in [NUT-08][08].
 
-`state` is an enum string field with possible values `"UNPAID"`, `"PENDING"`, `"PAID"`:
+Melt quote state transitions and payment retries follow [NUT-05][05]. For the `onchain` method, the states have the following method-specific meanings:
 
-- `"UNPAID"` means that the transaction has not been broadcast yet.
-- `"PENDING"` means that the transaction is being processed by the mint but has not reached the required number of confirmations.
+- `"UNPAID"` means that no transaction is being processed. No transaction has been broadcast, or a previous attempt is known to have failed.
+- `"PENDING"` means that the transaction is being processed by the mint but has not reached the required number of confirmations, or its status is uncertain.
 - `"PAID"` means that the transaction has been mined and confirmed.
 
 `outpoint` is the transaction ID and output index of the payment in the format `txid:vout`, present once the transaction has been broadcast.
@@ -236,7 +236,7 @@ For the `onchain` method, the wallet includes the following specific `PostMeltOn
 }
 ```
 
-Where `fee_index` is the selected fee of the quote's `fee_options`. The mint **MUST** reject a melt request with a `fee_index` that was not returned in the quote. Once `selected_fee_index` is set, the mint **MUST NOT** execute the quote again with a different `fee_index` value.
+Where `fee_index` is the selected fee of the quote's `fee_options`. The mint **MUST** reject a melt request with a `fee_index` that was not returned in the quote. Once `selected_fee_index` is set, the mint **MUST NOT** execute the quote again with a different `fee_index` value. A retry after a failed attempt therefore **MUST** use the same `fee_index`.
 
 If the `outputs` field is included and the mint does not claim the full `selected_fee_reserve` as the actual fee, the mint will respond with a `change` field containing blind signatures for the unclaimed amount (see [NUT-08][08]). The `change` field is omitted if there are no blind signatures to return. Note that because onchain transactions may be batched or have unpredictable costs, the mint is entitled to claim the full `selected_fee_reserve` as the actual fee.
 


### PR DESCRIPTION
## Summary

- define `UNPAID -> PENDING -> PAID|UNPAID` melt quote transitions
- require failed attempts to release inputs and remain idle at `UNPAID` until a wallet explicitly retries
- prevent repeated execution requests from causing a second payment while `PENDING` or after terminal `PAID`, without restricting payment-backend route attempts
- apply the common retry rules to BOLT11 and BOLT12, and preserve the selected onchain `fee_index` across retries of the same quote

## Context

The original NUT-05 state change explicitly allowed wallets to repeat an `UNPAID` melt request until payment succeeded. That sentence was lost when NUT-05 was later abstracted across payment methods. This restores and tightens the existing behavior without changing request or response formats.

Closes #428.

## Validation

- `npx prettier@3.9.1 --check .`