### PR TITLE
NUT-XX: add currency unit metadata

### DIFF
--- a/xx.md
+++ b/xx.md
@@ -1,0 +1,63 @@
+# NUT-XX: Currency unit metadata
+
+`optional`
+
+`depends on: NUT-06`
+
+---
+
+This NUT defines how a mint publishes display metadata for the currency units of its keysets. Wallets use the metadata to display amounts of units that are not defined elsewhere, such as custom units, without guessing. The metadata is display-only: it plays no role in transaction validation or in the keyset ID derivation described in [NUT-02][02].
+
+## Unit metadata
+
+The mint publishes the metadata in the settings for this NUT in the info response ([NUT-06][06]):
+
+```json
+{
+  "XX": {
+    "units": {
+      "ora": { "precision": 2, "name": "Ora" },
+      "usd": { "precision": 2, "name": "US Dollar", "symbol": "$" }
+    }
+  }
+}
+```
+
+`units` maps a unit string, as used in the `unit` field of a keyset ([NUT-02][02]), to a metadata object with the fields
+
+- `precision`: The number of decimal places of the unit. An amount `a` of this unit represents the value `a * 10^(-precision)`. **MUST** be an integer between `0` and `18`.
+- `name` (optional): The full name of the currency
+- `symbol` (optional): A symbol that wallets can display next to amounts of the unit
+
+For example, with the metadata above, the amount `500` of the unit `ora` is displayed as `5.00 ORA`.
+
+The metadata of a unit applies to all keysets of that unit. Mints **SHOULD** keep it stable over time. Wallets **SHOULD** refresh it together with the rest of the info response.
+
+The presence of the setting indicates that the mint supports this NUT.
+
+## Precedence
+
+The metadata fills gaps; it **MUST NOT** change how amounts of units that are already defined elsewhere are interpreted. Wallets determine the precision of a unit in the following order:
+
+1. For the units defined in [NUT-01][01] (`btc`, `sat`, `msat`, `auth`), wallets **MUST** use the values defined there (`btc`: 8 decimal places, all others: 0).
+2. For ISO 4217 currency codes, wallets **MUST** use the Minor Unit of the currency as defined by ISO 4217.
+3. For all other units, the published metadata is authoritative.
+
+Mints **MAY** include units covered by rules 1 and 2 in `units`. If they do, the published `precision` **MUST** match the values defined there. Wallets use the values of rules 1 and 2 regardless of what is published; a mismatch has no further consequence.
+
+[NUT-01][01] requires stablecoin amounts to represent the Minor Unit of the pegged currency. A wallet cannot verify which currency an unknown stablecoin code is pegged to. For codes a wallet does not recognize, rule 3 applies: the published metadata communicates the result of the [NUT-01][01] requirement.
+
+If a unit is not covered by rules 1 and 2 and the mint publishes no metadata for it, wallets **MUST NOT** guess a precision and **SHOULD** display the raw amount together with the unit string.
+
+## Wallet handling
+
+The metadata is display-only:
+
+- Wallets **MUST NOT** use it to accept, reject, or compare keysets.
+- It is not part of the keyset ID derivation ([NUT-02][02]).
+
+Since any unit can publish any `symbol`, wallets **SHOULD** use their own names and symbols for units covered by rules 1 and 2, and **SHOULD** display the unit string alongside a published symbol that collides with the symbol of a well-known currency.
+
+[01]: 01.md
+[02]: 02.md
+[06]: 06.md

--- a/xx.md
+++ b/xx.md
@@ -14,24 +14,25 @@ The mint publishes the metadata in the settings for this NUT in the info respons
 
 ```json
 {
-  "XX": {
-    "units": {
-      "ora": { "precision": 2, "name": "Ora" },
-      "usd": { "precision": 2, "name": "US Dollar", "symbol": "$" }
-    }
-  }
+  "XX": [
+    { "unit": "ora", "precision": 2, "name": "Ora" },
+    { "unit": "usd", "precision": 2, "name": "US Dollar", "symbol": "$" }
+  ]
 }
 ```
 
-`units` maps a unit string, as used in the `unit` field of a keyset ([NUT-02][02]), to a metadata object with the fields
+The setting is an array of metadata objects with the fields:
 
+- `unit`: The unit string, exactly as used in the `unit` field of a keyset ([NUT-02][02])
 - `precision`: The number of decimal places of the unit. An amount `a` of this unit represents the value `a * 10^(-precision)`. **MUST** be an integer between `0` and `18`.
 - `name` (optional): The full name of the currency
 - `symbol` (optional): A symbol that wallets can display next to amounts of the unit
 
-For example, with the metadata above, the amount `500` of the unit `ora` is displayed as `5.00 ORA`.
+Mints **MUST NOT** publish multiple entries for the same `unit`. Array order has no significance. Different units may share the same precision, name, or symbol.
 
-The metadata of a unit applies to all keysets of that unit. Mints **SHOULD** keep it stable over time. Wallets **SHOULD** refresh it together with the rest of the info response.
+For example, with the metadata above, the amount `500` of the unit `ora` is displayed as `5.00 ora`.
+
+The metadata is scoped to the publishing mint and applies to all of its keysets of that unit. Mints **MUST NOT** change the precision of an existing unit. Mints **SHOULD** keep names and symbols stable over time. Wallets **SHOULD** refresh the metadata together with the rest of the info response.
 
 The presence of the setting indicates that the mint supports this NUT.
 
