### PR TITLE
NUT-11: define lock state when now equals locktime

### DIFF
--- a/11.md
+++ b/11.md
@@ -172,13 +172,13 @@ If the `locktime` tag is not present, or is not a valid unix time, the lock is c
 
 ### Active Lock
 
-If the `locktime` tag is a valid unix time and the mint's local clock is less than `locktime`, the lock is "active".
+If the `locktime` tag is a valid unix time and the mint's local clock is less than or equal to `locktime` (`now <= locktime`), the lock is "active".
 
 [Locktime Multisig](#locktime-multisig) conditions apply if the `pubkeys` tag is present, [Basic Case](#basic-case) conditions if not.
 
 ### Expired Lock
 
-If the `locktime` tag is a valid unix time and the mint's local clock is greater than `locktime`, the lock has "expired".
+If the `locktime` tag is a valid unix time and the mint's local clock is greater than `locktime` (`now > locktime`), the lock has "expired".
 
 Both [Locktime Multisig](#locktime-multisig) and [Refund Multisig](#refund-multisig) conditions apply if the `refund` tag is present, otherwise the proof is considered unlocked and spendable without a witness signature.
 


### PR DESCRIPTION
# Closes #431

The Active Lock and Expired Lock definitions used "less than" and "greater than", leaving the exact second where the mint's clock equals `locktime` unassigned.

This PR makes the boundary explicit: the lock is active while `now <= locktime` and expired once `now > locktime`.

## Implementations

All three reference implementations already behave as specified, so no implementation PRs are needed:

- nutshell `cashu/mint/conditions.py`: `locktime_passed = secret.locktime is not None and secret.locktime < current_time`
- CDK `crates/cashu/src/nuts/nut10/mod.rs`: `.map(|locktime| locktime < current_time)`
- cashu-ts `src/crypto/NUT11.ts`: `return nowSeconds < locktime ? 'ACTIVE' : 'EXPIRED';`

