### PR TITLE
NUT-12: a Proof's DLEQ MUST be complete; strip it entirely for the mint

### DIFF
--- a/12.md
+++ b/12.md
@@ -84,7 +84,7 @@ The mint produces these DLEQ proofs when returning `BlindSignature`'s in the res
 
 ### User to user: DLEQ in `Proof`
 
-In order for `Alice` to communicate the DLEQ to another user `Carol`, we extend the `Proof` (see [NUT-00][00]) object and include the DLEQ proof. As explained below, we also need to include the blinding factor `r` for the proof to be convincing to another user `Carol`.
+In order for `Alice` to communicate the DLEQ to another user `Carol`, we extend the `Proof` (see [NUT-00][00]) object and include the DLEQ proof. As explained below, `Alice` **MUST** also include the blinding factor `r` for the proof to be convincing to `Carol`.
 
 ```json
 {
@@ -104,7 +104,7 @@ In order for `Alice` to communicate the DLEQ to another user `Carol`, we extend 
 
 > [!IMPORTANT]
 >
-> **Privacy:** The blinding factor `r` should not be shared with the mint or otherwise, the mint will be able to associate the `BlindSignature` with the `Proof`.
+> **Privacy:** The entire `dleq` field **SHOULD** be removed before sending a `Proof` to the mint as an input. The mint can associate the `BlindSignature` with the `Proof` given `e` and `s`, or using the blinding factor `r`.
 
 ## Alice (minting user) verifies DLEQ proof
 


### PR DESCRIPTION
NUT-12 is ambiguous about what a `Proof`'s `dleq` field may contain, and the ambiguity has cost real interoperability.

NUT-00 lists `e`, `s` and `r` together, required whenever the optional `d` block is present. NUT-12 then singles out one of them:

> **Privacy:** The blinding factor `r` should not be shared with the mint or otherwise, the mint will be able to associate the `BlindSignature` with the `Proof`.

Naming only `r` reads as licence to keep `e` and `s`, which produces proofs carrying a partial DLEQ. Neither half of the prose is normative, so nothing says a wallet is wrong to do it. cashubtc/cashu-ts#1130 is where this surfaced: a wallet shipping `{e, s}` proofs, and a library asked to accept them.

## A partial DLEQ still links the proof

Keeping `e` and `s` does not protect the holder. The mint knows its own `a`, and the response satisfies

```
s = k + e*a  mod n
```

so it recovers the nonce

```
k = s - e*a  mod n
```

With `k` it can walk the `B_` values in its issuance table and test each one:

```
C' = a*B'
R1 = k*G
R2 = k*B'
TEST hash(R1, R2, A, C') == e
```

The match identifies the `BlindSignature` that produced the `Proof`. The blinding factor links it just as directly, since `B_ = Y + r*G` is recomputable from the secret. Either half is enough, so the whole field has to go.

## Changes

Two sentences, covering both directions a `Proof` travels.

- User to user: `Alice` **MUST** include `r`. Without it the DLEQ convinces nobody, so a partial DLEQ is not a privacy-preserving variant, it is a broken proof.
- User to mint: the entire `dleq` field **SHOULD** be removed, and the note now names both linkage routes rather than one.

Between them there is no remaining reading in which a `Proof` legitimately carries `e` and `s` alone.

## Implementations

All three reference implementations already behave as specified, so no implementation PRs are needed:

- nutshell `cashu/core/base.py`: `def to_dict(self, include_dleq=False)` omits the block by default; only token serialization opts in with `include_dleq=True`. **Compliant.**
- CDK `crates/cashu/src/nuts/nut00/mod.rs`: `fn without_dleqs(&self)` sets `p.dleq = None` on every input. **Compliant.**
- cashu-ts `src/mint/Mint.ts`: `stripWalletFields` drops `dleq` before every request goes out. **Compliant.**

cashubtc/cashu-ts#1135 additionally refuses to emit an incomplete DLEQ and drops one on decode, so the `{e, s}` proofs that prompted this cannot be produced or forwarded.