@@ -41,13 +42,13 @@ The metadata fills gaps; it **MUST NOT** change how amounts of units that are al
 
 1. For the units defined in [NUT-01][01] (`btc`, `sat`, `msat`, `auth`), wallets **MUST** use the values defined there (`btc`: 8 decimal places, all others: 0).
 2. For ISO 4217 currency codes, wallets **MUST** use the Minor Unit of the currency as defined by ISO 4217.
-3. For all other units, the published metadata is authoritative.
+3. For all other units, wallets use the published precision for display.
 
-Mints **MAY** include units covered by rules 1 and 2 in `units`. If they do, the published `precision` **MUST** match the values defined there. Wallets use the values of rules 1 and 2 regardless of what is published; a mismatch has no further consequence.
+Mints **MAY** publish metadata for units covered by rules 1 and 2. If they do, the published `precision` **MUST** match the values defined there. Wallets use the values of rules 1 and 2 regardless of what is published; a mismatch has no further consequence.
 
 [NUT-01][01] requires stablecoin amounts to represent the Minor Unit of the pegged currency. A wallet cannot verify which currency an unknown stablecoin code is pegged to. For codes a wallet does not recognize, rule 3 applies: the published metadata communicates the result of the [NUT-01][01] requirement.
 
-If a unit is not covered by rules 1 and 2 and the mint publishes no metadata for it, wallets **MUST NOT** guess a precision and **SHOULD** display the raw amount together with the unit string.
+If a unit is not covered by rules 1 and 2 and the mint publishes no metadata for it, wallets **MUST NOT** guess a precision and **SHOULD** display the raw amount together with the unit string. Metadata ignored under the wallet handling rules below is treated as absent for this purpose.
 
 ## Wallet handling
 
@@ -56,7 +57,15 @@ The metadata is display-only:
 - Wallets **MUST NOT** use it to accept, reject, or compare keysets.
 - It is not part of the keyset ID derivation ([NUT-02][02]).
 
-Since any unit can publish any `symbol`, wallets **SHOULD** use their own names and symbols for units covered by rules 1 and 2, and **SHOULD** display the unit string alongside a published symbol that collides with the symbol of a well-known currency.
+Wallets **MUST** check for duplicate unit identifiers before using the metadata, including before converting the array to a map. If a unit occurs more than once, wallets **MUST** ignore all entries for that unit, even if the entries are identical.
+
+Mints **MUST NOT** repeat member names within a metadata object. If a wallet detects repeated member names, it **MUST** ignore this NUT's metadata for that response. Duplicate JSON member names are a parsing concern distinct from duplicate unit entries in the array.
+
+Wallets **SHOULD** detect changes to previously observed precision for the same mint and unit, and notify the user before applying changed precision to existing balances.
+
+Wallets **MUST NOT** use published names or symbols as unit identifiers, or infer that units are interchangeable because their metadata matches. Wallets **SHOULD** use their own names and symbols for units covered by rules 1 and 2. For all other units, wallets **MUST** display the unit string alongside any published name or symbol they display.
+
+The metadata is a mint's claim about how to display amounts. It does not establish currency identity, value, backing, or a stablecoin peg. A mint can publish misleading metadata or different metadata to different wallets without including duplicate entries. Duplicate checks and keyset verification cannot establish the truth of these claims.
 
 [01]: 01.md
 [02]: 02.md


### PR DESCRIPTION
Wallets currently have no way to discover how a mint intends amounts of a custom currency unit to be displayed. This NUT lets a mint publish `precision` and optional `name` and `symbol` metadata so wallets can format those amounts without guessing.

## Design

- The NUT-06 settings entry is an array directly under the NUT number: `"XX": [{ "unit": "ora", "precision": 2, "name": "Ora" }]`. Each entry identifies its unit explicitly; there is no `units` wrapper.
- Metadata is scoped to the publishing mint and applies to all of its keysets of that unit. Mints must publish at most one entry per unit. Wallets check for duplicates before using the metadata and ignore all entries for a duplicated unit, even if identical. Array order has no significance.
- The metadata is display-only and plays no role in transaction validation or keyset ID derivation. NUT-01 units and ISO 4217 currency codes retain their defined precision. For other units, absent or ignored metadata leads to the existing raw-amount fallback.
- Mints must not change an existing unit's precision. Wallets should detect precision changes and notify users before applying them to existing balances.
- Wallets must keep the actual unit identifier visible alongside published names or symbols for custom units. Matching metadata does not establish that units are interchangeable. Metadata is a mint's formatting claim and does not establish currency identity, value, backing, or a stablecoin peg; duplicate checks cannot verify those claims.
- Repeated JSON member names within metadata objects are prohibited. Wallets that detect them ignore this NUT's metadata for that response.

## Validation

- Prettier 3.9.1 formatting check passed on a clean snapshot of all tracked repository files.
- JSON example checked for the direct array format, unique unit identifiers, and precision bounds; local specification links checked.
